### PR TITLE
Issue 1269 patching methods

### DIFF
--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -72,7 +72,7 @@ class Pry
     end
 
     def runtime_patch?
-       !file_based_exception? && (opts.present?(:patch) || previously_patched?(code_object))
+       !file_based_exception? && (opts.present?(:patch) || previously_patched?(code_object) || pry_method?(code_object))
     end
 
     def apply_runtime_patch


### PR DESCRIPTION
Fixes #1269

I don't go with either of my ideas there, just instead force previously patched methods to be patched in future (the dynamic thing was iffy b/c, for example, it would try to patch `(eval)`)
