### PR TITLE
Update ShellCommand so that `.cd` autocompletes to `.cd ~`

### DIFF
--- a/lib/pry/commands/shell_command.rb
+++ b/lib/pry/commands/shell_command.rb
@@ -16,7 +16,7 @@ class Pry
     BANNER
 
     def process(cmd)
-      if cmd =~ /^cd\s+(.+)/i
+      if cmd =~ /^cd\s*(.*)/i
         process_cd parse_destination($1)
       else
         pass_block(cmd)
@@ -36,6 +36,7 @@ class Pry
     private
 
       def parse_destination(dest)
+        return "~" if dest.empty?
         return dest unless dest == "-"
         state.old_pwd || raise(CommandError, "No prior directory available")
       end

--- a/spec/commands/shell_command_spec.rb
+++ b/spec/commands/shell_command_spec.rb
@@ -31,6 +31,13 @@ describe "Command::ShellCommand" do
         end
       end
 
+      describe "given an empty string" do
+        it "sends ~ to File.expand_path" do
+          Dir.expects(:chdir).with(File.expand_path("~"))
+          @t.eval ".cd "
+        end
+      end
+
       describe "given a dash" do
         describe "given no prior directory" do
           it "raises the correct error" do


### PR DESCRIPTION
The `.cd` command currently does not do anything when given an empty string. This PR changes that so that `.cd` changes the current working directory to the users $HOME or tilde. It's based off of the discussion in #1028.
