### PR TITLE
Using licenses instead of license

### DIFF
--- a/pry.gemspec
+++ b/pry.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary = "An IRB alternative and runtime developer console"
   s.description = s.summary
   s.homepage = "http://pryrepl.org"
-  s.license = 'MIT'
+  s.licenses = ['MIT']
 
   s.executables   = ["pry"]
   s.require_paths = ["lib"]


### PR DESCRIPTION
#1238

s.license isn't used by rubygems.org for some reason, s.licenses is.
