### PR TITLE
Explicitly declare the required Ruby version

### DIFF
--- a/pry.gemspec
+++ b/pry.gemspec
@@ -5,6 +5,8 @@ Gem::Specification.new do |s|
   s.name    = "pry"
   s.version = Pry::VERSION
 
+  s.required_ruby_version = '>= 1.9.3'
+
   s.authors = ["John Mair (banisterfiend)", "Conrad Irwin", "Ryan Fitzgerald"]
   s.email = ["jrmair@gmail.com", "conrad.irwin@gmail.com", "rwfitzge@gmail.com"]
   s.summary = "An IRB alternative and runtime developer console"


### PR DESCRIPTION
:information_desk_person: While this library uses 1.9 specific syntax*, the Ruby version dependency isn't explicitly declared. This change adds a declaration for this.
- e.g. `lib/pry.rb:39`

``` ruby
    output.puts Pry.view_clip(value, id: true)
```
