### PR TITLE
Refactor and improve Command.group method

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -149,7 +149,7 @@ class Pry
                    case Pry::Method(block).source_file
                    when %r{/pry/.*_commands/(.*).rb}
                      $1.capitalize.gsub(/_/, " ")
-                   when %r{(pry-\w+)-([\d\.]+(\w+)?)}
+                   when %r{(pry-\w+)-([\d\.]+([\w\d\.]+)?)}
                      name, version = $1, $2
                      "#{name.to_s} (v#{version.to_s})"
                    when /pryrc/


### PR DESCRIPTION
Make `help` command be able to display groups, that are taken from gem
names correctly.

In this commit:

  a) Refactor group method by means of an if statement (remove
     repetition of assignment process);

  b) Remove unwanted square brackets from the Regexp (they do nothing);

  c) Add supplementary Regexp part to the existing one. This clause
     needs an explication:

```
   The old Regexp didn't capture the following strings properly:
     - "pry-pluginname-0.1.0.pre";
     - "pry-pluginname-0.1.0.rc1";
     - "pry-pluginname-0.1.0.BETA";
     - and so on.

  Instead of this, the old Regexp did capture the strings mentioned
  above as `pry-pluginname-0.1.0.` (in all cases).

  By making the Regexp a bit looser, the `help` command, when
  invoked without arguments, can display extra suffixes in
  group names.
```

Signed-off-by: Kyrylo Silin kyrylosilin@gmail.com
