### PR TITLE
Change behavior of `cd -` command

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -103,16 +103,17 @@ class Pry
   # 3) In a nested session  - behave like `cd ..`       (pop a binding)
   DEFAULT_CONTROL_D_HANDLER = proc do |eval_string, _pry_|
     if !eval_string.empty?
-      # clear input buffer
+      # Clear input buffer.
       eval_string.replace("")
     elsif _pry_.binding_stack.one?
-      # ^D at top-level breaks out of a REPL loop
+      # ^D at top-level breaks out of a REPL loop.
       _pry_.binding_stack.clear
       throw(:breakout)
     else
-      # otherwise just pops a binding and stores it as old binding
-      _pry_.command_state["cd"].old_binding = _pry_.binding_stack.pop
-      _pry_.command_state["cd"].append = true
+      # Otherwise, saves current binding stack as old stack and pops last
+      # binding out of binding stack (the old stack still has that binding).
+      _pry_.command_state["cd"].old_stack = _pry_.binding_stack.dup
+      _pry_.binding_stack.pop
     end
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,6 +8,12 @@ puts "Ruby v#{RUBY_VERSION} (#{defined?(RUBY_ENGINE) ? RUBY_ENGINE : "ruby"}), P
 require 'bacon'
 require 'open4'
 
+# A global space for storing temporary state during tests.
+ScratchPad = OpenStruct.new
+Pad = ScratchPad
+def ScratchPad.clear
+  @table = {}
+end
 
 # turn warnings off (esp for Pry::Hooks which will generate warnings
 # in tests)
@@ -55,7 +61,6 @@ class TestClassForShowSourceInstanceEval
   def alpha
   end
 end
-
 
 # in case the tests call reset_defaults, ensure we reset them to
 # amended (test friendly) values


### PR DESCRIPTION
Since banister begged me to do that... completely rewrite `cd -`
command (implemetation is much simpler now).

This commit brings such changes:
- completely rewrite behavior of `cd -` command;
- implement ScratchPad aka Pad for unit testing purposes (by
  banister);
- use Pad riches in the unit tests for `cd -` command;
- remove verbose and clunky unit tests;

This commit brings new meaning to the `cd -` command. The main
difference is that the new command saves entire binding stack, not just
the last binding. Let me show you an example of the variance between
these two implemetations:
- Old `cd -` implementation saves _only_ last binding. With our next
  `cd -` invocation our interjacent results are lost:
    [1] pry(main)> cd 1/2/3/../4
    [2] pry(4):3> cd -
    [3] pry(main)> cd -
    [4] pry(4):1> nesting
    Nesting status:
    --
  1. main (Pry top level)
  2. 4
     
     Also, there are a few bugs in old `cd -` command:
  
  ```
  * you type `cd :foo`, `cd 1/2/3` and `cd -`. The last command
    relocates you to the scope of `3` (leaves you where you was),
    when `:foo` is expected;
  
  * you type `cd :foo`, `cd 1/2/3/../4`, `cd -`. The last command
    relocates you to the scope of `3`, when `:foo` is expected.
  ```
- New and shiny `cd -` is devoid of those shortcomings:
    [1] pry(main)> cd 1/2/3/../4
    [2] pry(4):3> cd -
    [3] pry(main)> cd -
    [4] pry(4):3> nesting
    Nesting status:
    --
  1. main (Pry top level)
  2. 1
  3. 2
  4. 4

As I said before, this solution is _much_ simpler and less error-prone.

Signed-off-by: Kyrylo Silin kyrylosilin@gmail.com
