### PR TITLE
Pry <#.*> coloring falls apart when it has multiple lines

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -32,7 +32,7 @@ class Pry
     colorized = Helpers::BaseHelpers.colorize_code(stringified.gsub(/#</, "%<#{nonce}"))
 
     # avoid colour-leak from CodeRay and any of the users' previous output
-    colorized = colorized.sub(/(\n*)$/, "\e[0m\\1") if Pry.color
+    colorized = colorized.sub(/(\n*)\z/, "\e[0m\\1") if Pry.color
 
     Helpers::BaseHelpers.stagger_output("=> #{colorized.gsub(/%<(.*?)#{nonce}/, '#<\1')}", output)
   end


### PR DESCRIPTION
Take e.g this return value, made of an Array containing Rule instances:

```
=> [#<Rule:0x00000101d04650
  @chain_id=1,
  @filter_argument="tablet",
  @filter_method="client_class",
  @id=1,
  @order=1,
  @target="DROP">,
 #<Rule:0x00000101d03fe8
  @chain_id=2,
  @filter_argument="tablet",
  @filter_method="client_class",
  @id=2,
  @order=1,
  @target="DROP">,
 #<Rule:0x00000101d037a0
  @chain_id=2,
  @filter_argument=42,
  @filter_method="current_user",
  @id=3,
  @order=2,
  @resource_id=21,
  @target="ACCEPT">]
```

Pry will fail at coloring it consistently: the second and third objects will be colored in green, with `<#` and `>` delimiters in yellow, while the first object will have only its first line colored green, and the remainder with the default color. A single (and hence first) object outside an Array will show this behavior too, but this is less noticeable since it does not look so inconsistent.

The cause lies in this code in `lib/pry.rb`:

``` ruby
# avoid colour-leak from CodeRay and any of the users' previous output
colorized = colorized.sub(/(\n*)$/, "\e[0m\\1") if Pry.color
```

As `$` matches the first end of line, this clears the color after the first _newline_. One should instead use `\Z` to match end of string, as such:

``` ruby
colorized = colorized.sub(/(\n*)\Z/, "\e[0m\\1") if Pry.color
```

The colored output is then correct.
