### PR TITLE
Defer Readline load as long as possible (fix #1081, #1095)

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -196,6 +196,16 @@ class Pry
   # IRB = Pry thing.
   module ExtendCommandBundle
   end
+
+  def self.require_readline
+    return false if @required_readline
+    require 'readline'
+    @required_readline = true
+  rescue LoadError
+    warn "Sorry, you can't use Pry without Readline or a compatible library."
+    warn "Please `gem install rb-readline` or recompile Ruby --with-readline."
+    raise
+  end
 end
 
 if Pry::Helpers::BaseHelpers.mri_18?
@@ -213,19 +223,11 @@ require 'slop'
 require 'rbconfig'
 require 'tempfile'
 
-begin
-  require 'readline'
-rescue LoadError
-  warn "You're running a version of ruby with no Readline support"
-  warn "Please `gem install rb-readline` or recompile ruby --with-readline."
-  exit!
-end
-
 if Pry::Helpers::BaseHelpers.jruby?
   begin
     require 'ffi'
   rescue LoadError
-    warn "Need to `gem install ffi`"
+    warn "For a better Pry experience on JRuby, please `gem install ffi`."
   end
 end
 
@@ -236,7 +238,8 @@ if Pry::Helpers::BaseHelpers.windows? && !Pry::Helpers::BaseHelpers.windows_ansi
   # only fail on jruby (where win32console doesn't work).
   # Instead we'll recommend ansicon, which does.
   rescue LoadError
-    warn "For a better pry experience, please use ansicon: http://adoxa.3eeweb.com/ansicon/"
+    warn "For a better Pry experience on Windows, please use ansicon:"
+    warn "   http://adoxa.3eeweb.com/ansicon/"
   end
 end
 

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -5,13 +5,27 @@ class Pry
 
     # Get/Set the object to use for input by default by all Pry instances.
     # Pry.config.input is an option determining the input object - the object from
-    # which Pry retrieves its lines of input. Pry accepts any object that implements the readline method.
-    # This includes IO objects, StringIO, Readline, File and custom objects.
+    # which Pry retrieves its lines of input. Pry accepts any object that
+    # implements the readline method.  This includes IO objects, StringIO,
+    # Readline, File and custom objects. It can also be a Proc which returns an
+    # object implementing the readline method.
     # @return [#readline] The object to use for input by default by all
     #   Pry instances.
     # @example
     #   Pry.config.input = StringIO.new("@x = 10\nexit")
-    attr_accessor :input
+    def input
+      @reified_input ||=
+        if @input.respond_to?(:call)
+          @input.call
+        else
+          @input
+        end
+    end
+
+    def input=(input)
+      @reified_input = nil
+      @input = input
+    end
 
     # Get/Set the object to use for output by default by all Pry instances.
     # Pry.config.output is an option determining the output object - the object to which

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -1,6 +1,6 @@
 class Pry
-  # The History class is responsible for maintaining the user's input history, both
-  # internally and within Readline.
+  # The History class is responsible for maintaining the user's input history,
+  # both internally and within Readline.
   class History
     attr_accessor :loader, :saver, :pusher, :clearer
 
@@ -111,11 +111,13 @@ class Pry
     # The default pusher. Appends the given line to Readline::HISTORY.
     # @param [String] line
     def push_to_readline(line)
+      Pry.require_readline
       Readline::HISTORY << line
     end
 
     # The default clearer. Clears Readline::HISTORY.
     def clear_readline
+      Pry.require_readline
       Readline::HISTORY.shift until Readline::HISTORY.empty?
     end
   end

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -107,8 +107,7 @@ class Pry
   # Including: loading .pryrc, loading plugins, loading requires, and
   # loading history.
   def self.initial_session_setup
-
-    return if !initial_session?
+    return unless initial_session?
 
     # note these have to be loaded here rather than in pry_instance as
     # we only want them loaded once per entire Pry lifetime.
@@ -262,6 +261,7 @@ class Pry
   end
 
   def self.auto_resize!
+    Pry.require_readline
     ver = Readline::VERSION
     if ver[/edit/i]
       warn <<-EOT
@@ -286,7 +286,7 @@ Readline version #{ver} detected - will not auto_resize! correctly.
   end
 
   def self.set_config_defaults
-    config.input = Readline
+    config.input = proc { Pry.require_readline; Readline }
     config.output = $stdout
     config.commands = Pry::Commands
     config.prompt_name = DEFAULT_PROMPT_NAME
@@ -310,12 +310,7 @@ Readline version #{ver} detected - will not auto_resize! correctly.
     config.correct_indent = true
     config.collision_warning = false
     config.output_prefix = "=> "
-
-    if defined?(Bond) && Readline::VERSION !~ /editline/i
-      config.completer = Pry::BondCompleter
-    else
-      config.completer = Pry::InputCompleter
-    end
+    config.completer = Pry::BondCompleter
 
     config.gist ||= OpenStruct.new
     config.gist.inspecter = proc(&:pretty_inspect)

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -619,7 +619,7 @@ class Pry
         input.completion_proc = completion_proc
       end
 
-      if input == Readline
+      if defined?(Readline) && input == Readline
         if !$stdout.tty? && $stdin.tty? && !Pry::Helpers::BaseHelpers.windows?
           Readline.output = File.open('/dev/tty', 'w')
         end

--- a/lib/pry/terminal.rb
+++ b/lib/pry/terminal.rb
@@ -53,7 +53,7 @@ class Pry::Terminal
     end
 
     def screen_size_according_to_readline
-      if Readline.respond_to?(:get_screen_size)
+      if defined?(Readline) && Readline.respond_to?(:get_screen_size)
         size = Readline.get_screen_size
         size if nonzero_column?(size)
       end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -10,6 +10,8 @@ def completer_test(bind, pry=nil, assert_flag=true)
   return proc {|*symbols| symbols.each(&test) }
 end
 
+Pry.require_readline
+
 if defined?(Bond) && Readline::VERSION !~ /editline/i
   describe 'bond-based completion' do
     it 'should pull in Bond by default' do


### PR DESCRIPTION
This fixes my test case for rails/spring#244. I'd like to get this out in a 0.9 release so that pry-rails can be compatible with Spring. We can come up with a nicer version for master.
