### PR TITLE
  Fix issue with Puppet

### DIFF
--- a/lib/pry/commands/ls.rb
+++ b/lib/pry/commands/ls.rb
@@ -267,7 +267,7 @@ class Pry
     end
 
     def format_variables(type, vars)
-      vars.sort_by(&:downcase).map{ |var| color(type, var) }
+      vars.sort_by{ |var| var.to_s.downcase }.map{ |var| color(type, var) }
     end
 
     def format_constants(mod, constants)

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -60,6 +60,24 @@ describe "ls" do
       pry_eval("ls Net::HTTP::Get.new('localhost')").should =~ /Net::HTTPGenericRequest#methods/
     end
 
+    it "should work for objects which instance_variables returns array of symbol but there is no Symbol#downcase" do
+      test_case = "class Object; alias :fg :instance_variables; def instance_variables; fg.map(&:to_sym); end end;"
+      normalize = "class Object; def instance_variables; fg; end end;"
+
+      test = lambda do
+        begin
+          pry_eval(test_case, "class GeFromulate2; @flurb=1.3; end", "cd GeFromulate2", "ls")
+          pry_eval(normalize)
+        rescue
+          pry_eval(normalize)
+          raise
+        end
+      end
+
+      test.should.not.raise
+    end
+
+
     # see: https://travis-ci.org/pry/pry/jobs/5071918
     unless Pry::Helpers::BaseHelpers.rbx?
       it "should handle classes that (pathologically) define .ancestors" do


### PR DESCRIPTION
Puppet gem (under `Ruby 1.8`) overrides `Object#instance_variables` method.
It returns `Array` of `Symbol` rather than `Array` of `String`.
There is no `Symbol#downcase` under `Ruby 1.8`.

All of this reasons cause `NameError` when `ls` is invoked.

https://github.com/puppetlabs/puppet/blob/master/lib/puppet/util/monkey_patches.rb#L278
