### PR TITLE
Refactor tests for command groups

### DIFF
--- a/test/test_command.rb
+++ b/test/test_command.rb
@@ -696,17 +696,25 @@ describe "Pry::Command" do
 
   describe 'group' do
     before do
-      @set.import Pry::DefaultCommands::Cd
-    end
-
-    it 'should not change once it is initialized' do
-      @set.commands["cd"].group("-==CD COMMAND==-")
-      @set.commands["cd"].group.should == "Context"
+      @set.import(
+                  Pry::CommandSet.new do
+                    create_command("magic") { group("Not for a public use") }
+                  end
+                 )
     end
 
     it 'should be correct for default commands' do
-      @set.commands["cd"].group.should == "Context"
       @set.commands["help"].group.should == "Help"
+    end
+
+    it 'should not change once it is initialized' do
+      @set.commands["magic"].group("-==CD COMMAND==-")
+      @set.commands["magic"].group.should == "Not for a public use"
+    end
+
+    it 'should not disappear after the call without parameters' do
+      @set.commands["magic"].group
+      @set.commands["magic"].group.should == "Not for a public use"
     end
   end
 end


### PR DESCRIPTION
We should not rely on default commands, because they can be removed or
shuffled around in the future. Use our custom command in the tests.

Also, add a test that ensures that a group does not disappear after the
call without parameters.

Reported-by: John Mair jrmair@gmail.com
Signed-off-by: Kyrylo Silin kyrylosilin@gmail.com
