### PR TITLE
Altered play command message as seen in 'help'

### DIFF
--- a/lib/pry/commands/play.rb
+++ b/lib/pry/commands/play.rb
@@ -2,7 +2,7 @@ class Pry
   class Command::Play < Pry::ClassCommand
     match 'play'
     group 'Editing'
-    description 'Playback a string variable or a method or a file as input.'
+    description 'Playback a string variable, method, line, or file as input.'
 
     banner <<-'BANNER'
       Usage: play [OPTIONS] [--help]


### PR DESCRIPTION
Thanks for all the work that everyone has put into making Pry such a great tool!!!

When reading the 'help' section during pair programming today, the 'play' method wasn't clear to me.

The `help play` gives a very clear explanation but I wouldn't have found that based on the short explanation given by `help`.

So, this tweak is a rough first stab at altering the message and helping others benefit from this awesome utility :)

PS - At the very least this PR can constitute a reminder that I'd like to revise the message to be more revealing :smile: . 
