### PR TITLE
Ensures that loading pry inside config doesn't explode

### DIFF
--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -51,7 +51,9 @@ class Pry
   # This method can also be used to reload the files if they have changed.
   def self.load_rc_files
     rc_files_to_load.each do |file|
-      load_file_at_toplevel(file)
+      critical_section do
+        load_file_at_toplevel(file)
+      end
     end
   end
 


### PR DESCRIPTION
See #1051

I was looking through the tracker for something to work on. This seemed like low hanging fruit.

This deals with the stack explosion, and means you can get out of pry without having to `raise SystemExit`.

It'd be nice at some point to actually be able to debug your pryrc with pry, but it'll take me a bit to work out the required magic.
