### PR TITLE
Fix typo.

### DIFF
--- a/lib/pry/commands/find_method.rb
+++ b/lib/pry/commands/find_method.rb
@@ -24,9 +24,9 @@ class Pry
       find-method -c 'output.puts' Pry
     BANNER
 
-    def options(opti)
-      opti.on :n, :name,    "Search for a method by name"
-      opti.on :c, :content, "Search for a method based on content in Regex form"
+    def options(opt)
+      opt.on :n, :name,    "Search for a method by name"
+      opt.on :c, :content, "Search for a method based on content in Regex form"
     end
 
     def process


### PR DESCRIPTION
Rename parameter of options method from opti to opt, because in other commands opt is used.
