### PR TITLE
Fix Pry::Command#group does not override group name manually.

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -195,21 +195,23 @@ class Pry
       # This is usually auto-generated from directory naming, but it can be
       # manually overridden if necessary.
       def group(name=nil)
-        @group ||= if name
-                     name
+        @group = if name
+                   name
+                 elsif @group
+                   @group
+                 else
+                   case Pry::Method(block).source_file
+                   when %r{/pry/.*_commands/(.*).rb}
+                     $1.capitalize.gsub(/_/, " ")
+                   when %r{(pry-\w+)-([\d\.]+([\w\d\.]+)?)}
+                     name, version = $1, $2
+                     "#{name.to_s} (v#{version.to_s})"
+                   when /pryrc/
+                     "~/.pryrc"
                    else
-                     case Pry::Method(block).source_file
-                     when %r{/pry/.*_commands/(.*).rb}
-                       $1.capitalize.gsub(/_/, " ")
-                     when %r{(pry-\w+)-([\d\.]+([\w\.]+)?)}
-                       name, version = $1, $2
-                       "#{name.to_s} (v#{version.to_s})"
-                     when /pryrc/
-                       "~/.pryrc"
-                     else
-                       "(other)"
-                     end
+                     "(other)"
                    end
+                 end
       end
     end
 


### PR DESCRIPTION
Pry::Command#group can define group name manually.
But when it is already defined, this method can't override group name.
So I fixed.
