### PR TITLE
Auto create configuration objects for plugins

### DIFF
--- a/lib/pry/plugins.rb
+++ b/lib/pry/plugins.rb
@@ -42,15 +42,15 @@ class Pry
       # disabled)
       # Does not reload plugin if it's already active.
       def activate!
+        # Create the configuration object for the plugin.
+        Pry.config.send("#{gem_name.gsub('-', '_')}=", OpenStruct.new)
+
         begin
           require gem_name if !active?
         rescue LoadError => e
           warn "Warning: The plugin '#{gem_name}' was not found! (gem found but could not be loaded)"
           warn e
         end
-
-        # Create the configuration object for the plugin.
-        Pry.config.send("#{gem_name.gsub('-', '_')}=", OpenStruct.new)
 
         self.active = true
         self.enabled = true


### PR DESCRIPTION
Whenever a plugin is activated a configuration object (using OpenStruct) will be
created in Pry.config for that plugin. For example, for the plugin "pry-doc" the
object Pry.config.pry_doc would be created.

See #436 for more information.
