### PR TITLE
Support customizing the location of ~/.pryrc

### DIFF
--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -5,7 +5,7 @@ require 'pry/config'
 class Pry
 
   # The RC Files to load.
-  HOME_RC_FILE = "~/.pryrc"
+  HOME_RC_FILE = ENV["PRYRC"] || "~/.pryrc"
   LOCAL_RC_FILE = "./.pryrc"
 
   # @return [Hash] Pry's `Thread.current` hash


### PR DESCRIPTION
In Linux, there is a group that advocates less dotfiles in `$HOME` directly, instead moving all of those files into a dedicated `$HOME/.config` directory. This is the [XDG Base Directory Specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).

You don't have to go full-support of XDG, but I think changing [line 8 of `lib/pry/pry_class.rb`](https://github.com/pry/pry/blob/master/lib/pry/pry_class.rb#L8) to something along

``` ruby
HOME_RC_FILE = ENV["PRYRC"] || "~/.pryrc"
```

Would be nice.
