### PR TITLE
Adds the ability to customize the name displayed in the prompt

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -61,14 +61,16 @@ class Pry
   # Don't catch these exceptions
   DEFAULT_EXCEPTION_WHITELIST = [SystemExit, SignalException]
 
+  DEFAULT_PROMPT_NAME = 'pry'
+
   # The default prompt; includes the target and nesting level
   DEFAULT_PROMPT = [
                     proc { |target_self, nest_level, pry|
-                      "[#{pry.input_array.size}] pry(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}> "
+                      "[#{pry.input_array.size}] #{Pry.config.prompt_name}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}> "
                     },
 
                     proc { |target_self, nest_level, pry|
-                      "[#{pry.input_array.size}] pry(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}* "
+                      "[#{pry.input_array.size}] #{Pry.config.prompt_name}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}* "
                     }
                    ]
 
@@ -76,8 +78,8 @@ class Pry
   SIMPLE_PROMPT = [proc { ">> " }, proc { " | " }]
 
   SHELL_PROMPT = [
-                  proc { |target_self, _, _| "pry #{Pry.view_clip(target_self)}:#{Dir.pwd} $ " },
-                  proc { |target_self, _, _| "pry #{Pry.view_clip(target_self)}:#{Dir.pwd} * " }
+                  proc { |target_self, _, _| "#{Pry.config.prompt_name} #{Pry.view_clip(target_self)}:#{Dir.pwd} $ " },
+                  proc { |target_self, _, _| "#{Pry.config.prompt_name} #{Pry.view_clip(target_self)}:#{Dir.pwd} * " }
                  ]
 
   # A prompt that includes the full object path as well as
@@ -85,11 +87,11 @@ class Pry
   NAV_PROMPT = [
                 proc do |conf|
                   tree = conf.binding_stack.map { |b| Pry.view_clip(b.eval("self")) }.join " / "
-                  "[#{conf.expr_number}] (pry) #{tree}: #{conf.nesting_level}> "
+                  "[#{conf.expr_number}] (#{Pry.config.prompt_name}) #{tree}: #{conf.nesting_level}> "
                 end,
                 proc do |conf|
                   tree = conf.binding_stack.map { |b| Pry.view_clip(b.eval("self")) }.join " / "
-                  "[#{conf.expr_number}] (pry) #{tree}: #{conf.nesting_level}* "
+                  "[#{conf.expr_number}] (#{ Pry.config.prompt_name}) #{tree}: #{conf.nesting_level}* "
                 end,
                ]
 

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -112,6 +112,14 @@ class Pry
     #   Pry.config.prompt = proc { |obj, nest_level, _pry_| "#{obj}:#{nest_level}> " }
     attr_accessor :prompt
 
+    # The display name that is part of the prompt.  Default is 'pry'. 
+    # You can set your own name so you can identify which project your current pry session
+    # is using.  This is useful if you have a local pryrc file in a Rails project for example.
+    # @return [String]
+    # @example 
+    #   Pry.config.prompt_name = 'my_rails_project'
+    attr_accessor :prompt_name
+    
     # The default editor to use. Defaults to $VISUAL, $EDITOR, or a sensible fallback
     # for the platform.
     # If `editor` is a String then that string is used as the shell

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -244,6 +244,7 @@ class Pry
     config.input = Readline
     config.output = $stdout
     config.commands = Pry::Commands
+    config.prompt_name = DEFAULT_PROMPT_NAME
     config.prompt = DEFAULT_PROMPT
     config.print = DEFAULT_PRINT
     config.exception_handler = DEFAULT_EXCEPTION_HANDLER


### PR DESCRIPTION
I have multiple rails / ruby projects that I work on at a given time and I sometimes get confused which pry session I am in when I come back to my terminals.  So I added the ability to configure the prompt name in a local .pryrc file per project
