### PR TITLE
do not propagate nils from completion_proc

### DIFF
--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -599,7 +599,8 @@ class Pry
 
       if defined? Coolline and input.is_a? Coolline
         input.completion_proc = proc do |cool|
-          completion_proc.call cool.completed_word
+          completions = completion_proc.call cool.completed_word
+          completions.compact
         end
       elsif input.respond_to? :completion_proc=
         input.completion_proc = completion_proc


### PR DESCRIPTION
Fix issue #656

The default completion_proc will generate an array which might contain nils,
and Coolline is not able to handle them gracefully.

Tests are green and completion goes back to normal with pry-coolline.
