### PR TITLE
Fix color disappear on windows ruby2.0 (#961). Ruby 2.0 on windows suppo...

### DIFF
--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -71,7 +71,11 @@ class Pry
 
       # are we able to use ansi on windows?
       def windows_ansi?
-        defined?(Win32::Console) || ENV['ANSICON']
+        defined?(Win32::Console) || ENV['ANSICON'] || windows? && ruby_version2?
+      end
+
+      def ruby_version2?
+        RUBY_VERSION =~ /^2/
       end
 
       def jruby?


### PR DESCRIPTION
...rts ANSI escape sequences, so change use_ansi_codes? method to not return nil under Ruby 2.0 on windows environment.
