### PR TITLE
Ensure lines are integers, not rationals during indention.

### DIFF
--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -390,7 +390,7 @@ class Pry
       _, cols = Terminal.screen_size
 
       cols = cols.to_i
-      lines = cols != 0 ? (full_line.length / cols + 1) : 1
+      lines = (cols != 0 ? (full_line.length / cols + 1) : 1).to_i
 
       if Pry::Helpers::BaseHelpers.windows_ansi?
         move_up   = "\e[#{lines}F"


### PR DESCRIPTION
This is just a backport of #872 to v0.9.12. Fresh installs of pry still print odd characters after running `require 'mathn'`.
