### PR TITLE
Add docs badge to README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,5 @@
 [![Build Status](https://secure.travis-ci.org/pry/pry.png)](http://travis-ci.org/pry/pry) [![Code Climate](https://codeclimate.com/github/pry/pry.png)](https://codeclimate.com/github/pry/pry)
+[![Inline docs](http://inch-pages.github.io/github/pry/pry.png)](http://inch-pages.github.io/github/pry/pry)
 
 <center>
 ![The Pry Logo](https://dl.dropbox.com/u/26521875/pry%20stuff/logo/pry_logo_350.png)


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/pry/pry.png)](http://inch-pages.github.io/github/pry/pry) (And Pry really shines in this regard!)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for Pry is http://inch-pages.github.io/github/pry/pry/

Inch Pages is still in it's infancy, but already used by projects like [Virtus](https://github.com/solnic/virtus) and [libnotify](https://github.com/splattael/libnotify).

What do you think?
