### PR TITLE
Exclude the current line from history

### DIFF
--- a/lib/pry/default_commands/input.rb
+++ b/lib/pry/default_commands/input.rb
@@ -96,7 +96,8 @@ e.g amend-line puts 'hello again'   # no line number modifies immediately preced
       end
 
       command "hist", "Show and replay Readline history. Type `hist --help` for more info." do |*args|
-        history = Readline::HISTORY.to_a
+        # exclude the current command from history.
+        history = Readline::HISTORY.to_a[0..-2]
 
         opts = Slop.parse!(args) do |opt|
           opt.banner "Usage: hist [--replay START..END] [--clear] [--grep PATTERN] [--head N] [--tail N] [--help] [--save [START..END] file.txt]\n"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -74,12 +74,15 @@ end
 
 class InputTester
   def initialize(*actions)
+    if actions.last.is_a?(Hash) && actions.last.keys == [:history]
+      @hist = actions.pop[:history]
+    end
     @orig_actions = actions.dup
     @actions = actions
   end
 
   def readline(*)
-    @actions.shift
+    @actions.shift.tap{ |line| @hist << line if @hist }
   end
 
   def rewind

--- a/test/test_default_commands/test_input.rb
+++ b/test/test_default_commands/test_input.rb
@@ -211,7 +211,7 @@ describe "Pry::DefaultCommands::Input" do
       @hist.push "hello"
       @hist.push "world"
       str_output = StringIO.new
-      redirect_pry_io(InputTester.new("hist", "exit-all"), str_output) do
+      redirect_pry_io(InputTester.new("hist", "exit-all", :history => @hist), str_output) do
         pry
       end
       str_output.string.should =~ /hello\n.*world/
@@ -223,7 +223,7 @@ describe "Pry::DefaultCommands::Input" do
       @hist.push ":bucket"
       @hist.push ":ostrich"
       str_output = StringIO.new
-      redirect_pry_io(InputTester.new("hist --replay -1", "exit-all"), str_output) do
+      redirect_pry_io(InputTester.new("hist --replay -1", "exit-all", :history => @hist), str_output) do
         pry
       end
       str_output.string.should =~ /ostrich/
@@ -234,7 +234,7 @@ describe "Pry::DefaultCommands::Input" do
       @hist.push ":hello"
       @hist.push ":carl"
       str_output = StringIO.new
-      redirect_pry_io(InputTester.new("hist --replay 0..2", "exit-all"), str_output) do
+      redirect_pry_io(InputTester.new("hist --replay 0..2", "exit-all", :history => @hist), str_output) do
         pry
       end
       str_output.string.should =~ /:hello\n.*:carl/
@@ -253,21 +253,21 @@ describe "Pry::DefaultCommands::Input" do
       @hist.push "place holder"
 
       str_output = StringIO.new
-      redirect_pry_io(InputTester.new("hist --grep o", "exit-all"), str_output) do
+      redirect_pry_io(InputTester.new("hist --grep o", "exit-all", :history => @hist), str_output) do
         pry
       end
       str_output.string.should =~ /\d:.*?box\n\d:.*?button\n\d:.*?orange/
 
       # test more than one word in a regex match (def blah)
       str_output = StringIO.new
-      redirect_pry_io(InputTester.new("hist --grep def blah", "exit-all"), str_output) do
+      redirect_pry_io(InputTester.new("hist --grep def blah", "exit-all", :history => @hist), str_output) do
         pry
       end
       str_output.string.should =~ /def blah 1/
 
       # test more than one word with leading white space in a regex match (def boink)
       str_output = StringIO.new
-      redirect_pry_io(InputTester.new("hist --grep      def boink", "exit-all"), str_output) do
+      redirect_pry_io(InputTester.new("hist --grep      def boink", "exit-all", :history => @hist), str_output) do
         pry
       end
       str_output.string.should =~ /def boink 2/
@@ -280,7 +280,7 @@ describe "Pry::DefaultCommands::Input" do
       end
 
       str_output = StringIO.new
-      redirect_pry_io(InputTester.new("hist --tail 3", "exit-all"), str_output) do
+      redirect_pry_io(InputTester.new("hist --tail 3", "exit-all", :history => @hist), str_output) do
         pry
       end
 
@@ -297,7 +297,7 @@ describe "Pry::DefaultCommands::Input" do
       end
 
       str_output = StringIO.new
-      redirect_pry_io(InputTester.new("hist --head 4", "exit-all"), str_output) do
+      redirect_pry_io(InputTester.new("hist --head 4", "exit-all", :history => @hist), str_output) do
         pry
       end
 
@@ -314,7 +314,7 @@ describe "Pry::DefaultCommands::Input" do
       end
 
       str_output = StringIO.new
-      redirect_pry_io(InputTester.new("hist --show 1..4", "exit-all"), str_output) do
+      redirect_pry_io(InputTester.new("hist --show 1..4", "exit-all", :history => @hist), str_output) do
         pry
       end
 


### PR DESCRIPTION
Looking at the tests, this is the expected behaviour; but the stubbed out readline method did not append to history in the same was as the real readline does.
