### PR TITLE
Overwrite CodeRay's comment color.

### DIFF
--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -10,6 +10,8 @@ class Pry
       end
     end
 
+    CodeRay::Encoders::Terminal::TOKEN_COLORS[:comment][:self] = "\e[1;34m"
+
     def self.pp(obj, out = $>, width = 79)
       q = ColorPrinter.new(out, width)
       q.guard_inspect_key { q.pp obj }


### PR DESCRIPTION
From 30m(black) to 34m(blue). Fix #1061.
