### PR TITLE
ZeroDivisionError in correct_indentation

### DIFF
--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -300,7 +300,7 @@ class Pry
         cols = ENV['COLUMNS'].to_i
       end
 
-      lines = cols ? (full_line.length / cols + 1) : 1
+      lines = cols && cols != 0 ? (full_line.length / cols + 1) : 1
 
       if defined?(Win32::Console)
         move_up   = "\e[#{lines}F"


### PR DESCRIPTION
Hi,

I have been encountering an error because cols is set to zero when the division occurs.  Please get in touch if you would like me to make any corrections.  Thanks!
- Sonny
