### PR TITLE
Fix for issue #357. The easy way.

### DIFF
--- a/lib/pry/default_commands/context.rb
+++ b/lib/pry/default_commands/context.rb
@@ -143,11 +143,7 @@ class Pry
           i_num = 5
         end
 
-        if (meth = Pry::Method.from_binding(target))
-          meth_name = meth.name
-        else
-          meth_name = "N/A"
-        end
+        meth_name = Pry::Method.method_name_from_binding(target) || "N/A"
 
         if file != Pry.eval_path && (file =~ /(\(.*\))|<.*>/ || file == "" || file == "-e")
           raise CommandError, "Cannot find local context. Did you use `binding.pry`?"

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -45,7 +45,7 @@ class Pry
       # @return [Pry::Method, nil]
       #
       def from_binding(b)
-        meth_name = b.eval('__method__')
+        meth_name = method_name_from_binding(b)
         if [:__script__, nil, :__binding__, :__binding_impl__].include?(meth_name)
           nil
         else
@@ -111,6 +111,14 @@ class Pry
       def instance_resolution_order(klass)
         # include klass in case it is a singleton class,
         ([klass] + klass.ancestors).uniq
+      end
+
+      # Given a `Binding` extract name of the method it originated from.
+      # Return `nil` if no such method exists.
+      # @param [Binding] b
+      # @return [Symbol, nil]
+      def method_name_from_binding(b)
+        b.eval('__method__')
       end
 
       private


### PR DESCRIPTION
Here is the easiest fix for #357. There first problem with that issue is that sinatra generates horrible method names like `'GET /'` for its routes. When pry tries to use it as symbol [here](https://github.com/pry/pry/blob/28560c0d73461f783405c33ae0f17462d2e2e28a/lib/pry/method.rb#L52) it fails. 

Passing method name as `String` instead of `Symbol` doesn't solve the problem and leads to another exception. The reason is that sinatra uses unbounded methods that are removed from class right after being defined. You can see it in [`Sinatra::Base#generate_method`](https://github.com/sinatra/sinatra/blob/master/lib/sinatra/base.rb#L1186) or in [this gist](https://gist.github.com/1407204) that does pretty much the same stuff. And for that kind of methods `binding.eval("method('some_method')")` raises `NameError` exception. 

Bypassing method lookup and fetching only method name in `whereami` command makes `binding.pry` working fine inside sinatra route methods, but I think it'd better to update `Pry::Method.from_binding` in order to support that kind of methods as well. I spent some time trying to get method object from corresponding `Binding` object, but without any luck. May be someone can help me with that?
