### PR TITLE
Change redundant String#replace to String#clear

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -104,7 +104,7 @@ class Pry
   DEFAULT_CONTROL_D_HANDLER = proc do |eval_string, _pry_|
     if !eval_string.empty?
       # clear input buffer
-      eval_string.replace("")
+      eval_string.clear
     elsif _pry_.binding_stack.one?
       # ^D at top-level breaks out of loop
       _pry_.binding_stack.clear

--- a/lib/pry/default_commands/editing.rb
+++ b/lib/pry/default_commands/editing.rb
@@ -10,7 +10,7 @@ class Pry
       create_command "!", "Clear the input buffer. Useful if the parsing process goes wrong and you get stuck in the read loop.", :use_prefix => false do
         def process
           output.puts "Input buffer cleared!"
-          eval_string.replace("")
+          eval_string.clear
         end
       end
 

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -348,7 +348,7 @@ class Pry
     # from within Readline.
     rescue Interrupt
       output.puts ""
-      eval_string.replace("")
+      eval_string.clear
       return
     end
 


### PR DESCRIPTION
"foo".clear does the same as "foo".replace(""). But the former is more concise.
