### PR TITLE
Fix for Rubinius

### DIFF
--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -107,6 +107,10 @@ class Pry
     def singleton_class?
       if Pry::Method.safe_send(wrapped, :respond_to?, :singleton_class?)
         Pry::Method.safe_send(wrapped, :singleton_class?)
+      elsif defined?(Rubinius)
+        # https://github.com/rubinius/rubinius/commit/2e71722dba53d1a92c54d5e3968d64d1042486fe singleton_class? added 30 Jul 2014
+        # https://github.com/rubinius/rubinius/commit/4310f6b2ef3c8fc88135affe697db4e29e4621c4 has been around since 2011
+        !!Rubinius::Type.singleton_class_object(wrapped)
       else
         wrapped != Pry::Method.safe_send(wrapped, :ancestors).first
       end


### PR DESCRIPTION
## Problem

Currently, CI is failing b/c singleton_class? was added to MRI2.1 but not Rbx. e.g. https://travis-ci.org/pry/pry/builds/32133642

I did not look into why it is suddenly failing now. For quite a while, Rbx builds were erroring out (e.g.  https://travis-ci.org/pry/pry/jobs/30421343) They are no longer erroring, but are now failing, for the above reason.
## Context

Rbx has recently (11 days ago, 30 July 2014) received this method https://github.com/rubinius/rubinius/commit/2e71722dba53d1a92c54d5e3968d64d1042486fe

But the functionality has been available since April 2011 https://github.com/rubinius/rubinius/commit/4310f6b2ef3c8fc88135affe697db4e29e4621c4
## Solution

Fix the failures by falling back to the older functionality if we are on Rubinius, and the new method is unavailable.
