### PR TITLE
fallback to old ls display on different rubies

### DIFF
--- a/lib/pry/commands/ls.rb
+++ b/lib/pry/commands/ls.rb
@@ -293,6 +293,8 @@ class Pry
 
     def tablify things
       things = things.compact
+      return things.join(Pry.config.ls.separator) if TerminalInfo.screen_size.nil?
+
       screen_width = TerminalInfo.screen_size[1]
       maximum_width = things.map{|t| Pry::Helpers::Text.strip_color(t).length}.max + Pry.config.ls.separator.length
       columns = screen_width / maximum_width


### PR DESCRIPTION
on some rubies we can't get the terminal size yet, so just use the old
way of displaying items in an ls

This fixes the 1.8.7 breakages introduced from #766
