### PR TITLE
Show same show-doc results for ::Klass and Klass

### DIFF
--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -17,7 +17,7 @@ class Pry
     end
 
     def process
-      code_object = Pry::CodeObject.lookup(obj_name, _pry_, :super => opts[:super])
+      code_object = Pry::CodeObject.lookup(obj_name.to_s.gsub(/^::/, ''), _pry_, :super => opts[:super])
       raise CommandError, no_definition_message if !code_object
       @original_code_object = code_object
 

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -295,6 +295,11 @@ if !PryTestHelpers.mri18_and_no_real_source_location?
         end
       end
 
+      it 'should search the YARD registry for Klass when ::Klass is entered' do
+        lambda { pry_tester.process_command "show-doc ::Array" }.should.raise(Pry::CommandError).
+          message.should =~ /Cannot locate this method: Array/
+      end
+
       describe "show-doc -a" do
         it 'should show the docs for all monkeypatches defined in different files' do
           # local monkeypatch


### PR DESCRIPTION
Fixes issue #960. `show-doc ::Array` wasn't showing the same results as `show-doc Array` because of how top-level constants are keyed in the YARD registry. 

This takes care of showing the correct results for `show-doc ::Klass`, unless anyone can think of any case where we wouldn't want the same results for `show-doc ::Klass` and `show-doc Klass`?
