### PR TITLE
A few ideas and fixes for Hooks

### DIFF
--- a/lib/pry/hooks.rb
+++ b/lib/pry/hooks.rb
@@ -45,8 +45,12 @@ class Pry
 
     # Clear the list of callables for the `name` hook.
     # @param [Symbol] The name of the hook to delete.
+    # @return [Array, NilClass] The hooks that were deleted.
+    # @note Returns deleted hook for easy temp replacement.
     def delete_hook(name)
+      deleted = @hooks.delete(name)
       @hooks[name] = []
+      deleted
     end
 
     # Clear all hooks.


### PR DESCRIPTION
Expose @hooks to the class and pass it back into the instance when calling .new
Have Hooks#delete_hook return the deleted hooks. 
Signed-off-by: Jordon Bedwell jordon@envygeeks.com

1 Exposing @hooks to the class and then back into the instance and allowing us to access @hooks directly allows us to modify pieces of a specific hook so that we don't shiv the user.  In short if Jane Doe adds her own hook to :before_session at this time I either have to delete the entire array of hooks or nothing if I want to replace just the pry default hook, this makes extending pry very very obtrusive.  Exposing @hooks allows us to easily modify that set of hooks so that we can say remove the default_hook and leave all other user hooks intact if they exist.

2 The idea is that if we do Hooks#delete_hook(:before_session) we can do backup = Hooks#delete_hook(:before_session) and back up everything in that hook so that if we customise the startup for a debugger prompt and we only want our hook exposed to our scripts and only from our scripts, we might create the hook then delete the hooks into a backup var and test and put the hooks back if the tests fail.
