### PR TITLE
Add Pry.config.ansicon . If user want not to load win32console, use this...

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -5,6 +5,7 @@ require 'pp'
 
 require 'pry/input_lock'
 require 'pry/exceptions'
+require 'pry/platform'
 require 'pry/helpers/base_helpers'
 require 'pry/hooks'
 

--- a/lib/pry/commands/easter_eggs.rb
+++ b/lib/pry/commands/easter_eggs.rb
@@ -95,7 +95,7 @@ TEXT
         \____/   \________________________|
       EOS
 
-      if windows_ansi?
+      if Pry::Platform.windows_ansi?
         move_up = proc { |n| "\e[#{n}F" }
       else
         move_up = proc { |n| "\e[#{n}A\e[0G" }

--- a/lib/pry/editor.rb
+++ b/lib/pry/editor.rb
@@ -2,6 +2,7 @@ class Pry
   class Editor
     extend Pry::Helpers::BaseHelpers
     extend Pry::Helpers::CommandHelpers
+    extend Pry::Platform
 
     class << self
       def edit_tempfile_with_content(initial_content, line=1)

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -43,7 +43,7 @@ class Pry
       end
 
       def use_ansi_codes?
-        windows_ansi? || ENV['TERM'] && ENV['TERM'] != "dumb"
+        Pry::Platform.windows_ansi? || ENV['TERM'] && ENV['TERM'] != "dumb"
       end
 
       def colorize_code(code)
@@ -64,16 +64,6 @@ class Pry
         Pry.color ? "\e[1m#{text}\e[0m": text
       end
 
-      # have fun on the Windows platform.
-      def windows?
-        RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
-      end
-
-      # are we able to use ansi on windows?
-      def windows_ansi?
-        defined?(Win32::Console) || ENV['ANSICON'] || (windows? && mri_20?)
-      end
-
       def jruby?
         RbConfig::CONFIG['ruby_install_name'] == 'jruby'
       end
@@ -86,20 +76,12 @@ class Pry
         RbConfig::CONFIG['ruby_install_name'] == 'rbx'
       end
 
-      def mri?
-        RbConfig::CONFIG['ruby_install_name'] == 'ruby'
-      end
-
       def mri_18?
-        mri? && RUBY_VERSION =~ /1.8/
+        Pry::Platform.mri? && RUBY_VERSION =~ /1.8/
       end
 
       def mri_19?
-        mri? && RUBY_VERSION =~ /1.9/
-      end
-
-      def mri_20?
-        mri? && RUBY_VERSION =~ /2.0/
+        Pry::Platform.mri? && RUBY_VERSION =~ /1.9/
       end
 
       # Send the given text through the best available pager (if Pry.pager is

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -392,7 +392,7 @@ class Pry
       cols = cols.to_i
       lines = (cols != 0 ? (line_to_measure.length / cols + 1) : 1).to_i
 
-      if Pry::Helpers::BaseHelpers.windows_ansi?
+      if Pry::Platform.windows_ansi?
         move_up   = "\e[#{lines}F"
         move_down = "\e[#{lines}E"
       else

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -468,7 +468,7 @@ class Pry
         Pry::MethodInfo.info_for(@method) or raise CommandError, "Cannot locate this method: #{name}. (source_location returns nil)"
       else
         fail_msg = "Cannot locate this method: #{name}."
-        if mri?
+        if Pry::Platform.mri?
           fail_msg += ' Try `gem-install pry-doc` to get access to Ruby Core documentation.'
         end
         raise CommandError, fail_msg

--- a/lib/pry/platform.rb
+++ b/lib/pry/platform.rb
@@ -1,0 +1,25 @@
+class Pry
+  module Platform
+
+    module_function
+
+    # have fun on the Windows platform.
+    def windows?
+      RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+    end
+
+# are we able to use ansi on windows?
+    def windows_ansi?
+      defined?(Win32::Console) || ENV['ANSICON'] || (windows? && mri_20?)
+    end
+
+    def mri?
+      RbConfig::CONFIG['ruby_install_name'] == 'ruby'
+    end
+
+    def mri_20?
+      mri? && RUBY_VERSION =~ /2.0/
+    end
+
+  end
+end

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -86,7 +86,7 @@ class Pry
   def self.start(target=nil, options={})
     return if ENV['DISABLE_PRY']
 
-    load_win32console if Pry::Helpers::BaseHelpers.windows? && !Pry::Helpers::BaseHelpers.windows_ansi? && Pry.config.load_win32console
+    load_win32console if Pry::Platform.windows? && !Pry::Platform.windows_ansi? && Pry.config.load_win32console
 
     if in_critical_section?
       output.puts "ERROR: Pry started inside Pry."
@@ -192,7 +192,7 @@ class Pry
     return ENV['VISUAL'] if ENV['VISUAL'] and not ENV['VISUAL'].empty?
     return ENV['EDITOR'] if ENV['EDITOR'] and not ENV['EDITOR'].empty?
 
-    if Pry::Helpers::BaseHelpers.windows?
+    if Pry::Platform.windows?
       'notepad'
     else
       %w(editor nano vi).detect do |editor|

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -49,7 +49,7 @@ class Pry
 
       # Clear the line before starting Pry. This fixes issue #566.
       if Pry.config.correct_indent
-        Kernel.print Pry::Helpers::BaseHelpers.windows_ansi? ? "\e[0F" : "\e[0G"
+        Kernel.print Pry::Platform.windows_ansi? ? "\e[0F" : "\e[0G"
       end
     end
 
@@ -180,7 +180,7 @@ class Pry
         end
 
         if input == Readline
-          if !$stdout.tty? && $stdin.tty? && !Pry::Helpers::BaseHelpers.windows?
+          if !$stdout.tty? && $stdin.tty? && !Pry::Platform.windows?
             Readline.output = File.open('/dev/tty', 'w')
           end
           input_readline(current_prompt, false) # false since we'll add it manually

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -19,7 +19,7 @@ describe Pry::Editor do
     @tf_path = File.join(@tf_dir.to_s, 'hello world.rb')
   end
 
-  unless Pry::Helpers::BaseHelpers.windows?
+  unless Pry::Platform.windows?
     describe "build_editor_invocation_string" do
       before do
         class << Pry::Editor


### PR DESCRIPTION
... config. To add this config, remove require 'win32console' from pry.rb to pry_class.rb , add default setting of config.ansicon to true, and add command line option.
