### PR TITLE
Ensure that pry_instance doesn't pass nil to +=

### DIFF
--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -503,7 +503,7 @@ class Pry
     @input_array << code
     if code
       Pry.line_buffer.push(*code.each_line)
-      Pry.current_line += code.each_line.count
+      Pry.current_line += code.lines.count
     end
   end
 


### PR DESCRIPTION
When I ran `pry` within a Rails console, I'd keep getting `TypeError: nil can't be coerced into Fixnum` after each entry in the REPL.

The offending code in `lib/pry/pry_instance.rb` allowed for `nil` to be passed to `+=` which triggered the error.

This pull request simply checks whether `codes.each_lines` is empty before passing it to `+=`.

All tests pass, and this eliminates the error in my Rails console ([running Rails 4.1.1 on Ruby 2.1.2p95](https://github.com/18F/answers)). Nevertheless, I'm not well acquainted with the codebase here, so any guidance or feedback to make edits would be greatly appreciated.
