### PR TITLE
lib/pry/pry_class.rb fix initialize bugs of Pry.config and Pry.history

### DIFF
--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -382,8 +382,8 @@ Readline version #{ver} detected - will not auto_resize! correctly.
   # Basic initialization.
   def self.init
     @plugin_manager ||= PluginManager.new
-    self.config ||= Config.new
-    self.history ||= History.new
+    self.config = Config.new unless self.config.instance_of? Config
+    self.history = History.new unless self.history.instance_of? History
 
     reset_defaults
     locate_plugins


### PR DESCRIPTION
In rare cases(issue #978) Pry.config is initialized to unintended Object. To fix this problem, check classes of Pry.config and Pry.history before initialize them.
