### PR TITLE
Clean up ambiguous method warnings

### DIFF
--- a/lib/pry/commands/bang.rb
+++ b/lib/pry/commands/bang.rb
@@ -1,6 +1,6 @@
 class Pry
   class Command::Bang < Pry::ClassCommand
-    match /^\s*!\s*$/
+    match(/^\s*!\s*$/)
     group 'Editing'
     description 'Clear the input buffer.'
     command_options :use_prefix => false

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -711,7 +711,7 @@ describe "Pry::Command" do
 
         it "equals to :match option's inspect, if :match is Regexp" do
           class CoolWinter < Pry::ClassCommand
-            match /.*winter/
+            match(/.*winter/)
             description 'Is winter cool or cool?'
           end
           Pry.config.commands.add_command CoolWinter


### PR DESCRIPTION
When running with Ruby warnings, these usages of `#match` are ambiguous,
but can be made explicit with parens.
