### PR TITLE
patch non_interactive_mode to prevent double REPL layer

### DIFF
--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -215,8 +215,7 @@ end.add_option_processor do |opts|
 
   if Pry::CLI.input_args.any? && Pry::CLI.input_args != ["pry"]
     full_name = File.expand_path(Pry::CLI.input_args.first)
-    Pry.load_file_through_repl(full_name)
-    if Pry.config.exit_interactive
+    if Pry.load_file_through_repl(full_name) && Pry.config.exit_interactive
       Pry.toplevel_binding.pry
     end
     exit

--- a/lib/pry/repl_file_loader.rb
+++ b/lib/pry/repl_file_loader.rb
@@ -42,8 +42,10 @@ class Pry
       end
 
       content.lines.each do |line|
-        break unless _pry_.eval line, :generated => true
+        return false unless _pry_.eval line, :generated => true
       end
+
+      true
     end
 
     # Define a few extra commands useful for flipping back & forth


### PR DESCRIPTION
This commit fixes the issue wherein running a file `test.rb` with `pry -i test.rb` causes a second REPL to be run after the REPL created automatically to handle an exception caused by `test.rb` is closed.

```
vincents-air:pry vwoo$ pry -i ../test.rb

Exception: RuntimeError: lol
--
From: (pry) @ line 2 @ level: 0 of backtrace (of 21).

    1: x = 1
 => 2: raise 'lol'
...exception encountered, going interactive!
[3] pry(main)> <-- hitting ctrl-d here
[1] pry(main)> <-- yields a second console instead of quitting
```

`test.rb`:

```
x = 1
raise 'lol'
```
