### PR TITLE
Remove ScratchPad alias for Pad

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,9 +9,8 @@ require 'bacon'
 require 'open4'
 
 # A global space for storing temporary state during tests.
-ScratchPad = OpenStruct.new
-Pad = ScratchPad
-def ScratchPad.clear
+Pad = OpenStruct.new
+def Pad.clear
   @table = {}
 end
 


### PR DESCRIPTION
ScratchPad is the "official" name that was taken from Rubinius. We are
not Rubinius, so we use Pad. Merely "Pad".

Signed-off-by: Kyrylo Silin kyrylosilin@gmail.com
