### PR TITLE
Adding support for SublimeText2 Editor

### DIFF
--- a/lib/pry/helpers/command_helpers.rb
+++ b/lib/pry/helpers/command_helpers.rb
@@ -153,6 +153,8 @@ class Pry
           "+#{line_number} #{file_name}"
         when /^mate/, /^geany/
           "-l #{line_number} #{file_name}"
+        when /^subl/
+          "#{ file_name }:#{ line_number }"
         when /^uedit32/
           "#{file_name}/#{line_number}"
         when /^jedit/


### PR DESCRIPTION
This allows a user to edit-method from within pry, and properly jump to the correct location in a file when using SublimeText 2
