### PR TITLE
Added unit test for reload_object

### DIFF
--- a/spec/commands/reload_code_spec.rb
+++ b/spec/commands/reload_code_spec.rb
@@ -1,12 +1,18 @@
 require_relative '../helper'
 
 describe "reload_code" do
+
+  before do
+    @some_class = Class.new
+    @command_error = Pry::CommandError
+  end
+
   describe "reload_current_file" do
     it 'raises an error source code not found' do
       proc do
         pry_eval(
           "reload-code")
-      end.should.raise(Pry::CommandError).message.should =~ /cannot be found on disk!/
+      end.should.raise(@command_error).message.should =~ /cannot be found on disk!/
     end
 
     it 'raises an error when class not found' do
@@ -14,7 +20,34 @@ describe "reload_code" do
         pry_eval(
           "cd Class.new(Class.new{ def goo; end; public :goo })",
           "reload-code")
-      end.should.raise(Pry::CommandError).message.should =~ /Cannot locate self/
+      end.should.raise(@command_error).message.should =~ /Cannot locate self/
+    end
+  end
+
+  describe "reload_object" do
+    context = {
+      :target => binding,
+      :output => StringIO.new,
+      :pry_instance => Object.new,
+      :reload_code => Pry::Command::ReloadCode.new,
+      :code_object => Pry::CodeObject,
+      :some_class => Class.new
+    }
+
+    before do
+      context[:reload_code].stubs(:args).returns([])
+      context[:reload_code].stubs(:check_for_reloadability).returns(true)
+      context[:target].stubs(:eval).returns(Class)
+      context[:reload_code].stubs(:target).returns(context[:target])
+      context[:reload_code].stubs(:load)
+      context[:reload_code].stubs(:output).returns(context[:pry_instance])
+    end
+
+    it 'loads code_object and outputs success message' do
+      context[:code_object].expects(:lookup).returns(@some_class)
+      @some_class.expects(:source_file)
+      context[:pry_instance].expects(:puts).with("self was reloaded!")
+      context[:reload_code].process
     end
   end
 end


### PR DESCRIPTION
Added test for Pry::Command::ReloadCode#reload_code in response to https://github.com/pry/pry/issues/1204

`reload_code` was actually called from another test in this file so it was technically tested. This extra test covers all of the paths and tests `reload_code` more thoroughly. It's a private method so I had to call it via `process` thus I had to do quite a bit of stubbing. Open to suggestions if anyone can suggest a cleaner way. 
