### PR TITLE
Escape user input before completing it.

### DIFF
--- a/lib/pry/completion.rb
+++ b/lib/pry/completion.rb
@@ -45,6 +45,12 @@ class Pry
       proc do |input|
         bind = target
 
+        # Escape the user input before regexing it. This prevents Pry from
+        # throwing an error when trying to complete input such as ":class)".
+        # Because this would be converted to a Regexp instance (and since it
+        # wasn't properly closed) this would trigger a RegexpError.
+        input = Regexp.escape(input)
+
         case input
         when /^(\/[^\/]*\/)\.([^.]*)$/
           # Regexp

--- a/test/test_completion.rb
+++ b/test/test_completion.rb
@@ -22,5 +22,12 @@ describe Pry::InputCompleter do
       lambda{ completer.call "a.to_s." }.should.not.raise Exception
     end
   end
+
+  it 'should take parenthesis and other characters into account for symbols' do
+    b         = Pry.binding_for(Object.new)
+    completer = Pry::InputCompleter.build_completion_proc(b)
+
+    lambda { completer.call(":class)") }.should.not.raise(RegexpError)
+  end
 end
 


### PR DESCRIPTION
User input should be escaped using Regexp.escape() before trying to figure out
what data to use for the Readline completion system. Not escaping this input
would cause Pry to fail for input such as `[10, 20].map(&:class)`.

This problem was caused due to lib/completion.rb converting the input (in this
case it would be ":class)") to a Regexp object. Because this, when converted to
a Regexp object, is invalid it would cause Pry to throw a RegexpError error and
bail out.

See #601 for more information.
