### PR TITLE
Changes a faulty fail_msg

### DIFF
--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -484,7 +484,7 @@ class Pry
       else
         fail_msg = "Cannot locate this method: #{name}."
         if mri?
-          fail_msg += ' Try `gem-install pry-doc` to get access to Ruby Core documentation.'
+          fail_msg += ' Try `gem install pry-doc` to get access to Ruby Core documentation.'
         end
         raise CommandError, fail_msg
       end


### PR DESCRIPTION
was ‘gem-install pry-doc’
to  ‘gem install pry-doc’
