### PR TITLE
  adds HistoryArray#to_h and spec

### DIFF
--- a/lib/pry/history_array.rb
+++ b/lib/pry/history_array.rb
@@ -89,6 +89,11 @@ class Pry
       ((@count - size)...@count).map { |n| @hash[n] }
     end
 
+    # Returns [Hash] copy of the internal @hash history
+    def to_h
+      Marshal.load( Marshal.dump(@hash) )
+    end
+
     def pop!
       @hash.delete @count - 1
       @count -= 1

--- a/spec/history_array_spec.rb
+++ b/spec/history_array_spec.rb
@@ -64,4 +64,8 @@ describe Pry::HistoryArray do
     @populated.pop!
     @populated.to_a.should == [1, 2, 3]
   end
+
+  it 'should return an indexed hash' do
+    @populated.to_h[0].should == @populated[0]
+  end
 end


### PR DESCRIPTION
I was looking at the output of _out_.to_a because I wanted a specific item, but it was hard to determine how to get at that particular return via _out_[]. Turns out all I had to do was expose the internal @hash being used. Simply returning the object reads nicer, but I made it deep copy because that seemed like proper form. Also added a spec for coverage; can certainly elaborate on that if necessary. 
