### PR TITLE
New PR for tab-complete feature

### DIFF
--- a/lib/pry/commands/cd.rb
+++ b/lib/pry/commands/cd.rb
@@ -20,57 +20,9 @@ class Pry
     BANNER
 
     def process
-      # Extract command arguments. Delete blank arguments like " ", but
-      # don't delete empty strings like "".
-      path      = arg_string.split(/\//).delete_if { |a| a =~ /\A\s+\z/ }
-      stack     = _pry_.binding_stack.dup
-      old_stack = state.old_stack || []
-
-      # Special case when we only get a single "/", return to root.
-      if path.empty?
-        state.old_stack = stack.dup unless old_stack.empty?
-        stack = [stack.first]
-      end
-
-      path.each_with_index do |context, i|
-        begin
-          case context.chomp
-          when ""
-            state.old_stack = stack.dup
-            stack = [stack.first]
-          when "::"
-            state.old_stack = stack.dup
-            stack.push(TOPLEVEL_BINDING)
-          when "."
-            next
-          when ".."
-            unless stack.size == 1
-              # Don't rewrite old_stack if we're in complex expression
-              # (e.g.: `cd 1/2/3/../4).
-              state.old_stack = stack.dup if path.first == ".."
-              stack.pop
-            end
-          when "-"
-            unless old_stack.empty?
-              # Interchange current stack and old stack with each other.
-              stack, state.old_stack = state.old_stack, stack
-            end
-          else
-            state.old_stack = stack.dup if i == 0
-            stack.push(Pry.binding_for(stack.last.eval(context)))
-          end
-
-        rescue RescuableException => e
-          # Restore old stack to its initial values.
-          state.old_stack = old_stack
-
-          output.puts "Bad object path: #{arg_string.chomp}. Failed trying to resolve: #{context}"
-          output.puts e.inspect
-          return
-        end
-      end
-
-      _pry_.binding_stack = stack
+      stack, old_stack = context_from_object_path(arg_string, _pry_, state.old_stack||[])
+      state.old_stack = old_stack
+      _pry_.binding_stack = stack unless stack.nil?
     end
   end
 end

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -70,7 +70,7 @@ class Pry
       end
 
       def use_ansi_codes?
-         windows_ansi? || ENV['TERM'] && ENV['TERM'] != "dumb"
+        windows_ansi? || ENV['TERM'] && ENV['TERM'] != "dumb"
       end
 
       def colorize_code(code)
@@ -123,16 +123,16 @@ class Pry
       # simple_pager. Also do not page if Pry.pager is falsey
       def stagger_output(text, out = nil)
         out ||= case
-        when respond_to?(:output)
-          # Mixin.
-          output
-        when Pry.respond_to?(:output)
-          # Parent.
-          Pry.output
-        else
-          # Sys.
-          $stdout
-        end
+                when respond_to?(:output)
+                  # Mixin.
+                  output
+                when Pry.respond_to?(:output)
+                  # Parent.
+                  Pry.output
+                else
+                  # Sys.
+                  $stdout
+                end
 
         if text.lines.count < Pry::Pager.page_size || !Pry.pager
           out.puts text
@@ -143,6 +143,67 @@ class Pry
         Pry::Pager.page(text, :simple)
       rescue Errno::EPIPE
       end
+
+      # @param [String] arg_string The object path expressed as a string.
+      # @param [Pry] _pry_ The relevant Pry instance.
+      # @param [Array<Binding>] old_stack The state of the old binding stack
+      # @return [Array<Array<Binding>, Array<Binding>>] An array
+      #   containing two elements: The new `binding_stack` and the old `binding_stack`.
+      def context_from_object_path(arg_string, _pry_=nil, old_stack=[])
+
+        # Extract command arguments. Delete blank arguments like " ", but
+        # don't delete empty strings like "".
+        path      = arg_string.split(/\//).delete_if { |a| a =~ /\A\s+\z/ }
+        stack     = _pry_.binding_stack.dup
+        state_old_stack = old_stack
+
+        # Special case when we only get a single "/", return to root.
+        if path.empty?
+          state_old_stack = stack.dup unless old_stack.empty?
+          stack = [stack.first]
+        end
+
+        path.each_with_index do |context, i|
+          begin
+            case context.chomp
+            when ""
+              state_old_stack = stack.dup
+              stack = [stack.first]
+            when "::"
+              state_old_stack = stack.dup
+              stack.push(TOPLEVEL_BINDING)
+            when "."
+              next
+            when ".."
+              unless stack.size == 1
+                # Don't rewrite old_stack if we're in complex expression
+                # (e.g.: `cd 1/2/3/../4).
+                state_old_stack = stack.dup if path.first == ".."
+                stack.pop
+              end
+            when "-"
+              unless old_stack.empty?
+                # Interchange current stack and old stack with each other.
+                stack, state_old_stack = state_old_stack, stack
+              end
+            else
+              state_old_stack = stack.dup if i == 0
+              stack.push(Pry.binding_for(stack.last.eval(context)))
+            end
+
+          rescue RescuableException => e
+
+            # Restore old stack to its initial values.
+            state_old_stack = old_stack
+
+            output.puts "Bad object path: #{arg_string.chomp}. Failed trying to resolve: #{context}"
+            output.puts e.inspect
+            return nil, state_old_stack
+          end
+        end
+        return stack, state_old_stack
+      end
+
     end
   end
 end

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -360,7 +360,7 @@ class Pry
     @indent.reset if eval_string.empty?
 
     current_prompt = select_prompt(eval_string, target)
-    completion_proc = Pry::InputCompleter.build_completion_proc(target,
+    completion_proc = Pry::InputCompleter.build_completion_proc(target, self,
                                                         instance_eval(&custom_completions))
 
 

--- a/test/test_completion.rb
+++ b/test/test_completion.rb
@@ -1,5 +1,16 @@
 require 'helper'
 
+def new_completer(bind, pry=nil)
+    Pry::InputCompleter.build_completion_proc(Pry.binding_for(bind), pry)
+end
+
+def completer_test(bind, pry=nil, assert_flag=true)
+  completer = new_completer(bind, pry)
+  test = proc {|symbol| completer.call(symbol[0..-2]).include?(symbol).should  == assert_flag}
+  return proc {|*symbols| symbols.each(&test) }
+end
+
+
 describe Pry::InputCompleter do
 
   before do
@@ -33,30 +44,176 @@ describe Pry::InputCompleter do
   it 'should complete instance variables' do
     object = Object.new
 
+    # set variables in appropriate scope
     object.instance_variable_set(:'@name', 'Pry')
     object.class.send(:class_variable_set, :'@@number', 10)
 
-    object.instance_variables.map { |v| v.to_sym } \
-      .include?(:'@name').should == true
+    # check to see if variables are in scope
+    object.instance_variables.
+      map { |v| v.to_sym }.
+      include?(:'@name').should == true
 
-    object.class.class_variables.map { |v| v.to_sym } \
-      .include?(:'@@number').should == true
-
-    completer = Pry::InputCompleter.build_completion_proc(
-      Pry.binding_for(object)
-    )
+    object.class.class_variables.
+      map { |v| v.to_sym }.
+      include?(:'@@number').should == true
 
     # Complete instance variables.
-    completer.call('@na').include?('@name').should                 == true
-    completer.call('@name.down').include?('@name.downcase').should == true
+    b = Pry.binding_for(object)
+    completer_test(b).call('@name', '@name.downcase')
 
     # Complete class variables.
-    completer = Pry::InputCompleter.build_completion_proc(
-      Pry.binding_for(object.class)
-    )
+    b = Pry.binding_for(object.class)
+    completer_test(b).call('@@number', '@@number.class')
 
-    completer.call('@@nu').include?('@@number').should              == true
-    completer.call('@@number.cl').include?('@@number.class').should == true
   end
+
+
+  it 'should complete for stdlib symbols' do
+
+    o = Object.new
+    # Regexp
+    completer_test(o).call('/foo/.extend')
+
+    # Array
+    completer_test(o).call('[1].push')
+  
+    # Hash
+    completer_test(o).call('{"a" => "b"}.keys')
+    
+    # Proc
+    completer_test(o).call('{2}.call')
+
+    # Symbol
+    completer_test(o).call(':symbol.to_s')
+
+    # Absolute Constant
+    completer_test(o).call('::IndexError')
+  end
+
+  it 'should complete for target symbols' do
+    o = Object.new
+
+    # Constant
+    module Mod
+      Con = 'Constant'
+      module Mod2
+      end
+    end
+
+    completer_test(Mod).call('Con')
+
+    # Constants or Class Methods
+    completer_test(o).call('Mod::Con')
+
+    # Symbol
+    foo = :symbol
+    completer_test(o).call(':symbol')
+
+    # Variables
+    class << o
+      attr_accessor :foo
+    end
+    o.foo = 'bar'
+    completer_test(binding).call('o.foo')
+
+    # trailing slash
+    new_completer(Mod).call('Mod2/').include?('Mod2/').should   == true
+  end
+
+  it 'should complete for arbitrary scopes' do
+    module Bar
+      @barvar = :bar
+    end
+
+    module Baz
+      @bar = Bar
+      @bazvar = :baz
+      Con = :constant
+    end
+
+    pry = Pry.new()
+    stack = pry.binding_stack
+    stack.push(Pry.binding_for(Baz))
+    stack.push(Pry.binding_for(Bar))
+
+    b = Pry.binding_for(Bar)
+    completer_test(b, pry).call("../@bazvar")
+    completer_test(b, pry).call('/Con')
+  end
+
+  it 'should complete for stdlib symbols' do
+
+    o = Object.new
+    # Regexp
+    completer_test(o).call('/foo/.extend')
+
+    # Array
+    completer_test(o).call('[1].push')
+  
+    # Hash
+    completer_test(o).call('{"a" => "b"}.keys')
+    
+    # Proc
+    completer_test(o).call('{2}.call')
+
+    # Symbol
+    completer_test(o).call(':symbol.to_s')
+
+    # Absolute Constant
+    completer_test(o).call('::IndexError')
+  end
+
+  it 'should complete for target symbols' do
+    o = Object.new
+
+    # Constant
+    module Mod
+      Con = 'Constant'
+      module Mod2
+      end
+    end
+
+    completer_test(Mod).call('Con')
+
+    # Constants or Class Methods
+    completer_test(o).call('Mod::Con')
+
+    # Symbol
+    foo = :symbol
+    completer_test(o).call(':symbol')
+
+    # Variables
+    class << o
+      attr_accessor :foo
+    end
+    o.foo = 'bar'
+    completer_test(binding).call('o.foo')
+
+    # trailing slash
+    new_completer(Mod).call('Mod2/').include?('Mod2/').should   == true
+
+  end
+
+  it 'should complete for arbitrary scopes' do
+    module Bar
+      @barvar = :bar
+    end
+
+    module Baz
+      @bar = Bar
+      @bazvar = :baz
+      Con = :constant
+    end
+
+    pry = Pry.new()
+    stack = pry.binding_stack
+    stack.push(Pry.binding_for(Baz))
+    stack.push(Pry.binding_for(Bar))
+
+    b = Pry.binding_for(Bar)
+    completer_test(b, pry).call("../@bazvar")
+    completer_test(b, pry).call('/Con')
+  end
+
 end
 


### PR DESCRIPTION
This should fix the rbx and mri 1.8.7 issues. 

It turns out that the way that we were handling constants in the complete check was a little bit naive. There's now a check to see if the contexts responds to constants, and if not we get the binding's class. I'm honestly a little surprised that this worked in mri 1.9.2. 

As always, this was a team effort and as such @ingrid deserves half of the credit and the blame. 
