### PR TITLE
Fix alias command do not work with command_prefix. 

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -243,7 +243,7 @@ class Pry
     # @example
     #   run "amend-line",  "5", 'puts "hello world"'
     def run(command_string, *args)
-      command_string = Pry.config.command_prefix.to_s + command_string
+      command_string = _pry_.config.command_prefix.to_s + command_string
       complete_string = "#{command_string} #{args.join(" ")}".rstrip
       command_set.process_line(complete_string, context)
     end

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -8,7 +8,8 @@ describe Pry::CommandSet do
 
     @ctx = {
       :target => binding,
-      :command_set => @set
+      :command_set => @set,
+      :pry_instance => Pry.new
     }
   end
 
@@ -185,17 +186,19 @@ describe Pry::CommandSet do
 
     it "should be able to alias command with command_prefix" do
       run = false
-      @set.command('owl', 'stuff') { run = true }
-      @set.alias_command 'owlet', 'owl'
+      begin
+        @set.command('owl', 'stuff') { run = true }
+        @set.alias_command 'owlet', 'owl'
 
-      Pry.config.command_prefix = '%'
-      @set.commands['owlet'].match.should == 'owlet'
-      @set.commands['owlet'].description.should == 'Alias for `owl`'
+        Pry.config.command_prefix = '%'
+        @set['%owlet'].match.should == 'owlet'
+        @set['%owlet'].description.should == 'Alias for `owl`'
 
-      @set.process_line '%owlet', @ctx
-      run.should == true
-
-      Pry.config.command_prefix = ''
+        @set.run_command @ctx, 'owlet'
+        run.should == true
+      ensure
+        Pry.config.command_prefix = ''
+      end
     end
 
     it 'should inherit options from original command' do


### PR DESCRIPTION
To fix Pry::Command#run to call command_set.process_line with command_prefix arg, in case _pry_.config.command_prefix is set.

I think this is temporary fix.  I feel command class should not have responsibility to check command_prefix. Because command_prefix is user side matter, so remove prefix from args more near CLI (surface).
So someday refactor it ....

This will fix #1055 .
