### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-[![Build Status](https://secure.travis-ci.org/pry/pry.png)](http://travis-ci.org/pry/pry)
+[![Build Status](https://secure.travis-ci.org/pry/pry.png)](http://travis-ci.org/pry/pry) [![Code Climate](https://codeclimate.com/github/pry/pry.png)](https://codeclimate.com/github/pry/pry)
 
 <center>
 ![The Pry Logo](https://dl.dropbox.com/u/26521875/pry%20stuff/logo/pry_logo_350.png)


### PR DESCRIPTION
Hello,

It looks like someone (maybe you) added Pry to Code Climate a little while back, and I thought you might want to know.

Code Climate is a tool I helped to build that does automated code reviews for Ruby using static analysis. It's free for OSS, and your metrics live here:

https://codeclimate.com/github/pry/pry

We use Pry pretty extensively here at Code Climate, so thank you. We don't always need it, but when we do, it sure does come in handy.

This PR just adds a dynamic badge to the README (similar to Travis) that displays the code quality GPA, in case you want this information to be available to contributors.

If you have any questions, let me know.

I hope you find Code Climate useful.

Cheers,

Noah
