### PR TITLE
Fix sticky_locals(_ and __) when lambda is given

### DIFF
--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -184,8 +184,8 @@ class Pry
       _ex_: last_exception,
       _file_: last_file,
       _dir_: last_dir,
-      _: last_result,
-      __: output_array[-2]
+      _: proc { last_result },
+      __: proc { output_array[-2] }
     }.merge(config.extra_sticky_locals)
   end
 

--- a/spec/sticky_locals_spec.rb
+++ b/spec/sticky_locals_spec.rb
@@ -40,6 +40,21 @@ describe "Sticky locals (_file_ and friends)" do
     Pry.commands.delete "file-and-dir-test"
   end
 
+  it 'locals should return last result (_)' do
+    pry_tester.tap do |t|
+      lam = t.eval 'lambda { |foo| }'
+      t.eval('_').should == lam
+    end
+  end
+
+  it 'locals should return second last result (__)' do
+    pry_tester.tap do |t|
+      lam = t.eval 'lambda { |foo| }'
+      t.eval 'num = 1'
+      t.eval('__').should == lam
+    end
+  end
+
   describe "User defined sticky locals" do
     describe "setting as Pry.config option" do
       it 'should define a new sticky local for the session (normal value)' do


### PR DESCRIPTION
When lambda is given, Pry#inject_sticky_locals! causes arguments error.
By warpping (_ and __) with proc, solve this bug.
This will fix #1119.
