### PR TITLE
Add Watch Command

### DIFF
--- a/lib/pry/commands/watch_expression.rb
+++ b/lib/pry/commands/watch_expression.rb
@@ -1,0 +1,97 @@
+class Pry
+  class Command::WatchExpression < Pry::ClassCommand
+    require 'pry/commands/watch_expression/expression.rb'
+    extend Pry::Helpers::BaseHelpers
+
+    match 'watch'
+    group 'Context'
+    description 'Evaluate an expression after every command and display it when its value changes.'
+    command_options :use_prefix => false
+
+    banner <<-'BANNER'
+      Usage: watch [EXPRESSION]
+             watch
+             watch --delete [INDEX]
+
+      Evaluate an expression after every command and display it when its value changes.
+    BANNER
+
+    def options(opt)
+      opt.on :d, :delete,
+        "Delete the watch expression with the given index. If no index is given; clear all watch expressions.",
+        :optional_argument => true, :as => Integer
+      opt.on :l, :list,
+        "Show all current watch expressions and their values.  Calling watch with no expressions or options will also show the watch expressions."
+    end
+
+    def process
+      ret = case
+            when opts.present?(:delete)
+              delete opts[:delete]
+            when opts.present?(:list) || args.empty?
+              list
+            else
+              add_hook
+              add_expression(args)
+            end
+    end
+
+    private
+
+    def expressions
+       state.expressions ||= []
+       state.expressions
+    end
+
+    def delete(index)
+      if index
+        output.puts "Deleting watch expression ##{index}: #{expressions[index-1]}"
+        expressions.delete_at(index-1)
+      else
+        output.puts "Deleting all watched expressions"
+        expressions.clear
+      end
+    end
+
+    def list
+      if expressions.empty?
+        output.puts "No watched expressions"
+      else
+        Pry::Pager.with_pager(output) do |pager|
+          pager.puts "Listing all watched expressions:"
+          pager.puts ""
+          expressions.each_with_index do |expr, index|
+            pager.print text.with_line_numbers(expr.to_s, index+1)
+          end
+          pager.puts ""
+        end
+      end
+    end
+
+    def eval_and_print_changed
+      expressions.each do |expr|
+        expr.eval!
+        if expr.changed?
+          output.puts "#{text.blue "watch"}: #{expr.to_s}"
+        end
+      end
+    end
+
+    def add_expression(arguments)
+      e = expressions
+      e << Expression.new(target, arg_string)
+      output.puts "Watching #{Code.new(arg_string)}"
+    end
+
+    def add_hook
+      hook = [:after_eval, :watch_expression]
+      unless Pry.config.hooks.hook_exists? *hook
+        _pry_.hooks.add_hook(*hook) do
+          eval_and_print_changed
+        end
+      end
+    end
+  end
+
+  Pry::Commands.add_command(Pry::Command::WatchExpression)
+end

--- a/lib/pry/commands/watch_expression/expression.rb
+++ b/lib/pry/commands/watch_expression/expression.rb
@@ -1,0 +1,41 @@
+class Pry
+  class Command::WatchExpression
+    class Expression
+      attr_reader :target, :source, :value, :previous_value
+
+      def initialize(target, source)
+        @target = target
+        @source = source
+      end
+
+      def eval!
+        @previous_value = value
+        @value = target_eval(target, source)
+      end
+
+      def to_s
+        "#{print_source} => #{print_value}"
+      end
+
+      def changed?
+        (value != previous_value)
+      end
+
+      def print_value
+        Pry::ColorPrinter.pp(value, "")
+      end
+
+      def print_source
+        Code.new(source).strip
+      end
+
+      private
+
+      def target_eval(target, source)
+        target.eval(source)
+      rescue => e
+        e
+      end
+    end
+  end
+end

--- a/spec/commands/watch_expression_spec.rb
+++ b/spec/commands/watch_expression_spec.rb
@@ -1,0 +1,61 @@
+require 'helper'
+
+describe "watch expression" do
+
+  # Custom eval that will:
+  # 1) Create an instance of pry that can use for multiple calls
+  # 2) Exercise the after_eval hook
+  # 3) Return the output
+  def eval(expr)
+    output = @tester.eval expr
+    @tester.pry.hooks.exec_hook :after_eval
+    output
+  end
+
+  before do
+    @tester = pry_tester
+    @tester.pry.hooks.clear :after_eval
+    eval "watch --delete"
+  end
+
+  it "registers the before_session hook" do
+    eval 'watch 1+1'
+    @tester.pry.hooks.hook_exists?(:after_eval, :watch_expression).should == true
+  end
+
+  it "prints no watched expressions" do
+    eval('watch').should =~ /No watched expressions/
+  end
+
+  it "watches an expression" do
+    eval "watch 1+1"
+    eval('watch').should =~ /=> 2/
+  end
+
+  it "watches a local variable" do
+    eval 'foo = :bar'
+    eval 'watch foo'
+    eval('watch').should =~ /=> :bar/
+  end
+
+  #it "prints only when an expression changes" do
+  #  # TODO: This is one of the main features, but I am not sure how to test the
+  #  # output from a hook.
+  #end
+
+  describe "deleting expressions" do
+    before do
+      eval 'watch :keeper'
+      eval 'watch :delete'
+      eval 'watch -d 2'
+    end
+
+    it "keeps keeper" do
+      eval('watch').should =~ /keeper/
+    end
+
+    it "deletes delete" do
+      eval('watch').should.not =~ /delete/
+    end
+  end
+end


### PR DESCRIPTION
@ConradIrwin mentioned that having a `watch` command that will evaluate an expression on every command. This sounded amazingly useful to me, so I figured I would take a swing at implementing it. But first I thought I might see if anyone had any feedback.

What about something like this:

```
[1] pry(main)> watch capt_mal
  watch:
    capt_mal #=> "Tight Pants"

[2] pry(main)> capt_mal = "Pretty floral bonnet"
  watch:
    capt_mal #=> "Pretty floral bonnet"
=> "Pretty floral bonnet"
```

The help banner might be like this:

```
Usage:   watch [EXPRESSION]
         watch --delete
         watch --delete [N]
         watch --list

Evaluate and display an expression after every command.

    -d, --delete           Delete the watch expression at given index. If no
                           index is given will clear all watch expressions.
    -l, --list             Show the list of the current watch expressions

```

This is just a suggestion if something isn't idiomatic for pry let me know. Or say something if you'd prefer things to work differently.
