### PR TITLE
Fix issue 962

### DIFF
--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -424,7 +424,7 @@ class Pry
 
     begin
       if !process_command(val, eval_string, target)
-        eval_string << "#{indented_val.chomp}\n" unless val.empty?
+        eval_string << "#{indented_val.chomp}\n" unless val.empty? && eval_string.empty?
       end
     ensure
       Pry.history << indented_val if interactive

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -208,6 +208,17 @@ describe Pry do
 
           o.instance_variable_get(:@x).should == 10
         end
+
+        it 'should preserve newlines correctly with multi-line input' do
+          input_strings = ['@s = <<-END', '1', '', '', '2', 'END']
+          input = InputTester.new(*input_strings)
+
+          o = Object.new
+
+          pry_tester = Pry.start(o, :input => input, :output => StringIO.new)
+
+          o.instance_variable_get(:@s).should == "1\n\n\n2\n"
+        end
       end
 
       describe "complete_expression?" do


### PR DESCRIPTION
Fixes issue #962 by preserving the correct number of newlines when evaluating multi-line input.

ACHIEVEMENT UNLOCKED: FIRST PULL REQUEST SUBMITTED WHILE HURTLING THROUGH THE AIR

:sparkles: :airplane: :sparkles: 
