### PR TITLE
Update Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,28 +4,27 @@ require 'rubygems/package_task'
 $:.unshift 'lib'
 require 'pry/version'
 
-CLOBBER.include("**/*~", "**/*#*", "**/*.log")
-CLEAN.include("**/*#*", "**/*#*.*", "**/*_flymake*.*", "**/*_flymake",
-              "**/*.rbc", "**/.#*.*")
+CLOBBER.include('**/*~', '**/*#*', '**/*.log')
+CLEAN.include('**/*#*', '**/*#*.*', '**/*_flymake*.*', '**/*_flymake', '**/*.rbc', '**/.#*.*')
 
 def apply_spec_defaults(s)
-  s.name = "pry"
+  s.name = 'pry'
   s.summary = "An IRB alternative and runtime developer console"
   s.version = Pry::VERSION
   s.date = Time.now.strftime '%Y-%m-%d'
   s.author = "John Mair (banisterfiend)"
   s.email = 'jrmair@gmail.com'
   s.description = s.summary
-  s.homepage = "http://pry.github.com"
-  s.executables = ["pry"]
+  s.homepage = 'http://pry.github.com'
+  s.executables = ['pry']
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- test/*`.split("\n")
-  s.add_dependency("coderay","~>0.9.8")
-  s.add_dependency("slop","~>2")
-  s.add_dependency("method_source","~>0.6.7")
-  s.add_development_dependency("bacon","~>1.1.0")
-  s.add_development_dependency("open4", "~>1.0.1")
-  s.add_development_dependency("rake", "~>0.9")
+  s.add_dependency('coderay', '~> 0.9')
+  s.add_dependency('slop', ['>= 2.4.1', '< 3'])
+  s.add_dependency('method_source','~> 0.6')
+  s.add_development_dependency('bacon', '~> 1.1')
+  s.add_development_dependency('open4', '~> 1.3')
+  s.add_development_dependency('rake', '~> 0.9')
 end
 
 desc "Set up and run tests"
@@ -75,8 +74,8 @@ end
 namespace :jruby do
   spec = Gem::Specification.new do |s|
     apply_spec_defaults(s)
-    s.add_dependency("spoon", "~>0.0.1")
-    s.platform = "java"
+    s.add_dependency('spoon', '~> 0.0')
+    s.platform = 'java'
   end
 
   Gem::PackageTask.new(spec) do |pkg|
@@ -90,7 +89,7 @@ end
   namespace v do
     spec = Gem::Specification.new do |s|
       apply_spec_defaults(s)
-      s.add_dependency("win32console", "~>1.3.0")
+      s.add_dependency('win32console', '~> 1.3')
       s.platform = "i386-#{v}"
     end
 
@@ -102,10 +101,10 @@ end
 end
 
 desc "build all platform gems at once"
-task :gems => [:clean, :rmgems, "ruby:gem", "mswin32:gem", "mingw32:gem", "jruby:gem"]
+task :gems => [:clean, :rmgems, 'ruby:gem', 'mswin32:gem', 'mingw32:gem', 'jruby:gem']
 
 desc "remove all platform gems"
-task :rmgems => ["ruby:clobber_package"]
+task :rmgems => ['ruby:clobber_package']
 
 desc "build and push latest gems"
 task :pushgems => :gems do


### PR DESCRIPTION
I replaced the deprecated `rake/gempackagetask` with `rubygems/package_task` and updated some gem dependencies. Specifically, this update makes pry use the latest gem versions of slop and coderay.

I regenerated the gemspec and ran the tests, which all still pass, but didn't commit the new gemspec, since it will need to be generated again before the next release.

Please let me know if you have any feedback for this pull request.

Thanks!
