### PR TITLE
Refactor jump_to and its spec

### DIFF
--- a/lib/pry/commands/jump_to.rb
+++ b/lib/pry/commands/jump_to.rb
@@ -9,18 +9,14 @@ class Pry
     BANNER
 
     def process(break_level)
-      break_level = break_level.to_i
-      nesting_level = _pry_.binding_stack.size - 1
+      break_level    = break_level.to_i
+      nesting_level  = _pry_.binding_stack.size - 1
+      max_nest_level = nesting_level - 1
 
       case break_level
-      when nesting_level
-        output.puts "Already at nesting level #{nesting_level}"
-      when (0...nesting_level)
-        _pry_.binding_stack.slice!(break_level + 1, _pry_.binding_stack.size)
-
-      else
-        max_nest_level = nesting_level - 1
-        output.puts "Invalid nest level. Must be between 0 and #{max_nest_level}. Got #{break_level}."
+      when nesting_level       then output.puts "Already at nesting level #{nesting_level}"
+      when (0..max_nest_level) then _pry_.binding_stack = _pry_.binding_stack[0..break_level]
+      else                          output.puts "Invalid nest level. Must be between 0 and #{max_nest_level}. Got #{break_level}."
       end
     end
   end

--- a/spec/commands/jump_to_spec.rb
+++ b/spec/commands/jump_to_spec.rb
@@ -1,15 +1,18 @@
-require_relative '../helper'
+require 'helper'
 
-describe "jump-to" do
-  it 'should jump to the proper binding index in the stack' do
-    pry_eval('cd 1', 'cd 2', 'jump-to 1', 'self').should == 1
+RSpec.describe "jump-to" do
+  let(:obj) { Object.new }
+
+  it 'jumps to the proper binding index in the stack' do
+    expect(pry_eval obj, "cd 1", "cd 2", "jump-to 0", 'self').to eq obj
+    expect(pry_eval obj, 'cd 1', 'cd 2', 'jump-to 1', 'self').to eq 1
   end
 
-  it 'should print error when trying to jump to a non-existent binding index' do
-    pry_eval("cd 1", "cd 2", "jump-to 100").should =~ /Invalid nest level/
+  it 'prints an error when trying to jump to the same binding index' do
+    expect(pry_eval obj,  "cd 1", "cd 2", "jump-to 2").to match /Already/
   end
 
-  it 'should print error when trying to jump to the same binding index' do
-    pry_eval("cd 1", "cd 2", "jump-to 2").should =~ /Already/
+  it 'prints error when trying to jump to a non-existent binding index' do
+    expect(pry_eval obj, "cd 1", "cd 2", "jump-to 3").to match /Invalid nest level/
   end
 end


### PR DESCRIPTION
Update jump_to command's spec to RSpec 3 (https://github.com/pry/pry/issues/1294)
Perform some refactorings in lib along the way.