### PR TITLE
Fix bug in edit regarding file names with path but no suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
   being inferred from context (#877)
 * Rename `--installed-plugins` flag to `--plugins`
 * Strip ANSI codes from prompt before measuring length for indentation (#493)
+* Fix bug in `edit` regarding recognition of file names without suffix.
 
 #### Dev-facing changes
 * `rake pry` now accepts switches prefixed with `_` (e.g., `rake pry _v`)

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -186,7 +186,7 @@ class Pry
     end
 
     def probably_a_file?(str)
-      [".rb", ".c", ".py", ".yml", ".gemspec"].include? File.extname(str) ||
+      [".rb", ".c", ".py", ".yml", ".gemspec"].include?(File.extname(str)) ||
         str =~ /\/|\\/
     end
 

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -35,6 +35,16 @@ describe "edit" do
       FileUtils.rm(@tf_path) if File.exists?(@tf_path)
     end
 
+    it "should not allow patching any known kind of file" do
+      ["file.rb", "file.c", "file.py", "file.yml", "file.gemspec",
+       "/tmp/file", "\\\\Temp\\\\file"].each do |file|
+        proc {
+          pry_eval "edit -p #{file}"
+        }.should.raise(NotImplementedError).
+          message.should =~ /Cannot yet patch false objects!/
+      end
+    end
+
     it "should invoke Pry.config.editor with absolutified filenames" do
       pry_eval 'edit lib/pry.rb'
       @file.should == File.expand_path('lib/pry.rb')


### PR DESCRIPTION
I've tried to figure out the role of `Edit#probably_a_file?` and came up with the spec example you see.
