### PR TITLE
correct_indentation ignores readline \001 & \002 sequences

### DIFF
--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -389,6 +389,7 @@ class Pry
     #   the difference in length between the old line and the new one).
     # @return [String]
     def correct_indentation(prompt, code, overhang=0)
+      prompt = prompt.delete("\001\002")
       full_line = prompt + code
       whitespace = ' ' * overhang
 


### PR DESCRIPTION
Refs #822
