### PR TITLE
gist --doc works with classes and methods, fixes #609

### DIFF
--- a/lib/pry/default_commands/gist.rb
+++ b/lib/pry/default_commands/gist.rb
@@ -40,7 +40,7 @@ class Pry
           opt.on :d, :doc, "Gist a method's documentation.", :argument => true do |meth_name|
             meth = get_method_or_raise(meth_name, target, {})
             text.no_color do
-              self.content << process_comment_markup(meth.doc, self.code_type) << "\n"
+              self.content << process_comment_markup(meth.doc, :plain) << "\n"
             end
             self.filename = meth.source_file + ".doc"
           end


### PR DESCRIPTION
`gist --doc` was not working with classes and methods because in `gist.rb` `self.code_type` does not exist. To address this we substituted `self.code_type` with `:plain`. The regression was introduced in commit 910afec.

Please let us know if you have any suggestions. Thanks!
