### PR TITLE
Escape method definition names before using in regexp

### DIFF
--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -179,11 +179,11 @@ class Pry
       end
 
       def singleton_method_definition?(name, definition_line)
-        /^define_singleton_method\(?\s*[:\"\']#{name}|^def\s*self\.#{name}/ =~ definition_line.strip
+        /^define_singleton_method\(?\s*[:\"\']#{Regexp.escape(name)}|^def\s*self\.#{Regexp.escape(name)}/ =~ definition_line.strip
       end
 
       def instance_method_definition?(name, definition_line)
-        /^define_method\(?\s*[:\"\']#{name}|^def\s*#{name}/ =~ definition_line.strip
+        /^define_method\(?\s*[:\"\']#{Regexp.escape(name)}|^def\s*#{Regexp.escape(name)}/ =~ definition_line.strip
       end
 
       private


### PR DESCRIPTION
I had aliased and monkey patched a [] and was using pry-nav to step through it. When it hit the call() to the aliased parent method, singleton_method_definition choked. 

This pull request wraps the method name inside of Regexp.escape() before using it in the regular expressions. 

```
...earlier in the code...
alias :parent_square :[] 
...later on inside pry...
    53:
    54:   if doit.strip == 'y'
 => 55:     send(:parent_square,args)
    56:   else
    57:     puts "Didn't run it"
    58:   end
    59: end

[1] pry(#<Sequel::Postgres::Database>)> step

Frame number: 0/5
before_session hook failed: RegexpError: empty char-class:   /^define_singleton_method\(?\s*[:\"\'][]|^def\s*self\.[]/
/usr/local/rvm/gems/ruby-1.9.3-p286@mapfeeder-fulcrum-sync-michael/gems/pry-0.9.12/lib/pry/method.rb:183:in `singleton_method_definition?'
(see _pry_.hooks.errors to debug)
```
