### PR TITLE
fixed Pry::Editor#invoke_editor

### DIFF
--- a/lib/pry/commands/gem_open.rb
+++ b/lib/pry/commands/gem_open.rb
@@ -16,7 +16,7 @@ class Pry
 
     def process(gem)
       Dir.chdir(Rubygem.spec(gem).full_gem_path) do
-        Pry::Editor.invoke_editor(".", 0, false)
+        Pry::Editor.new(_pry_).invoke_editor(".", 0, false)
       end
     end
 


### PR DESCRIPTION
Pry::Editor doesn't have a class method called invoke_editor. Fixed to call on an initialized Pry::Editor instance
