### PR TITLE
Momentary deprecation pause: needs stable release

### DIFF
--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -370,6 +370,7 @@ class Pry
 
   # @deprecated Use `Pry::REPL.new(pry, :target => target).start` instead.
   def repl(target = nil)
+=begin
     @@repl_warning ||= (warn Pry::Helpers::CommandHelpers.unindent(<<-S); true)
       DEPRECATION: Pry#repl is deprecated. Instead, use
 
@@ -381,6 +382,7 @@ class Pry
       Call stack:
         #{caller.join("\n" + (' ' * 8))}
     S
+=end
     Pry::REPL.new(self, :target => target).start
   end
 


### PR DESCRIPTION
This is causing:

http://showterm.io/550cffe02c59d4b22cce6

And I don't want pry-debugger to have to hack itself to support both APIs in transition.

Especially not since we can't get a consistent `gem push` for pry-debugger.
