### PR TITLE
Show method docs for Foo() and class docs for Foo

### DIFF
--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -119,10 +119,10 @@ class Pry
       return nil if str.to_s.empty?
 
       obj = case str
-            when /::(?:\S+)\Z/
-              Pry::WrappedModule.from_str(str,target) || Pry::Method.from_str(str, target)
+            when /\S+\(\)\z/
+              Pry::Method.from_str(str.sub(/\(\)\z/, ''),target) || Pry::WrappedModule.from_str(str, target)
             else
-              Pry::Method.from_str(str,target) || Pry::WrappedModule.from_str(str, target)
+              Pry::WrappedModule.from_str(str,target) || Pry::Method.from_str(str, target)
             end
 
       lookup_super(obj, super_level)

--- a/spec/code_object_spec.rb
+++ b/spec/code_object_spec.rb
@@ -244,8 +244,14 @@ describe Pry::CodeObject do
       Object.remove_method(:ClassyWassy)
     end
 
-    it 'should look up methods before classes (at top-level)' do
+    it 'should look up classes before methods (at top-level)' do
       m = Pry::CodeObject.lookup("ClassyWassy", @p)
+      m.is_a?(Pry::WrappedModule).should == true
+      m.source.should =~ /piggy/
+    end
+
+    it 'should look up methods before classes when ending in () (at top-level)' do
+      m = Pry::CodeObject.lookup("ClassyWassy()", @p)
       m.is_a?(Pry::Method).should == true
       m.source.should =~ /ducky/
     end


### PR DESCRIPTION
Resolves #960 such that when a top-level class and method exist with the same name,  `show-doc Foo()` returns the method docs and `show-doc Foo` returns the class docs.
