### PR TITLE
delete '(default)' from pry/commands/ls.rb#options, because option'm' is...

### DIFF
--- a/lib/pry/commands/ls.rb
+++ b/lib/pry/commands/ls.rb
@@ -28,7 +28,7 @@ class Pry
 
 
     def options(opt)
-      opt.on :m, :methods,   "Show public methods defined on the Object (default)"
+      opt.on :m, :methods,   "Show public methods defined on the Object"
       opt.on :M, "instance-methods", "Show methods defined in a Module or Class"
       opt.on :p, :ppp,       "Show public, protected (in yellow) and private (in green) methods"
       opt.on :q, :quiet,     "Show only methods defined on object.singleton_class and object.class"


### PR DESCRIPTION
... not default
