### PR TITLE
Alias for the --simple-prompt mode

### DIFF
--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -1,4 +1,3 @@
-
 class Pry
 
   # Manage the processing of command line options
@@ -131,7 +130,9 @@ Copyright (c) 2011 John Mair (banisterfiend)
     exit
   end
 
-  on "simple-prompt", "Enable simple prompt mode" do
+  on :p, "simple-prompt", "Enable simple prompt mode" do
+    Pry.config.should_load_rc = false
+    Pry.config.should_load_local_rc = false
     Pry.config.prompt = Pry::SIMPLE_PROMPT
   end
 


### PR DESCRIPTION
Hello,

It's just a little pull request which provides an alias for the `--simple-prompt` option. It's a bit of a pain to switch the prompt mode because we have to call 

``` bash
$ pry -f --simple-prompt
```

command to set the simple-prompt mode. Here, we just have to call:

``` bash
$ pry -p
```

Have a nice day.
