### PR TITLE
Added feature from issue #222: show-method and show-doc should accept multiple method names

### DIFF
--- a/lib/pry/default_commands/documentation.rb
+++ b/lib/pry/default_commands/documentation.rb
@@ -11,7 +11,7 @@ class Pry
         target = target()
 
         opts = Slop.parse!(args) do |opt|
-          opt.banner = "Usage: show-doc [OPTIONS] [METH]\n" \
+          opt.banner = "Usage: show-doc [OPTIONS] [METH 1] [METH 2] [METH N]\n" \
                        "Show the comments above method METH. Tries instance methods first and then methods by default.\n" \
                        "e.g show-doc hello_method"
 
@@ -28,25 +28,28 @@ class Pry
 
         next if opts.help?
 
-        meth_name = args.shift
-        if (meth = get_method_object(meth_name, target, opts.to_hash(true))).nil?
-          output.puts "Invalid method name: #{meth_name}. Type `show-doc --help` for help"
-          next
-        end
+        args = [nil] if args.empty?
+        args.each do |method_name|
+          meth_name = method_name
+          if (meth = get_method_object(meth_name, target, opts.to_hash(true))).nil?
+            output.puts "Invalid method name: #{meth_name}. Type `show-doc --help` for help"
+            next
+          end
 
-        doc, code_type = doc_and_code_type_for(meth)
-        next if !doc
+          doc, code_type = doc_and_code_type_for(meth)
+          next if !doc
 
-        next output.puts("No documentation found.") if doc.empty?
-        doc = process_comment_markup(doc, code_type)
-        output.puts make_header(meth, code_type, doc)
-        output.puts "#{text.bold("visibility: ")} #{method_visibility(meth).to_s}"
-        if meth.respond_to?(:parameters)
-          output.puts "#{text.bold("signature: ")} #{signature_for(meth)}"
-          output.puts
+          next output.puts("No documentation found.") if doc.empty?
+          doc = process_comment_markup(doc, code_type)
+          output.puts make_header(meth, code_type, doc)
+          output.puts "#{text.bold("visibility: ")} #{method_visibility(meth).to_s}"
+          if meth.respond_to?(:parameters)
+            output.puts "#{text.bold("signature: ")} #{signature_for(meth)}"
+            output.puts
+          end
+          render_output(opts.flood?, false, doc)
+          doc
         end
-        render_output(opts.flood?, false, doc)
-        doc
       end
 
       alias_command "?", "show-doc", ""

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -32,6 +32,11 @@ def sample_method
   :sample
 end
 
+# another sample doc
+def another_sample_method
+  :another_sample
+end
+
 def redirect_pry_io(new_in, new_out)
   old_in = Pry.input
   old_out = Pry.output

--- a/test/test_default_commands/test_documentation.rb
+++ b/test/test_default_commands/test_documentation.rb
@@ -10,6 +10,16 @@ describe "Pry::DefaultCommands::Documentation" do
 
       str_output.string.should =~ /sample doc/
     end
+    
+    it 'should output multiple methods\' documentation' do
+      str_output = StringIO.new
+      redirect_pry_io(InputTester.new("show-doc sample_method another_sample_method", "exit-all"), str_output) do
+        pry
+      end
+
+      str_output.string.should =~ /sample doc/
+      str_output.string.should =~ /another sample doc/
+    end
 
     it 'should output a method\'s documentation if inside method without needing to use method name' do
       $str_output = StringIO.new

--- a/test/test_default_commands/test_introspection.rb
+++ b/test/test_default_commands/test_introspection.rb
@@ -10,6 +10,16 @@ describe "Pry::DefaultCommands::Introspection" do
 
       str_output.string.should =~ /def sample/
     end
+    
+    it 'should output multiple methods\' sources' do
+      str_output = StringIO.new
+      redirect_pry_io(InputTester.new("show-method sample_method another_sample_method", "exit-all"), str_output) do
+        pry
+      end
+
+      str_output.string.should =~ /def sample/
+      str_output.string.should =~ /def another_sample/
+    end
 
     it 'should output a method\'s source with line numbers' do
       str_output = StringIO.new


### PR DESCRIPTION
Added feature described in issue #222: show-method and show-doc should accept multiple method names. For example

`show-method Enumerable#map Array#each`
and
`show-doc Enumerable#map Enumerable#inject`

work as expected. All tests passed.
