### PR TITLE
Fix calls to Tempfile.new (GH issue #792)

### DIFF
--- a/spec/commands/cat_spec.rb
+++ b/spec/commands/cat_spec.rb
@@ -143,7 +143,7 @@ describe "cat" do
     it 'each successive cat --ex should show the next level of backtrace, and going past the final level should return to the first' do
       temp_files = []
       3.times do |i|
-        temp_files << Tempfile.new(['pry', '*.rb'])
+        temp_files << Tempfile.new(['pry', '.rb'])
         temp_files.last << "bt number #{i}"
         temp_files.last.flush
       end

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -321,7 +321,7 @@ describe "edit" do
   describe "old edit-method tests now migrated to edit" do
     describe "on a method defined in a file" do
       before do
-        @tempfile = (Tempfile.new(['pry', '*.rb']))
+        @tempfile = (Tempfile.new(['pry', '.rb']))
         @tempfile.puts <<-EOS
         module A
           def a


### PR DESCRIPTION
Suffix of "_.rb" caused temp files to be named with "_.rb" at the end, literally.  Not all file systems like that, and it's almost certainly not what was intended.
