### PR TITLE
Change 'pry-version' command to 'version'

### DIFF
--- a/lib/pry/default_commands/misc.rb
+++ b/lib/pry/default_commands/misc.rb
@@ -16,7 +16,7 @@ class Pry
         end
       end
 
-      command "pry-version", "Show Pry version." do
+      command "version", "Show Pry version." do
         output.puts "Pry version: #{Pry::VERSION} on Ruby #{RUBY_VERSION}."
       end
 


### PR DESCRIPTION
### Description

I did some research on this topic and it turns out that initially Pry had `version` command instead of `pry-version`. Since v0.9.3 Pry started to use [`pry-version` command](https://github.com/pry/pry/commit/9fc824a087356e01bf1acb2632d4112c607228de#L1L19). Since then, in order to know the version of Pry users have to use `pry-version` command, whereas `<= 0.9.2` users use `version`.
### Research

Let's ensure, that both of these commands really work with the specific version of Pry.
- _Pry >= 0.9.3:_
  
  ```
  % pry --simple-prompt
  >> pry-version
  Pry version: 0.9.9.6 on Ruby 1.9.3.
  ```
- _Pry <= 0.9.2:_
  
  ```
  % pry --simple-prompt
  >> version
  Pry version: 0.9.2 on Ruby 1.9.3.
  ```

There is one problem in the new (pry-version) command: it's not obvious to guess. I'll explain that hereinafter. Let's investigate the situation further.
- _Pry <= 0.9.2:_
  
  ```
  % pry --simple-prompt
  >> version
  Pry version: 0.9.2 on Ruby 1.9.3.
  >> pry-version
  >> ^D
  NoMethodError: undefined method `-' for main:Object
  from (pry):in `<main>'
  ```
- _Pry >= 0.9.3:_

```
% pry --simple-prompt
>> pry-version
Pry version: 0.9.9.6 on Ruby 1.9.3.
>> version
=> ">= 0"
>> help version
pry-version        Show Pry version.
```

Wait, what? `version` still works? But how the hell?! Definitely something is wrong up here.

The autocompletion works for `version`, which adds even more confusion to the user:

```
>> ver<TAB>
>> version
```

Well, the answer is that `version` is a variable:

```
>> defined? version
=> "local-variable"
```
### The Answer

The variable `version` is defined in "_which pry_" executable. However, I don't know where the variable lives, when you launch Pry from repository (with help of `rake pry`).

"which pry" returns _~/.gem/ruby/1.9.1/bin/pry_ for me:

``` ruby
#!/usr/bin/ruby
#
# This file was generated by RubyGems.
#
# The application 'pry' is installed as part of a gem, and
# this file is here to facilitate running it.
#

require 'rubygems'

version = ">= 0" # <- This is what we get in Pry, whenever execute `version`.

if ARGV.first
  str = ARGV.first
  str = str.dup.force_encoding("BINARY") if str.respond_to? :force_encoding
  if str =~ /\A_(.*)_\z/
    version = $1
    ARGV.shift
  end
end

gem 'pry', version
load Gem.bin_path('pry', 'pry', version)
```
### Wrap Up

I do think, this is a problem. Let me explain my opinion. First of all, `pry-version` and `pry-backtrace` are the only two commands that use `pry-*` prefix. But I don't see any logical explanation why `version` has been changed to `pry-version` (the commit in the beginning of the issue doesn't explain that). Why not to use `pry-*` prefix for every single command, then? `pry-nesting`, `pry-cat`, `pry-play` and so on… Because it's verbose! So is `pry-version`.

At first, I thought it's a bug in Pry (I forgot that `pry-version` command exists, and thought that `version` is the only valid command for that action, but that's my individual problem). I've spent some time, trying to figure out, what was that "version" thingie and where it comes from, but the output from `help` confused me even more. I wonder, why does RubyGems define the `version` variable at the top-level of your application every time when you use executables?

My solution of the problem is to change `pry-version` back to `version`.
