### PR TITLE
Fix for issue #569

### DIFF
--- a/lib/pry/completion.rb
+++ b/lib/pry/completion.rb
@@ -8,7 +8,7 @@ class Pry
   module InputCompleter
 
     if Readline.respond_to?("basic_word_break_characters=")
-      Readline.basic_word_break_characters = " \t\n\"\\'`><=;|&{("
+      Readline.basic_word_break_characters = "/ \t\n\"\\'`><=;|&{("
     end
 
     Readline.completion_append_character = nil


### PR DESCRIPTION
This is a simple fix to include a forward slash in the delimiter list for Readline.
