### PR TITLE
On my machine (RVM, Ruby 1.9.2, Rails 3.0.9, MacOS 10.6) this throws a `S

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -349,7 +349,7 @@ avaiable.
 
 ### Use Pry as your Rails Console
 
-    pry -r./config/environment
+    pry -r ./config/environment
 
 MyArtChannel has kindly provided a hack to replace the `rails console` command in Rails 3: [https://gist.github.com/941174](https://gist.github.com/941174) This is not recommended for code bases with multiple developers, as they may not all want to use Pry.
 


### PR DESCRIPTION
On my machine (RVM, Ruby 1.9.2, Rails 3.0.9, MacOS 10.6) this throws a `Slop::MissingArgumentError` unless there's a space between `-r` and `./config...`. With the space it works just fine.

```
$ pry -r./config/environment
/Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/slop-2.1.0/lib/slop.rb:858:in `block in enable_multiple_switches': '-r' expects an argument, used in multiple_switch context (Slop::MissingArgumentError)
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/slop-2.1.0/lib/slop.rb:853:in `each_char'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/slop-2.1.0/lib/slop.rb:853:in `enable_multiple_switches'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/slop-2.1.0/lib/slop.rb:904:in `extract_option'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/slop-2.1.0/lib/slop.rb:777:in `block in parse_items'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/slop-2.1.0/lib/slop.rb:766:in `each'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/slop-2.1.0/lib/slop.rb:766:in `each_with_index'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/slop-2.1.0/lib/slop.rb:766:in `parse_items'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/slop-2.1.0/lib/slop.rb:444:in `parse'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/slop-2.1.0/lib/slop.rb:739:in `initialize_and_parse'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/slop-2.1.0/lib/slop.rb:279:in `parse'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/gems/pry-0.9.5/bin/pry:15:in `<top (required)>'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/bin/pry:19:in `load'
    from /Users/jordan/.rvm/gems/ruby-1.9.2-p180/bin/pry:19:in `<main>'
```
