### PR TITLE
Add unit tests for DEFAULT_CONTROL_D_HANDLER

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -106,7 +106,7 @@ class Pry
       # clear input buffer
       eval_string.replace("")
     elsif _pry_.binding_stack.one?
-      # ^D at top-level breaks out of loop
+      # ^D at top-level breaks out of a REPL loop
       _pry_.binding_stack.clear
       throw(:breakout)
     else

--- a/test/test_control_d_handler.rb
+++ b/test/test_control_d_handler.rb
@@ -1,0 +1,61 @@
+require 'helper'
+
+describe Pry::DEFAULT_CONTROL_D_HANDLER do
+  describe 'control-d press' do
+    before do
+      @control_d = "Pry::DEFAULT_CONTROL_D_HANDLER.call('', _pry_)"
+      @binding_stack = "$binding_stack = _pry_.binding_stack.dup"
+    end
+
+    #describe 'in an expression' do
+      #it 'should clear input buffer' do
+      #end
+    #end
+
+    describe 'at top-level session' do
+      it 'should break out of a REPL loop' do
+        instance = nil
+        redirect_pry_io(InputTester.new(@control_d)) do
+          instance = Pry.new
+          instance.repl
+        end
+
+        instance.binding_stack.should.be.empty
+      end
+    end
+
+    describe 'in a nested session' do
+      it 'should pop last binding from the binding stack' do
+        $obj = Object.new
+        $obj.instance_variable_set(:@x, :mon_dogg)
+        $obj.instance_variable_set(:@y, :john_dogg)
+
+        redirect_pry_io(InputTester.new("cd $obj", @control_d,
+                                        @binding_stack, "exit-all")) do
+          Pry.start
+        end
+
+        $binding_stack.size.should == 1
+        $binding_stack.last.eval("self") == TOPLEVEL_BINDING.eval("self")
+
+        redirect_pry_io(InputTester.new("cd $obj/@x", "cd $obj/@y",
+                                        "cd 42", @control_d, @binding_stack,
+                                        "exit-all")) do
+          Pry.start
+        end
+
+        $binding_stack.size.should == 5
+        $binding_stack.last.eval("self") == :john_dogg
+
+        redirect_pry_io(InputTester.new("cd $obj/@x", "cd $obj/@y", "cd 42",
+                                        @control_d, @control_d, @control_d,
+                                        @binding_stack, "exit-all")) do
+          Pry.start
+        end
+
+        $binding_stack.size.should == 3
+        $binding_stack.last.eval("self") == :mon_dogg
+      end
+    end
+  end
+end


### PR DESCRIPTION
DEFAULT_CONTROL_D_HANDLER handles a user's Control-D (^D) presses. Add
unit tests for ^D presses. Note that this commit doesn't include unit
tests for the situation when ^D is being pressed in an expression[1].

[1]:
Example of the untested situation:
  % pry
  [1] pry(main)> class Foo
  [1] pry(main)\*   ^D
  [2] pry(main)>
