### PR TITLE
Added tests for Pry::Command::ReloadCode#reload_object and Pry::Command:...

### DIFF
--- a/spec/commands/reload_code_spec.rb
+++ b/spec/commands/reload_code_spec.rb
@@ -17,5 +17,16 @@ describe "reload_code" do
           "reload-code")
       end.should.raise(Pry::CommandError)
     end
+
+    it 'reloads pry commmand' do
+      pry_eval("reload-code reload-code").should =~ /reload-code was reloaded!/
+    end
+
+    it 'raises an error when pry command not found' do
+      proc do
+        pry_eval(
+          "reload-code not-a-real-command")
+      end.should.raise(Pry::CommandError).message.should =~ /Cannot locate not-a-real-command!/
+    end
   end
 end


### PR DESCRIPTION
...:ReloadCode#process

Added test for Pry::Command::ReloadCode#reload_code and Pry::Command::ReloadCode#process in response to #1204

Used `pry_eval` to make test simpler and more robust, as advised by @ConradIrwin in https://github.com/pry/pry/pull/1212.

reload_code_spec.rb now tests all paths of `process` and tests `reload-code`.
