### PR TITLE
Add print option to play command (resolves #864)

### DIFF
--- a/lib/pry/commands/play.rb
+++ b/lib/pry/commands/play.rb
@@ -32,19 +32,27 @@ class Pry
                     ' modify the method.'
 
       opt.on :e, :expression=, 'Executes until end of valid expression', :as => Integer
+      opt.on :p, :print, 'Prints executed code'
     end
 
     def process
       @cc = CodeCollector.new(args, opts, _pry_)
 
       perform_play
-      run "show-input" unless Pry::Code.complete_expression?(eval_string)
+      show_input
     end
 
     def perform_play
       eval_string << content_after_options
       run "fix-indent"
     end
+
+    def show_input
+      if opts.present?(:print) or !Pry::Code.complete_expression?(eval_string)
+        run "show-input"
+      end
+    end
+
 
     def content_after_options
       if opts.present?(:open)

--- a/spec/commands/play_spec.rb
+++ b/spec/commands/play_spec.rb
@@ -36,6 +36,33 @@ describe "play" do
     end
   end
 
+  describe "playing a file" do
+    it 'should play a file' do
+      @t.process_command 'play spec/fixtures/whereami_helper.rb'
+      @t.eval_string.should == unindent(<<-STR)
+        class Cor
+          def a; end
+          def b; end
+          def c; end
+          def d; end
+        end
+      STR
+    end
+
+
+    it 'should output file contents with print option' do
+      @t.process_command 'play --print spec/fixtures/whereami_helper.rb'
+      @t.last_output.should == unindent(<<-STR)
+        1: class Cor
+        2:   def a; end
+        3:   def b; end
+        4:   def c; end
+        5:   def d; end
+        6: end
+      STR
+    end
+  end
+
   describe "whatever" do
     before do
       def @o.test_method


### PR DESCRIPTION
When print option in play is used, it prints the executed code.
