### PR TITLE
Go to interactive_mode end-of-input is raised

### DIFF
--- a/lib/pry/repl_file_loader.rb
+++ b/lib/pry/repl_file_loader.rb
@@ -44,6 +44,11 @@ class Pry
       content.lines.each do |line|
         break unless _pry_.eval line, :generated => true
       end
+
+      unless _pry_.eval_string.empty?
+        _pry_.output.puts "#{_pry_.eval_string}...exception encountered, going interactive!"
+        interactive_mode(_pry_)
+      end
     end
 
     # Define a few extra commands useful for flipping back & forth


### PR DESCRIPTION
When pry is run with file which causes syntax error (expecting
end-of-input), gose to interactive_mode.
This is same when other errors are raised.
This commit will fix #1098.
