### PR TITLE
Stop using compatibility aliases for Pry.config

### DIFF
--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -128,7 +128,7 @@ Copyright (c) 2013 John Mair (banisterfiend)
   end
 
   on "no-color", "Disable syntax highlighting for session" do
-    Pry.color = false
+    Pry.config.color = false
   end
 
   on :f, "Suppress loading of ~/.pryrc and ./.pryrc" do

--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -262,7 +262,7 @@ class Pry
     def print_to_output(output)
       @lines.each do |loc|
         loc = loc.dup
-        loc.colorize(@code_type)              if Pry.color
+        loc.colorize(@code_type)              if Pry.config.color
         loc.add_line_number(max_lineno_width) if @with_line_numbers
         loc.add_marker(@marker_lineno)        if @with_marker
         loc.indent(@indentation_num)          if @with_indentation

--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -18,7 +18,7 @@ class Pry
     end
 
     def text(str, width = str.length)
-      super(*if !Pry.color
+      super(*if !Pry.config.color
         [str, width]
       # Don't recolorize output with color [Issue #751]
       elsif str.include?("\e[")
@@ -43,7 +43,7 @@ class Pry
       obj_id = obj.__id__.to_s(16) rescue 0
       str    = "#<#{klass}:0x#{obj_id}>"
 
-      text(Pry.color ? highlight_object_literal(str) : str)
+      text(Pry.config.color ? highlight_object_literal(str) : str)
     end
 
     private

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -122,7 +122,7 @@ class Pry
     # @param [String, Regexp] search The match or listing of the command.
     # @yield The block to be run before the command.
     # @example Display parameter before invoking command
-    #   Pry.commands.before_command("whereami") do |n|
+    #   Pry.config.commands.before_command("whereami") do |n|
     #     output.puts "parameter passed was #{n}"
     #   end
     def before_command(search, &block)
@@ -136,7 +136,7 @@ class Pry
     # @param [String, Regexp] search The match or listing of the command.
     # @yield The block to be run after the command.
     # @example Display text 'command complete' after invoking command
-    #   Pry.commands.after_command("whereami") do |n|
+    #   Pry.config.commands.after_command("whereami") do |n|
     #     output.puts "command complete!"
     #   end
     def after_command(search, &block)
@@ -336,7 +336,7 @@ class Pry
     #   Returns the new command (matched with "pattern".)
     #
     # @example
-    #   Pry.commands["help"] = MyHelpCommand
+    #   Pry.config.commands["help"] = MyHelpCommand
     #
     def []=(pattern, command)
       if command.equal?(nil)

--- a/lib/pry/commands/easter_eggs.rb
+++ b/lib/pry/commands/easter_eggs.rb
@@ -83,8 +83,8 @@ TEXT
     end
 
     command "test-ansi", "" do
-      prev_color = Pry.color
-      Pry.color = true
+      prev_color = Pry.config.color
+      Pry.config.color = true
 
       picture = unindent <<-'EOS'.gsub(/[[:alpha:]!]/) { |s| text.red(s) }
          ____      _______________________
@@ -106,7 +106,7 @@ TEXT
       output.puts "\n" * 6
       output.puts "** ENV['TERM'] is #{ENV['TERM']} **\n\n"
 
-      Pry.color = prev_color
+      Pry.config.color = prev_color
     end
   end
 end

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -47,7 +47,7 @@ class Pry
       end
 
       def colorize_code(code)
-        if Pry.color
+        if Pry.config.color
           CodeRay.scan(code, :ruby).term
         else
           code
@@ -61,7 +61,7 @@ class Pry
       # formatting
       def heading(text)
         text = "#{text}\n--"
-        Pry.color ? "\e[1m#{text}\e[0m": text
+        Pry.config.color ? "\e[1m#{text}\e[0m": text
       end
 
       # have fun on the Windows platform.
@@ -102,7 +102,7 @@ class Pry
         mri? && RUBY_VERSION =~ /2.1/
       end
 
-      # Send the given text through the best available pager (if Pry.pager is
+      # Send the given text through the best available pager (if Pry.config.pager is
       # enabled). Infers where to send the output if used as a mixin.
       def stagger_output(text, out = nil)
         out ||= case
@@ -111,7 +111,7 @@ class Pry
                   output
                 when Pry.respond_to?(:output)
                   # Parent.
-                  Pry.output
+                  Pry.config.output
                 else
                   # Sys.
                   $stdout

--- a/lib/pry/helpers/documentation_helpers.rb
+++ b/lib/pry/helpers/documentation_helpers.rb
@@ -8,7 +8,7 @@ class Pry
       module_function
 
       def process_rdoc(comment)
-        return comment unless Pry.color
+        return comment unless Pry.config.color
         comment = comment.dup
         comment.gsub(/<code>(?:\s*\n)?(.*?)\s*<\/code>/m) { CodeRay.scan($1, :ruby).term }.
           gsub(/<em>(?:\s*\n)?(.*?)\s*<\/em>/m) { "\e[1m#{$1}\e[0m" }.
@@ -37,7 +37,7 @@ class Pry
         yard_tags = ["param", "return", "option", "yield", "attr", "attr_reader", "attr_writer",
                      "deprecate", "example", "raise"]
         (yard_tags - ["example"]).inject(comment) { |a, v| process_yardoc_tag(a, v) }.
-          gsub(/^@(#{yard_tags.join("|")})/) { Pry.color ? "\e[33m#{$1}\e[0m": $1 }
+          gsub(/^@(#{yard_tags.join("|")})/) { Pry.config.color ? "\e[33m#{$1}\e[0m": $1 }
       end
 
       def process_comment_markup(comment)

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -21,11 +21,11 @@ class Pry
 
         COLORS.each_pair do |color, value|
           define_method color do |text|
-            Pry.color ? "\033[0;#{30+value}m#{text}\033[0m" : text.to_s
+            Pry.config.color ? "\033[0;#{30+value}m#{text}\033[0m" : text.to_s
           end
 
           define_method "bright_#{color}" do |text|
-            Pry.color ? "\033[1;#{30+value}m#{text}\033[0m" : text.to_s
+            Pry.config.color ? "\033[1;#{30+value}m#{text}\033[0m" : text.to_s
           end
         end
 
@@ -38,12 +38,12 @@ class Pry
         end
 
         # Returns _text_ as bold text for use on a terminal.
-        # _Pry.color_ must be true for this method to perform any transformations.
+        # _Pry.config.color_ must be true for this method to perform any transformations.
         #
         # @param [String, #to_s] text
         # @return [String] _text_
         def bold(text)
-          Pry.color ? "\e[1m#{text}\e[0m" : text.to_s
+          Pry.config.color ? "\e[1m#{text}\e[0m" : text.to_s
         end
 
         # Returns `text` in the default foreground colour.
@@ -56,7 +56,7 @@ class Pry
         end
         alias_method :bright_default, :bold
 
-        # Executes the block with `Pry.color` set to false.
+        # Executes the block with `Pry.config.color` set to false.
         # @yield
         # @return [void]
         def no_color(&block)

--- a/lib/pry/hooks.rb
+++ b/lib/pry/hooks.rb
@@ -52,7 +52,7 @@ class Pry
     # FIXME:
     # This is a hack to alert people of the new API.
     def [](event_name)
-      warn "`Pry.hooks[]` is deprecated! Please use the new `Pry::Hooks` API! http://rubydoc.info/github/pry/pry/master/Pry/Hooks"
+      warn "`Pry.config.hooks[]` is deprecated! Please use the new `Pry::Hooks` API! http://rubydoc.info/github/pry/pry/master/Pry/Hooks"
 
       get_hook(event_name, nil)
     end
@@ -60,7 +60,7 @@ class Pry
     # FIXME:
     # This is a hack to alert people of the new API.
     def []=(event_name, callable)
-      warn "`Pry.hooks[]=` is deprecated! Please use the new `Pry::Hooks` API! http://rubydoc.info/github/pry/pry/master/Pry/Hooks"
+      warn "`Pry.config.hooks[]=` is deprecated! Please use the new `Pry::Hooks` API! http://rubydoc.info/github/pry/pry/master/Pry/Hooks"
 
       add_hook(event_name, nil, callable)
     end

--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -7,7 +7,7 @@ module Pry::Pager
   class StopPaging < StandardError
   end
 
-  # Send the given text through the best available pager (if `Pry.pager` is
+  # Send the given text through the best available pager (if `Pry.config.pager` is
   # enabled).
   # @param [String] text A piece of text to run through a pager.
   # @param [IO] output (`$stdout`) An object to send output to.
@@ -36,7 +36,7 @@ module Pry::Pager
   # These requirements can be avoided by using `.with_pager` instead.
   # @param [#<<] output ($stdout) An object to send output to.
   def self.best_available(output)
-    if !Pry.pager
+    if !Pry.config.pager
       NullPager.new(output)
     elsif !SystemPager.available? || Pry::Helpers::BaseHelpers.jruby?
       SimplePager.new(output)
@@ -46,7 +46,7 @@ module Pry::Pager
   end
 
   # `NullPager` is a "pager" that actually just prints all output as it comes
-  # in. Used when `Pry.pager` is false.
+  # in. Used when `Pry.config.pager` is false.
   class NullPager
     def initialize(out)
       @out = out
@@ -94,7 +94,7 @@ module Pry::Pager
 
         if @tracker.page?
           @out.print "\n"
-          @out.print "\e[0m" if Pry.color
+          @out.print "\e[0m" if Pry.config.color
           @out.print "<page break> --- Press enter to continue " \
                      "( q<enter> to break ) --- <page break>\n"
           raise StopPaging if Readline.readline("").chomp == "q"

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -212,7 +212,7 @@ class Pry
   end
 
   # Run a Pry command from outside a session. The commands available are
-  # those referenced by `Pry.commands` (the default command set).
+  # those referenced by `Pry.config.commands` (the default command set).
   # @param [String] command_string The Pry command (including arguments,
   #   if any).
   # @param [Hash] options Optional named parameters.
@@ -231,8 +231,8 @@ class Pry
     options = {
       :target => TOPLEVEL_BINDING,
       :show_output => true,
-      :output => Pry.output,
-      :commands => Pry.commands
+      :output => Pry.config.output,
+      :commands => Pry.config.commands
     }.merge!(options)
 
     # :context for compatibility with <= 0.9.11.4

--- a/lib/pry/test/helper.rb
+++ b/lib/pry/test/helper.rb
@@ -7,8 +7,8 @@ class << Pry
   def reset_defaults
     orig_reset_defaults
 
-    Pry.color = false
-    Pry.pager = false
+    Pry.config.color = false
+    Pry.config.pager = false
     Pry.config.should_load_rc      = false
     Pry.config.should_load_local_rc= false
     Pry.config.should_load_plugins = false

--- a/spec/code_object_spec.rb
+++ b/spec/code_object_spec.rb
@@ -73,19 +73,19 @@ describe Pry::CodeObject do
         end
 
         it 'should return Pry::ClassCommand class when looking up class command' do
-          Pry.commands.add_command(LobsterLady)
+          Pry.config.commands.add_command(LobsterLady)
           m = Pry::CodeObject.lookup("lobster-lady", @p)
           (m <= Pry::ClassCommand).should == true
           m.source.should =~ /class LobsterLady/
-          Pry.commands.delete("lobster-lady")
+          Pry.config.commands.delete("lobster-lady")
         end
 
         it 'should return Pry::WrappedModule when looking up command class directly (as a class, not as a command)' do
-          Pry.commands.add_command(LobsterLady)
+          Pry.config.commands.add_command(LobsterLady)
           m = Pry::CodeObject.lookup("LobsterLady", @p)
           m.is_a?(Pry::WrappedModule).should == true
           m.source.should =~ /class LobsterLady/
-          Pry.commands.delete("lobster-lady")
+          Pry.config.commands.delete("lobster-lady")
         end
       end
 

--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -462,7 +462,7 @@ describe "commands" do
       end
     end
 
-    Pry.commands = klass
+    Pry.config.commands = klass
     pry_tester.eval("hello").should == "hello world\n"
     pry_tester(:commands => other_klass).eval("goodbye").should == "goodbye world\n"
   end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -653,11 +653,11 @@ describe "Pry::Command" do
         end
       end
 
-      Pry.commands.add_command MyTestCommand
+      Pry.config.commands.add_command MyTestCommand
     end
 
     after do
-      Pry.commands.delete 'my-test'
+      Pry.config.commands.delete 'my-test'
     end
 
     it "allows creation of custom subclasses of Pry::Command" do
@@ -689,11 +689,11 @@ describe "Pry::Command" do
             match 'happy-new-year'
             description 'Happy New Year 2013'
           end
-          Pry.commands.add_command HappyNewYear
+          Pry.config.commands.add_command HappyNewYear
 
           HappyNewYear.options[:listing].should == 'happy-new-year'
 
-          Pry.commands.delete 'happy-new-year'
+          Pry.config.commands.delete 'happy-new-year'
         end
 
         it "can be set explicitly" do
@@ -702,11 +702,11 @@ describe "Pry::Command" do
             description 'Merry Christmas!'
             command_options :listing => 'happy-holidays'
           end
-          Pry.commands.add_command MerryChristmas
+          Pry.config.commands.add_command MerryChristmas
 
           MerryChristmas.options[:listing].should == 'happy-holidays'
 
-          Pry.commands.delete 'merry-christmas'
+          Pry.config.commands.delete 'merry-christmas'
         end
 
         it "equals to :match option's inspect, if :match is Regexp" do
@@ -714,11 +714,11 @@ describe "Pry::Command" do
             match /.*winter/
             description 'Is winter cool or cool?'
           end
-          Pry.commands.add_command CoolWinter
+          Pry.config.commands.add_command CoolWinter
 
           CoolWinter.options[:listing].should == '/.*winter/'
 
-          Pry.commands.delete /.*winter/
+          Pry.config.commands.delete /.*winter/
         end
       end
     end

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -719,7 +719,7 @@ describe "edit" do
     end
 
     it 'should edit method context' do
-      Pry.editor = lambda do |file, line|
+      Pry.config.editor = lambda do |file, line|
         [file, line].should == BinkyWink.instance_method(:tots_macgee).source_location
         nil
       end
@@ -729,7 +729,7 @@ describe "edit" do
     end
 
     it 'errors when cannot find method context' do
-      Pry.editor = lambda do |file, line|
+      Pry.config.editor = lambda do |file, line|
         [file, line].should == BinkyWink.instance_method(:tits_macgee).source_location
         nil
       end

--- a/spec/commands/save_file_spec.rb
+++ b/spec/commands/save_file_spec.rb
@@ -141,7 +141,7 @@ describe "save-file" do
   describe "saving commands" do
     it 'should save a command to a file' do
       @t.eval "save-file --to '#{@path}' show-source"
-      cmd_source = Pry.commands["show-source"].source
+      cmd_source = Pry.config.commands["show-source"].source
       File.read(@path).should == cmd_source
     end
   end

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -433,7 +433,7 @@ describe "show-doc" do
           end
         end
 
-        Pry.commands.add_command(LobsterLady)
+        Pry.config.commands.add_command(LobsterLady)
       end
 
       after do
@@ -442,12 +442,12 @@ describe "show-doc" do
 
       it 'should display "help" when looking up by command name' do
         pry_eval('show-doc lobster-lady').should =~ /nada/
-        Pry.commands.delete("lobster-lady")
+        Pry.config.commands.delete("lobster-lady")
       end
 
       it 'should display actual preceding comment for a class command, when class is used (rather than command name) when looking up' do
         pry_eval('show-doc LobsterLady').should =~ /pretty pink pincers/
-        Pry.commands.delete("lobster-lady")
+        Pry.config.commands.delete("lobster-lady")
       end
     end
   end

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -173,13 +173,13 @@ describe "show-source" do
 
   it "should output the source of a command defined inside Pry" do
     command_definition = %{
-      Pry.commands.command "hubba-hubba" do
+      Pry.config.commands.command "hubba-hubba" do
         puts "that's what she said!"
       end
     }
     out = pry_eval(command_definition, 'show-source hubba-hubba')
     out.should =~ /what she said/
-    Pry.commands.delete "hubba-hubba"
+    Pry.config.commands.delete "hubba-hubba"
   end
 
   describe "finding super methods with help of `--super` switch" do
@@ -677,7 +677,7 @@ describe "show-source" do
           def process() :body_of_temp end
         end
 
-        Pry.commands.add_command(::TemporaryCommand)
+        Pry.config.commands.add_command(::TemporaryCommand)
       end
 
       after do
@@ -695,7 +695,7 @@ describe "show-source" do
             def process() :body_of_temp end
           end
         }
-        Pry.commands.add_command(::TemporaryCommandInPry)
+        Pry.config.commands.add_command(::TemporaryCommandInPry)
         pry_eval('show-source temp-command-in-pry').should =~ /:body_of_temp/
         Object.remove_const(:TemporaryCommandInPry)
       end

--- a/spec/documentation_helper_spec.rb
+++ b/spec/documentation_helper_spec.rb
@@ -25,11 +25,11 @@ describe Pry::Helpers::DocumentationHelpers do
 
   describe "process_rdoc" do
     before do
-      Pry.color = true
+      Pry.config.color = true
     end
 
     after do
-      Pry.color = false
+      Pry.config.color = false
     end
 
     it "should syntax highlight indented code" do
@@ -64,8 +64,8 @@ describe Pry::Helpers::DocumentationHelpers do
       @helper.process_rdoc("--\n  comment in a bubble\n++").should =~ /\+\+/
     end
 
-    it "should do nothing if Pry.color is false" do
-      Pry.color = false
+    it "should do nothing if Pry.config.color is false" do
+      Pry.config.color = false
       @helper.process_rdoc("  4 + 4\n").should == "  4 + 4\n"
     end
   end

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -9,22 +9,22 @@ describe "test Pry defaults" do
 
   after do
     Pry.reset_defaults
-    Pry.color = false
+    Pry.config.color = false
   end
 
   describe "input" do
     after do
       Pry.reset_defaults
-      Pry.color = false
+      Pry.config.color = false
     end
 
     it 'should set the input default, and the default should be overridable' do
-      Pry.input = InputTester.new("5")
-      Pry.output = @str_output
+      Pry.config.input = InputTester.new("5")
+      Pry.config.output = @str_output
       Object.new.pry
       @str_output.string.should =~ /5/
 
-      Pry.output = @str_output
+      Pry.config.output = @str_output
       Object.new.pry :input => InputTester.new("6")
       @str_output.string.should =~ /6/
     end
@@ -75,17 +75,17 @@ describe "test Pry defaults" do
   end
 
   it 'should set the output default, and the default should be overridable' do
-    Pry.output = @str_output
+    Pry.config.output = @str_output
 
-    Pry.input  = InputTester.new("5")
+    Pry.config.input  = InputTester.new("5")
     Object.new.pry
     @str_output.string.should =~ /5/
 
-    Pry.input  = InputTester.new("6")
+    Pry.config.input  = InputTester.new("6")
     Object.new.pry
     @str_output.string.should =~ /5\n.*6/
 
-    Pry.input  = InputTester.new("7")
+    Pry.config.input  = InputTester.new("7")
     @str_output = StringIO.new
     Object.new.pry :output => @str_output
     @str_output.string.should.not =~ /5\n.*6/
@@ -94,9 +94,9 @@ describe "test Pry defaults" do
 
   it "should set the print default, and the default should be overridable" do
     new_print = proc { |out, value| out.puts "=> LOL" }
-    Pry.print =  new_print
+    Pry.config.print =  new_print
 
-    Pry.new.print.should == Pry.print
+    Pry.new.print.should == Pry.config.print
     Object.new.pry :input => InputTester.new("\"test\""), :output => @str_output
     @str_output.string.should == "=> LOL\n"
 
@@ -105,7 +105,7 @@ describe "test Pry defaults" do
                    :print => proc { |out, value| out.puts value.reverse }
     @str_output.string.should == "tset\n"
 
-    Pry.new.print.should == Pry.print
+    Pry.new.print.should == Pry.config.print
     @str_output = StringIO.new
     Object.new.pry :input => InputTester.new("\"test\""), :output => @str_output
     @str_output.string.should == "=> LOL\n"
@@ -135,7 +135,7 @@ describe "test Pry defaults" do
 
   describe "prompts" do
     before do
-      Pry.output = StringIO.new
+      Pry.config.output = StringIO.new
     end
 
     def get_prompts(pry)
@@ -385,8 +385,8 @@ describe "test Pry defaults" do
   end
 
   it 'should set the hooks default, and the default should be overridable' do
-    Pry.input = InputTester.new("exit-all")
-    Pry.hooks = Pry::Hooks.new.
+    Pry.config.input = InputTester.new("exit-all")
+    Pry.config.hooks = Pry::Hooks.new.
       add_hook(:before_session, :my_name) { |out,_,_|  out.puts "HELLO" }.
       add_hook(:after_session, :my_name) { |out,_,_| out.puts "BYE" }
 
@@ -394,7 +394,7 @@ describe "test Pry defaults" do
     @str_output.string.should =~ /HELLO/
     @str_output.string.should =~ /BYE/
 
-    Pry.input.rewind
+    Pry.config.input.rewind
 
     @str_output = StringIO.new
     Object.new.pry :output => @str_output,
@@ -406,7 +406,7 @@ describe "test Pry defaults" do
     @str_output.string.should =~ /EVENING/
 
     # try below with just defining one hook
-    Pry.input.rewind
+    Pry.config.input.rewind
     @str_output = StringIO.new
     Object.new.pry :output => @str_output,
                    :hooks => Pry::Hooks.new.
@@ -414,7 +414,7 @@ describe "test Pry defaults" do
 
     @str_output.string.should =~ /OPEN/
 
-    Pry.input.rewind
+    Pry.config.input.rewind
     @str_output = StringIO.new
     Object.new.pry :output => @str_output,
                    :hooks => Pry::Hooks.new.
@@ -423,6 +423,6 @@ describe "test Pry defaults" do
     @str_output.string.should =~ /CLOSE/
 
     Pry.reset_defaults
-    Pry.color = false
+    Pry.config.color = false
   end
 end

--- a/spec/pry_output_spec.rb
+++ b/spec/pry_output_spec.rb
@@ -62,11 +62,11 @@ describe Pry do
 
   describe "color" do
     before do
-      Pry.color = true
+      Pry.config.color = true
     end
 
     after do
-      Pry.color = false
+      Pry.config.color = false
     end
 
     it "should colorize strings as though they were ruby" do

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -35,7 +35,7 @@ describe Pry do
   describe "Pry.critical_section" do
     it "should prevent Pry being called" do
       output = StringIO.new
-      Pry.output = output
+      Pry.config.output = output
       Pry.critical_section do
         Pry.start
       end
@@ -305,13 +305,13 @@ describe Pry do
       describe "nesting" do
         after do
           Pry.reset_defaults
-          Pry.color = false
+          Pry.config.color = false
         end
 
         it 'should nest properly' do
-          Pry.input = InputTester.new("cd 1", "cd 2", "cd 3", "\"nest:\#\{(_pry_.binding_stack.size - 1)\}\"", "exit-all")
+          Pry.config.input = InputTester.new("cd 1", "cd 2", "cd 3", "\"nest:\#\{(_pry_.binding_stack.size - 1)\}\"", "exit-all")
 
-          Pry.output = @str_output
+          Pry.config.output = @str_output
 
           o = Object.new
 
@@ -353,14 +353,14 @@ describe Pry do
 
         after do
           Pry.reset_defaults
-          Pry.color = false
+          Pry.config.color = false
         end
 
         it "should start a pry session on the receiver (first form)" do
-          Pry.input = InputTester.new("self", "exit-all")
+          Pry.config.input = InputTester.new("self", "exit-all")
 
           str_output = StringIO.new
-          Pry.output = str_output
+          Pry.config.output = str_output
 
           20.pry
 
@@ -368,10 +368,10 @@ describe Pry do
         end
 
         it "should start a pry session on the receiver (second form)" do
-          Pry.input = InputTester.new("self", "exit-all")
+          Pry.config.input = InputTester.new("self", "exit-all")
 
           str_output = StringIO.new
-          Pry.output = str_output
+          Pry.config.output = str_output
 
           pry 20
 

--- a/spec/spec_helpers/mock_pry.rb
+++ b/spec/spec_helpers/mock_pry.rb
@@ -15,16 +15,16 @@ end
 
 # Set I/O streams. Out defaults to an anonymous StringIO.
 def redirect_pry_io(new_in, new_out = StringIO.new)
-  old_in = Pry.input
-  old_out = Pry.output
+  old_in = Pry.config.input
+  old_out = Pry.config.output
 
-  Pry.input = new_in
-  Pry.output = new_out
+  Pry.config.input = new_in
+  Pry.config.output = new_out
   begin
     yield
   ensure
-    Pry.input = old_in
-    Pry.output = old_out
+    Pry.config.input = old_in
+    Pry.config.output = old_out
   end
 end
 

--- a/spec/sticky_locals_spec.rb
+++ b/spec/sticky_locals_spec.rb
@@ -47,7 +47,7 @@ describe "Sticky locals (_file_ and friends)" do
   end
 
   it 'locals should keep value after cd-ing (_file_ and _dir_)' do
-    Pry.commands.command "file-and-dir-test" do
+    Pry.config.commands.command "file-and-dir-test" do
       set_file_and_dir_locals("/blah/ostrich.rb")
     end
 
@@ -57,7 +57,7 @@ describe "Sticky locals (_file_ and friends)" do
     pry_eval('file-and-dir-test', 'cd 0', '_dir_').
       should =~ /\/blah/
 
-    Pry.commands.delete "file-and-dir-test"
+    Pry.config.commands.delete "file-and-dir-test"
   end
 
   it 'locals should return last result (_)' do


### PR DESCRIPTION
We should hardly ever be reading from the global config, so this makes it easy to grep for bugs. It should be a total no-op in terms of functionality.
