### PR TITLE
Clean up gem dependencies (fix #1148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 * remove runtime dependency on `openstruct` from pry
 * 1.8 support discontinued from 0.10/1.0 up.  0.9 branch continues 1.8 support.
-* Require Coderay `>= 1.1.0`
+* Require Coderay `~> 1.1.0`
 
 #### Features
 * Added a `watch` command that lets you see how values change over time.

--- a/pry.gemspec
+++ b/pry.gemspec
@@ -17,15 +17,14 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency 'coderay',       '>= 1.1.0'
+  s.add_dependency 'coderay',       '~> 1.1.0'
   s.add_dependency 'slop',          '~> 3.4'
   s.add_dependency 'method_source', '~> 0.8'
 
   s.add_development_dependency 'bacon', '~> 1.2'
-  s.add_development_dependency 'open4', '~> 1.3'
-  s.add_development_dependency 'rake',  '>= 0.9'
-  s.add_development_dependency 'mocha', '~> 0.13.1'
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'rake',  '~> 10.0'
+  s.add_development_dependency 'mocha', '~> 1.0'
+  s.add_development_dependency 'simplecov', '~> 0.8'
   # TODO: make this a plain dependency:
-  s.add_development_dependency 'bond',  '~> 0.5.0'
+  s.add_development_dependency 'bond',  '~> 0.5'
 end


### PR DESCRIPTION
- Remove unused development dependency on open4
- Use pessimistic versioning for coderay, rake, and simplecov
- Bump versions of rake and mocha
- Loosen pessimistic versioning on mocha and bond

The only remaining warning from RubyGems is on coderay -- we chose not to use
'~> 1.1' because there were breaking changes between 1.0 and 1.1.
