### PR TITLE
Print the bacon command when user has explicitly set Rake's verbose option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,9 +10,11 @@ CLEAN.include('**/*#*', '**/*#*.*', '**/*_flymake*.*', '**/*_flymake', '**/*.rbc
 desc "Set up and run tests"
 task :default => [:test]
 
-def run_specs paths
-  quiet = ENV['VERBOSE'] ? '' : '-q'
-  exec "bacon -Ispec -rubygems #{quiet} #{paths.join ' '}"
+def self.run_specs paths
+  quiet   = ENV['VERBOSE'] ? '' : '-q'
+  command = "bacon -Ispec -rubygems #{quiet} #{paths.join ' '}"
+  $stderr.puts command if Rake::FileUtilsExt.verbose_flag.equal?(true)
+  exec command
 end
 
 desc "Run tests"


### PR DESCRIPTION
Explicitly check true as verbose defaults to a unique object:
https://github.com/ruby/ruby/blob/8f0543a364e0f90623eb893294ea9301a3d7826f/lib/rake/file_utils_ext.rb#L16-18

This leaves setting the VERBOSE environment variable to determine
which bacon formatter to use. Seems kind of confusing, that there
are two verbose options, but this convention already exists in pry,
so seems reasonable not to change it. And calling --verbose already
exists in Rake, so was surprising when it didn't print the command.
Seems like this is most reasonable way to support both without bigger
changes that I don't understand the impact of.

Also, methods defined in Rakefile execute in context of main,
so make run_specs a singleton method instead of puting it on object.
