### PR TITLE
Fix gem require

### DIFF
--- a/lib/pry/commands/gem_install.rb
+++ b/lib/pry/commands/gem_install.rb
@@ -21,10 +21,10 @@ class Pry
     def process(gem)
       Rubygem.install(gem)
       output.puts "Gem `#{ text.green(gem) }` installed."
+      require gem
+    rescue LoadError
       require_path = gem.split('-').join('/')
       require require_path
-    rescue LoadError
-      require gem
     end
   end
 


### PR DESCRIPTION
The Rubygem documentation here http://guides.rubygems.org/name-your-gem/
suggests the naming of rubygems. If the name contains dashes (-) the
require statements should include forward slashes that replace the dashes.

For example, the 'net-ssh' rubygem should have the require statement of

``` ruby
require 'net/ssh'
```

This simple fix tries to address this problem and falls back to the
original require statement if there is a `LoadError`. This will handle
cases where some gem author didn't follow the naming convention
suggested in the documentation.
