### PR TITLE
Apply hist --tail or --head after --grep

### DIFF
--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -173,6 +173,23 @@ class Pry
       end
     end
 
+    # Take `num_lines` from `start_line`, forward or backwards
+    #
+    # @param [Fixnum] start_line
+    # @param [Fixnum] num_lines
+    # @return [Code]
+    def take_lines(start_line, num_lines)
+      if start_line >= 0
+        start_idx = @lines.index { |l| l.last >= start_line } || @lines.length
+      else
+        start_idx = @lines.length + start_line
+      end
+
+      alter do
+        @lines = @lines.slice(start_idx, num_lines)
+      end
+    end
+
     # Remove all lines except for the `lines` up to and excluding `line_num`.
     #
     # @param [Fixnum] line_num

--- a/lib/pry/default_commands/input.rb
+++ b/lib/pry/default_commands/input.rb
@@ -167,20 +167,22 @@ class Pry
         def process
           @history = Pry::Code(Pry.history.to_a)
 
-          @history = case
-            when opts.present?(:head)
-              @history.between(1, opts[:head] || 10)
-            when opts.present?(:tail)
-              @history.between(-(opts[:tail] || 10), -1)
-            when opts.present?(:show)
-              @history.between(opts[:show])
-            else
-              @history
-            end
+          if opts.present?(:show)
+            @history = @history.between(opts[:show])
+          end
 
           if opts.present?(:grep)
             @history = @history.grep(opts[:grep])
           end
+
+          @history = case
+            when opts.present?(:head)
+              @history.take_lines(1, opts[:head] || 10)
+            when opts.present?(:tail)
+              @history.take_lines(-(opts[:tail] || 10), opts[:tail] || 10)
+            else
+              @history
+            end
 
           if opts.present?(:'exclude-pry')
             @history = @history.select { |l, ln| !command_set.valid_command?(l) }

--- a/test/test_default_commands/test_input.rb
+++ b/test/test_default_commands/test_input.rb
@@ -347,6 +347,38 @@ describe "Pry::DefaultCommands::Input" do
       str_output.string.should =~ /x\n\d+:.*y\n\d+:.*z/
     end
 
+    it 'should apply --tail after --grep' do
+      @hist.push "print 1"
+      @hist.push "print 2"
+      @hist.push "puts  3"
+      @hist.push "print 4"
+      @hist.push "puts  5"
+
+      str_output = StringIO.new
+      redirect_pry_io(InputTester.new("hist --tail 2 --grep print", "exit-all"), str_output) do
+        pry
+      end
+
+      str_output.string.each_line.count.should == 2
+      str_output.string.should =~ /\d:.*?print 2\n\d:.*?print 4/
+    end
+
+    it 'should apply --head after --grep' do
+      @hist.push "puts  1"
+      @hist.push "print 2"
+      @hist.push "puts  3"
+      @hist.push "print 4"
+      @hist.push "print 5"
+
+      str_output = StringIO.new
+      redirect_pry_io(InputTester.new("hist --head 2 --grep print", "exit-all"), str_output) do
+        pry
+      end
+
+      str_output.string.each_line.count.should == 2
+      str_output.string.should =~ /\d:.*?print 2\n\d:.*?print 4/
+    end
+
     # strangeness in this test is due to bug in Readline::HISTORY not
     # always registering first line of input
     it 'should return first N lines in history with --head switch' do


### PR DESCRIPTION
`hist --grep pattern --tail N`

The behaviour of `--tail` and `--head` in `history` command combined with `--grep` is not what I expected. For me, the result of combine these two options should be "_the first/last N lines of history matching a pattern_" but not "_the lines mathing a pattern within the first/last N lines of history_". I think the first use case makes more sense and is more common.
