### PR TITLE
addresses issue 235

### DIFF
--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -111,6 +111,10 @@ class Pry
     # @return [Proc] The proc that manages ^D presses in the REPL.
     #   The proc is passed the current eval_string and the current pry instance.
     attr_accessor :control_d_handler
+
+    # @return [Set] A set of exception classes that are NOT caught by the
+    #   REPL.
+    attr_accessor :exception_whitelist
   end
 end
 

--- a/lib/pry/default_commands/context.rb
+++ b/lib/pry/default_commands/context.rb
@@ -99,6 +99,21 @@ class Pry
         end
       end
 
+      command "raise-up", "Raise an exception to the last time you invoked #pry, adding it the ignored exception list just this once" do |exc|
+        # we don't want to add this exception to the global ignore list
+        unless _pry_.has_own_attribute? :exception_whitelist
+          _pry_.exception_whitelist = Pry.exception_whitelist.dup
+        end
+        exc = Object.const_get(exc) rescue exc
+        #attempt to see if it matches a known exception type
+        if (exc.is_a?(Class) and exc < Exception)
+          _pry_.exception_whitelist << exc
+        else
+          _pry_.exception_whitelist << RuntimeError
+        end
+        Kernel.raise exc
+      end
+
       alias_command "quit", "exit", ""
 
       command "exit-program", "End the current program. Aliases: quit-program, !!!" do

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -52,7 +52,7 @@ class Pry
     def_delegators :@plugin_manager, :plugins, :load_plugins, :locate_plugins
 
     delegate_accessors :@config, :input, :output, :commands, :prompt, :print, :exception_handler,
-      :hooks, :color, :pager, :editor, :memory_size
+      :hooks, :color, :pager, :editor, :memory_size, :exception_whitelist
   end
 
   # Load the rc files given in the `Pry::RC_FILES` array.
@@ -222,6 +222,8 @@ class Pry
     config.history.file = File.expand_path("~/.pry_history")
 
     config.control_d_handler = DEFAULT_CONTROL_D_HANDLER
+
+    config.exception_whitelist = DEFAULT_EXCEPTION_WHITELIST
 
     config.memory_size = 100
   end

--- a/test/test_pry.rb
+++ b/test/test_pry.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'ruby-debug'
 
 puts "Ruby Version #{RUBY_VERSION}"
 puts "Testing Pry #{Pry::VERSION}"
@@ -175,6 +176,47 @@ describe Pry do
         lambda { mock_pry("raise SystemExit") }.should.raise SystemExit
         # SIGTERM
         lambda { mock_pry("raise SignalException.new(15)") }.should.raise SignalException
+        lambda { mock_pry("raise Exception")}.should.not.raise Exception
+      end
+
+      it 'should be able to specify exceptions not to catch' do
+        Pry.config.exception_whitelist << NoMethodError
+        lambda { mock_pry("raise NoMethodError")}.should.raise NoMethodError
+        Pry.config.exception_whitelist.delete NoMethodError
+        lambda { mock_pry("raise NoMethodError","exit-all")}.should.not.raise NoMethodError
+      end
+
+      it 'should be able to specify exceptions not to raise on an instance level' do
+        o = Exception.new
+        input = InputTester.new("raise NoMethodError","raise SystemExit", "raise ArgumentError")
+        output = StringIO.new
+        raised_exceptions = []
+
+        pry_instance = Pry.new(:input => input,
+                               :output => output,
+                               :exception_whitelist => [ArgumentError],
+                               :exception_handler => proc { |o,e| raised_exceptions << e })
+
+        lambda { pry_instance.repl(o) }.should.raise ArgumentError
+
+        raised_exceptions.each do |ex|
+          [NoMethodError, SystemExit].should.include ex.class
+          [ArgumentError].should.not.include ex.class
+        end
+
+        raised_exceptions.clear
+        input.rewind
+        #uses the defaults
+        pry_instance_again = Pry.new(:input => input,
+                                     :output => output,
+                                     :exception_handler => proc { |o, e| raised_exceptions << e })
+
+        lambda { pry_instance_again.repl(o) }.should.raise SystemExit
+
+        raised_exceptions.each do |ex|
+          [NoMethodError].should.include ex.class
+          [SystemExit, ArgumentError].should.not.include ex.class
+        end
       end
     end
 


### PR DESCRIPTION
Adds an "exception whitelist" to the configuration.  Exception classes which are in the exception white list are not caught by Pry but are passed up the stack until either the main program has to deal with them, or it encounters a different Pry instance that wants to handle it.

I added a "raise-up" command which accomplishes the latter, even if you didn't add a particular exception to your white list.
