### PR TITLE
Set architecture to "universal" for Windows (fix #934)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -82,11 +82,11 @@ namespace :jruby do
 end
 
 
-[:mingw32, :mswin32].each do |v|
-  namespace v do
+[:mingw32, :mswin32].each do |platform|
+  namespace platform do
     spec = modify_base_gemspec do |s|
       s.add_dependency('win32console', '~> 1.3')
-      s.platform = "i386-#{v}"
+      s.platform = Gem::Platform.new(['universal', platform])
     end
 
     Gem::PackageTask.new(spec) do |pkg|


### PR DESCRIPTION
This is based on this commit:

  https://github.com/djberg96/win32-api/commit/ceb47f0eb48e

It should fix the issue where we were only building i386-specific gems
for Windows.
