### PR TITLE
Remove define of Pry class attributes from lib/pry/pry_class.rb to lib/p...

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -9,6 +9,7 @@ require 'pry/helpers/base_helpers'
 require 'pry/hooks'
 
 require 'securerandom'
+require 'forwardable'
 
 class Pry
 

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -1,5 +1,4 @@
 require 'ostruct'
-require 'forwardable'
 require 'pry/config'
 
 class Pry


### PR DESCRIPTION
...ry.rb . pry/commands and Pry.config have circular-dependency. In rare case (c.f . #978) Pry.config is initialized not properly. We will fix this bug by this commit.
