### PR TITLE
Restore correct description of gist command

### DIFF
--- a/lib/pry/commands/gist.rb
+++ b/lib/pry/commands/gist.rb
@@ -2,7 +2,7 @@ class Pry
   class Command::Gist < Pry::ClassCommand
     match 'gist'
     group 'Misc'
-    description 'Playback a string variable or a method or a file as input.'
+    description 'Upload code, docs, history to https://gist.github.com/.'
     command_options :requires_gem => "jist"
 
     banner <<-'BANNER'


### PR DESCRIPTION
Hi Pry developers,

I noticed while looking at the Pry help that the gist command seemed to have the same description as the playback command:
[1] pry(main)> help
...
  play               Playback a string variable or a method or a file as input.
...
  gist               Playback a string variable or a method or a file as input.

I tracked that down to https://github.com/amonat/pry/commit/b6b78157a5b502a2eaa0b997e98184dc0547895b, which re-implemented gist and seems to have accidentally included copying and pasting the description of the play command.

I restored the old description, and took the liberty of adding a period at the end, to match (most of) the other descriptions.

Thanks!
