### PR TITLE
Add recursive reload flag to reload_code.

### DIFF
--- a/spec/commands/reload_code_spec.rb
+++ b/spec/commands/reload_code_spec.rb
@@ -1,46 +1,69 @@
 require 'helper'
 
-describe "reload-code" do
-  before do
-    @o = Object.new
-    @t = pry_tester(@o)
-    @tmp_dir ||= Pathname.new(Dir.mktmpdir).realpath
-  end
+unless Pry::Helpers::BaseHelpers.mri_18?
+  describe "reload-code" do
 
-  it "should reload the source of descendants and self" do
-    file_path = File.join(@tmp_dir, "my_module.rb")
-
-    File.open(file_path,"w") do |f|
-      f.puts <<-MODEL
-      class Parent
-        class Child
-          class Grandchild
-            attr_accessor :not_foo
-          end
-        end
-      end
-      MODEL
+    before do
+      @o = Object.new
+      @t = pry_tester(@o)
     end
 
-    @t.eval "require '#{file_path}'"
-
-    File.open(file_path,"w") do |f|
-      f.puts <<-MODEL
-      class Parent
-        attr_reader :cannot_be_without_method
-        class Child
-          class Grandchild
-            attr_accessor :foo
+    it "should reload the source of descendants and self" do
+      Dir.mktmpdir do |dir|
+        tmp_file = Pathname.new(dir).realpath.join("my_module.rb")
+        File.open(tmp_file,"w") do |f|
+          f.puts <<-MODEL
+          class Parent
+            attr_accessor :method_must_exist_to_lookup
+            module Child
+              class Grandchild
+                attr_accessor :not_foo
+              end
+            end
           end
+          MODEL
         end
+
+        @t.eval "require '#{tmp_file}'"
+
+        File.open(tmp_file,"w") do |f|
+          f.puts <<-MODEL
+          class Parent
+            attr_accessor :method_must_exist_to_lookup
+            module Child
+              class Grandchild
+                attr_accessor :foo
+              end
+            end
+          end
+          MODEL
+        end
+
+        @t.eval("Parent::Child::Grandchild.new.respond_to?(:foo)").should == false
+        @t.process_command 'reload-code -r Parent'
+        @t.eval("Parent::Child::Grandchild.new.respond_to?(:foo)").should == true
       end
-      MODEL
     end
 
-    @t.eval("Parent::Child::Grandchild.new.respond_to?(:foo)").should == false
-    @t.process_command 'reload-code -r Parent'
-    @t.eval("Parent::Child::Grandchild.new.respond_to?(:foo)").should == false
+    it "not recurse infinitely when given a circular reference" do
+      Dir.mktmpdir do |dir|
+        tmp_file = Pathname.new(dir).realpath.join("my_module.rb")
+        File.open(tmp_file,"w") do |f|
+          f.puts <<-MODEL
+          module Fred
+            attr_accessor :method_must_exist_to_lookup
+            module Daphne
+              attr_accessor :method_must_exist_to_lookup
+              Scooby = ::Fred
+            end
+          end
+          MODEL
+        end
+
+        @t.eval "require '#{tmp_file}'"
+        @t.process_command 'reload-code -r Fred'
+        true.should == true
+      end
+    end
   end
 end
-
-


### PR DESCRIPTION
The core of this patch is a method that recursively searches through and
creates Pry::CodeObject(s) for each. Then passes each CodeObject through
the existing reload_code functionality.

In reference to issue #895
