### PR TITLE
Fix ruby 2.1 string issue.

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -51,7 +51,7 @@ class Pry
     colorized = colorized.sub(/(\n*)\z/, "\e[0m\\1") if Pry.color
 
     result = colorized.gsub(/%<(.*?)#{nonce}/, '#<\1')
-    result = "=> #{result}"if options[:hashrocket]
+    result = "=> #{result}" if options[:hashrocket]
     Helpers::BaseHelpers.stagger_output(result, output)
   end
 


### PR DESCRIPTION
You can't have expressions right on the tail of a string anymore because of string suffixes: https://bugs.ruby-lang.org/issues/8579
