### PR TITLE
Fix source lookup for instrumented classes

### DIFF
--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -302,11 +302,15 @@ class Pry
 
     # @return [Pry::WrappedModule::Candidate] The candidate with the
     #   highest rank, that is the 'monkey patch' of this module with the
-    #   highest number of methods, which actually contains a source code
-    #   line that declaes the module. It is considered the 'canonical'
-    #   definition for the module.
+    #   highest number of methods, which contains a source code line that
+    #   defines the module. It is considered the 'canonical' definition
+    #   for the module. In the absense of a suitable candidate, the
+    #   candidate of rank 0 will be returned, or a CommandError raised if
+    #   there are no candidates at all.
     def primary_candidate
-      @primary_candidate ||= candidates.find { |c| c.file }
+      @primary_candidate ||= candidates.find { |c| c.file } ||
+        # This will raise an exception if there is no candidate at all.
+        candidate(0)
     end
 
     # @return [Array<Array<Pry::Method>>] The array of `Pry::Method` objects,


### PR DESCRIPTION
Once I include DataMapper::Resource, which defines a lot of
additional methods in dm-core/support/hook.rb, the "popularity"
of my own source file ranks lower than first, so candidate(0)
returns the DataMapper source file.  However, none of the REs
returned by Pry::WrappedModule::Candidate#class_regexes
matches because my class is obviously not defined there.

This fixes the problem by re-defining #primary_candidate so that
it filters out obviously invalid candidates.
