### PR TITLE
Extend command group regexp (bugfix)

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -143,21 +143,21 @@ class Pry
       # This is usually auto-generated from directory naming, but it can be
       # manually overridden if necessary.
       def group(name=nil)
-        @group = if name
-                   name
-                 else
-                   case Pry::Method(block).source_file
-                   when %r{/pry/.*_commands/(.*).rb}
-                     $1.capitalize.gsub(/_/, " ")
-                   when %r{(pry-\w+)-([\d\.]+([\w\d\.]+)?)}
-                     name, version = $1, $2
-                     "#{name.to_s} (v#{version.to_s})"
-                   when /pryrc/
-                     "~/.pryrc"
+        @group ||= if name
+                     name
                    else
-                     "(other)"
+                     case Pry::Method(block).source_file
+                     when %r{/pry/.*_commands/(.*).rb}
+                       $1.capitalize.gsub(/_/, " ")
+                     when %r{(pry-\w+)-([\d\.]+([\w\d\.]+)?)}
+                       name, version = $1, $2
+                       "#{name.to_s} (v#{version.to_s})"
+                     when /pryrc/
+                       "~/.pryrc"
+                     else
+                       "(other)"
+                     end
                    end
-                 end
       end
     end
 

--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -693,4 +693,20 @@ describe "Pry::Command" do
       instance.command_state[/[Hh]ello-world/].my_state.should == 4
     end
   end
+
+  describe 'group' do
+    before do
+      @set.import Pry::DefaultCommands::Cd
+    end
+
+    it 'should not change once it is initialized' do
+      @set.commands["cd"].group("-==CD COMMAND==-")
+      @set.commands["cd"].group.should == "Context"
+    end
+
+    it 'should be correct for default commands' do
+      @set.commands["cd"].group.should == "Context"
+      @set.commands["help"].group.should == "Help"
+    end
+  end
 end


### PR DESCRIPTION
Adjust wrong nesting (remove extra blank from each line) in some tests.

Aaaaand...

Fix issue #631 (In `help` output: aliases are no longer grouped under
Aliases heading but under (other))

Forbid redefining a group of a command once it is initialized. Also, add
some unit tests, checking for that, so we won't miss this if it happens
next time.
