### PR TITLE
delete require 'rb-readline' from lib/pry.rb . When use gem rb-readline,...

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -193,11 +193,7 @@ require 'tempfile'
 require 'pathname'
 
 begin
-  begin
-    require 'readline'
-  rescue LoadError
-    require 'rb-readline'
-  end
+  require 'readline'
 rescue LoadError
   warn "You're running a version of ruby with no Readline support"
   warn "Please `gem install rb-readline` or recompile ruby --with-readline."


### PR DESCRIPTION
... require 'readline' not 'rb-readline'.
