### PR TITLE
Remove unecessary eval's from cd_spec

### DIFF
--- a/spec/commands/cd_spec.rb
+++ b/spec/commands/cd_spec.rb
@@ -13,15 +13,15 @@ describe 'cd' do
       end
 
       def binding_stack
-        eval '_pry_.binding_stack.dup'
+        pry.binding_stack.dup
       end
 
       def command_state
-        eval '_pry_.command_state["cd"]'
+        pry.command_state["cd"]
       end
 
       def old_stack
-        eval '_pry_.command_state["cd"].old_stack.dup'
+        pry.command_state['cd'].old_stack.dup
       end
     end
   end


### PR DESCRIPTION
Small tweak to `cd_spec` helper methods that probably do not need to be eval'd. 
