### PR TITLE
Remove deprecation warning for File.exists?

### DIFF
--- a/lib/pry/method/weird_method_locator.rb
+++ b/lib/pry/method/weird_method_locator.rb
@@ -164,7 +164,7 @@ class Pry
       end
 
       def valid_file?(file)
-        (File.exists?(file) && !File.directory?(file)) || Pry.eval_path == file
+        (File.exist?(file) && !File.directory?(file)) || Pry.eval_path == file
       end
 
       def lines_for_file(file)


### PR DESCRIPTION
Rspec 3.0 + Ruby 2.1.1 raises deprecation warning `warning: File.exists? is a deprecated name, use File.exist? instead`
