### PR TITLE
Make pryrc load errors more useful.

### DIFF
--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -70,6 +70,7 @@ class Pry
       toplevel_binding.eval(File.read(full_name), full_name) if File.exists?(full_name)
     rescue RescuableException => e
       puts "Error loading #{file_name}: #{e}"
+      puts e.backtrace.first
     end
   end
 


### PR DESCRIPTION
As it stands pryrc leaves you clueless about where an error happens, this small changes makes it so that .load_file_at_toplevel at least returns e.backtrace.first so that users get hinted at the file causing the issue.  This is extremely useful when doing requires from inside of pryrc.
