### PR TITLE
If Module#name is overridden the completion code crashes unexpectedly

### DIFF
--- a/lib/pry/completion.rb
+++ b/lib/pry/completion.rb
@@ -157,7 +157,7 @@ class Pry
             candidates = []
             ObjectSpace.each_object(Module){|m|
               begin
-                name = m.name
+                name = m.name.to_s
               rescue Exception
                 name = ""
               end

--- a/test/test_completion.rb
+++ b/test/test_completion.rb
@@ -1,0 +1,23 @@
+require 'helper'
+
+describe Pry::InputCompleter do
+
+  before do
+    # The AMQP gem has some classes like this:
+    #  pry(main)> AMQP::Protocol::Test::ContentOk.name
+    #  => :content_ok
+    module SymbolyName
+      def self.name; :symboly_name; end
+    end
+  end
+
+  after do
+    Object.remove_const :SymbolyName
+  end
+
+  it "should not crash if there's a Module that has a symbolic name." do
+    completer = Pry::InputCompleter.build_completion_proc(Pry.binding_for(Object.new))
+    lambda{ completer.call "a.to_s." }.should.not.raise Exception
+  end
+end
+


### PR DESCRIPTION
The completion code was assuming that all modules would have names that were strings, this is not always the case.
