### PR TITLE
Don't use self-deprecated method

### DIFF
--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -227,9 +227,9 @@ class Pry
 
     output = options[:show_output] ? options[:output] : StringIO.new
 
-    Pry.new(:output => output, :input => StringIO.new("#{command_string}\nexit-all\n"),
+    Pry::REPL.new(Pry.new(:output => output, :input => StringIO.new("#{command_string}\nexit-all\n"),
             :commands => options[:commands],
-            :prompt => proc {""}, :hooks => Pry::Hooks.new).repl(options[:context])
+            :prompt => proc {""}, :hooks => Pry::Hooks.new), :target => options[:context]).start
   end
 
   def self.default_editor_for_platform


### PR DESCRIPTION
Master pry currently complains on run_command because Pry#repl isn't supposed to be used anymore.  This makes run_command stop using that.

I don't know if it's 100% right to do it this way, thoughts?
