### PR TITLE
Convert start_line in code.rb to integer before comparing it with the index

### DIFF
--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -110,7 +110,7 @@ class Pry
         lines = lines.lines
       end
 
-      @lines = lines.each_with_index.map { |l, i| [l.chomp, i + start_line] }
+      @lines = lines.each_with_index.map { |l, i| [l.chomp, i + start_line.to_i] }
       @code_type = code_type
     end
 


### PR DESCRIPTION
This addresses this issue:
https://github.com/pry/pry/issues/459

I'm not sure what the implications of this fix are, but it seems trivial enough.  This got my show-method working again. See below.

```
[2] pry(main)> show-method Blog.classify_blogs

From: /Users/joepeduto/.rvm/gems/ree-1.8.7-2011.03@ss/gems/pry-0.9.8.1/lib/pry/method.rb @ line 300:
Number of lines: 14
Owner: #<Class:Blog(id: integer, url: string, feed_url: string, canonical_url: string, title: string, description: text, average_daily_visits: decimal, average_daily_visitors: decimal, average_daily_pageviews: decimal, platform_id: string, created_at: datetime, updated_at: datetime, vertical_id: integer, publisher_id: integer, review_status: string, majority_country: string, cost: integer, auth_username: string, foreign_id: string, auth_token: string, auth_secret: string, author_name: string, type: string, screen_name: string, full_name: string, followers_count: integer, stats_updated_at: datetime, ga_status: string, open_offers_count: integer, approved_offers_count: integer, premium: boolean, design_quality: integer, writing_quality: integer, last_active_at: datetime, language_id: integer, audited_at: datetime, rejection_explanation: text, argus_posts_count: integer, publishing_status: string, ga_token: string, ga_secret: string, crypted_auth_password: string, admin_url: string, protocol_id: string, ga_profile_id: string, ga_last_reported_at: datetime, vertical_locked: boolean, advertiser_rating: decimal, claimed: boolean, staff_pick: boolean, auto_classify: boolean, can_sample_products: boolean, lead_threshold_enabled: boolean, lead_threshold: integer, deals_theme: string, widget_size: string, total_clicks: integer, total_views: integer, ctr: decimal)>
Visibility: public

def self.classify_blogs
  ga_verified.auto_classifiable.each do |blog|
    next if blog.average_daily_visitors.blank? || blog.average_daily_visitors.zero?

    begin
      transaction do
        blog.lock!
        blog.classify!
      end
    rescue Exception => err
      logger.error("Error classifying blog #{blog.id}: #{err}")
    end
  end
end
```
