### PR TITLE
Pry hack API love

### DIFF
--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -303,6 +303,8 @@ class Pry
         output.puts "Error: #{e.message}"
       end
 
+      exec_hook :before_syntax_check, eval_string, self
+
       begin
         break if Pry::Code.complete_expression?(eval_string)
       rescue SyntaxError => e


### PR DESCRIPTION
Added a hook to allow access to the string retrieved from the user before it is parsed for valid ruby. This allows pry-syntax to work without monkey patching retrieve_line, but it also opens a new world of possibilities for other plugins as well.
