### PR TITLE
Fix `exit` after previous syntax error in `exit` command.

### DIFF
--- a/lib/pry/default_commands/navigating_pry.rb
+++ b/lib/pry/default_commands/navigating_pry.rb
@@ -41,11 +41,14 @@ class Pry
       end
 
       command "exit-all", "End the current Pry session (popping all bindings) and returning to caller. Accepts optional return value. Aliases: !!@" do
+        # calculate user-given value
+        exit_value = target.eval(arg_string)
+
         # clear the binding stack
         _pry_.binding_stack.clear
 
         # break out of the repl loop
-        throw(:breakout, target.eval(arg_string))
+        throw(:breakout, exit_value)
       end
 
       alias_command "!!@", "exit-all"

--- a/test/test_default_commands/test_context.rb
+++ b/test/test_default_commands/test_context.rb
@@ -77,6 +77,12 @@ describe "Pry::DefaultCommands::Context" do
     it 'should break out of the repl loop of Pry instance when binding_stack has only one binding with exit, and return user-given value' do
       Pry.start(0, :input => StringIO.new("exit :john")).should == :john
     end
+
+    it 'should break out the repl loop of Pry instance even after an exception in user-given value' do
+      redirect_pry_io(InputTester.new("exit = 42", "exit"), StringIO.new) do
+        ins = Pry.new.tap { |v| v.repl(0).should == nil }
+      end
+    end
   end
 
   describe "jump-to" do


### PR DESCRIPTION
I accidentally tried to assign a value to an "exit" variable, forgetting that it was actually a pry command. As a result, later calls to exit don't work:

```
[1] pry(main)> exit = 0
SyntaxError: <main>: syntax error, unexpected '='
from /.../pry/lib/pry/default_commands/navigating_pry.rb:48:in `eval'
[2] pry(nil):-1> exit
NoMethodError: private method `eval' called for nil:NilClass
from /.../pry/lib/pry/default_commands/navigating_pry.rb:83:in `process_pop_and_return'
[3] pry(nil):-1> 
```

We can even see a `-1` level at the prompt.

This happened because the user-given value passed to exit was `eval`ed inline with a `throw` statement. If there is an exception while `eval`ing, we won't go back to the correspondent `catch`.

Now the user-given value is first `eval`ed, and then later the binding stack is cleared and we do the proper `throw`.

If there is anything that could be improved, please let me know.
