### PR TITLE
Fix watch_expression to access correct hooks

### DIFF
--- a/lib/pry/commands/watch_expression.rb
+++ b/lib/pry/commands/watch_expression.rb
@@ -82,8 +82,8 @@ class Pry
 
     def add_hook
       hook = [:after_eval, :watch_expression]
-      unless Pry.hooks.hook_exists?(*hook)
-        Pry.hooks.add_hook(*hook) do |_, _pry_|
+      unless _pry_.hooks.hook_exists?(*hook)
+        _pry_.hooks.add_hook(*hook) do |_, _pry_|
           eval_and_print_changed _pry_.output
         end
       end


### PR DESCRIPTION
Now by refactoring config, Pry.config and @pry.config have different
hooks. So to access correct pry config hooks, fix
Pry::Command::WatchExpression.add_hook.
