### PR TITLE
Support `ENV['VISUAL']` as editor

### DIFF
--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -200,9 +200,9 @@ class Pry
 
   def self.default_editor_for_platform
     if RUBY_PLATFORM =~ /mswin|mingw/
-      ENV['EDITOR'] || "notepad"
+      ENV['VISUAL'] || ENV['EDITOR'] || "notepad"
     else
-      ENV['EDITOR'] || "nano"
+      ENV['VISUAL'] || ENV['EDITOR'] || "nano"
     end
   end
 


### PR DESCRIPTION
Historically, `$VISUAL` is given higher precedence than `$EDITOR`, as the former is for screen based editors while the latter is supposed to work on a teletype. Archaic, I know, but it wouldn't be UNIX if we phased things out. :)
