### PR TITLE
Fix space handling for `edit` command

### DIFF
--- a/lib/pry/default_commands/editing.rb
+++ b/lib/pry/default_commands/editing.rb
@@ -1,4 +1,5 @@
 require 'tempfile'
+require 'shellwords'
 require 'pry/default_commands/hist'
 
 class Pry
@@ -141,8 +142,12 @@ class Pry
           line = opts[:l].to_i if opts.present?(:line)
 
           reload = opts.present?(:reload) || ((opts.present?(:ex) || file_name.end_with?(".rb")) && !opts.present?(:'no-reload')) && !Pry.config.disable_auto_reload
-          invoke_editor(file_name, line, reload)
-          set_file_and_dir_locals(file_name)
+
+          # Sanitize blanks.
+          sanitized_file_name = Shellwords.escape(file_name)
+
+          invoke_editor(sanitized_file_name, line, reload)
+          set_file_and_dir_locals(sanitized_file_name)
 
           if reload
             silence_warnings do


### PR DESCRIPTION
Fix issue #623 (edit command can't handle paths with spaces in the
name).

---

Description by banister:

> > .cd /Users/john/Library/Application Support/
> > edit hello.rb

  The editor freaks out, opening two files, one called
  `/Users/john/Library/Application` and the other called
##   `Support/hello.rb`

Use Shellwords, because it's is a jewel.

Reported-by: John Mair jrmair@gmail.com
Signed-off-by: Kyrylo Silin kyrylosilin@gmail.com
