### PR TITLE
Add prompt stack to fix bug where prompt is not restored after returning 

### DIFF
--- a/lib/pry/commands.rb
+++ b/lib/pry/commands.rb
@@ -270,10 +270,10 @@ e.g: gist -d my_method
     command "shell-mode", "Toggle shell mode. Bring in pwd prompt and file completion." do
       case Pry.active_instance.prompt
       when Pry::SHELL_PROMPT
-        Pry.active_instance.prompt = Pry::DEFAULT_PROMPT
+        Pry.active_instance.pop_prompt
         Pry.active_instance.custom_completions = Pry::DEFAULT_CUSTOM_COMPLETIONS
       else
-        Pry.active_instance.prompt = Pry::SHELL_PROMPT
+        Pry.active_instance.push_prompt Pry::SHELL_PROMPT
         Pry.active_instance.custom_completions = Pry::FILE_COMPLETIONS
         Readline.completion_proc = Pry::InputCompleter.build_completion_proc target,
         Pry.active_instance.instance_eval(&Pry::FILE_COMPLETIONS)

--- a/test/test.rb
+++ b/test/test.rb
@@ -737,6 +737,67 @@ describe Pry do
             Pry.new.select_prompt(true, 0).should == "test prompt> "
             Pry.new.select_prompt(false, 0).should == "test prompt* "
           end
+
+          describe 'storing and restoring the prompt' do
+            before do
+              make = lambda do |name,i|
+                prompt = [ proc { "#{i}>" } , proc { "#{i+1}>" } ]
+                (class << prompt; self; end).send(:define_method, :inspect) { "<Prompt-#{name}>" }
+                prompt
+              end
+              @a , @b , @c = make[:a,0] , make[:b,1] , make[:c,2]
+              @pry = Pry.new :prompt => @a
+            end
+            it 'should have a prompt stack' do
+              @pry.push_prompt @b
+              @pry.push_prompt @c
+              @pry.prompt.should == @c
+              @pry.pop_prompt
+              @pry.prompt.should == @b
+              @pry.pop_prompt
+              @pry.prompt.should == @a
+            end
+
+            it 'should restore overridden prompts when returning from file-mode' do
+              pry = Pry.new :input => InputTester.new('shell-mode', 'shell-mode'),
+                            :prompt => [ proc { 'P>' } ] * 2
+              pry.select_prompt(true, 0).should == "P>"
+              pry.re
+              pry.select_prompt(true, 0).should =~ /\Apry .* \$ \z/
+              pry.re
+              pry.select_prompt(true, 0).should == "P>"
+            end
+
+            it '#pop_prompt should return the popped prompt' do
+              @pry.push_prompt @b
+              @pry.push_prompt @c
+              @pry.pop_prompt.should == @c
+              @pry.pop_prompt.should == @b
+            end
+
+            it 'should not pop the last prompt' do
+              @pry.push_prompt @b
+              @pry.pop_prompt.should == @b
+              @pry.pop_prompt.should == @a
+              @pry.pop_prompt.should == @a
+              @pry.prompt.should == @a
+            end
+
+            describe '#prompt= should replace the current prompt with the new prompt' do
+              it 'when only one prompt on the stack' do
+                @pry.prompt = @b
+                @pry.prompt.should == @b
+                @pry.pop_prompt.should == @b
+                @pry.pop_prompt.should == @b
+              end
+              it 'when several prompts on the stack' do
+                @pry.push_prompt @b
+                @pry.prompt = @c
+                @pry.pop_prompt.should == @c
+                @pry.pop_prompt.should == @a
+              end
+            end
+          end
         end
 
         it 'should set the hooks default, and the default should be overridable' do


### PR DESCRIPTION
Add prompt stack to fix bug where prompt is not restored after returning from shell-mode

When returning from shell-mode, the prompt is not properly restored.
The problem is that it gets clobbered by the new prompt, so we need somewhere to store it.
This adds a prompt stack so you can push and pop prompts in order to temporarily change
the current prompt and then later restore the previous prompt.

prompt and prompt= are also overridden to have meaning in the context of the prompt stack.
