### PR TITLE
Fix edit command on windows

### DIFF
--- a/lib/pry/editor.rb
+++ b/lib/pry/editor.rb
@@ -44,7 +44,7 @@ class Pry
         _pry_.config.editor.call(*args)
       else
         sanitized_file = if windows?
-                            file.gsub(/\//, '\\')
+                            file
                           else
                             Shellwords.escape(file)
                           end

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -43,11 +43,6 @@ describe Pry::Editor do
       end
     end
 
-    it "should replace / by \\" do
-      invocation_str = @editor.build_editor_invocation_string(@tf_path, 5, true)
-      invocation_str.should =~ %r(\\#{@tf_dir.basename}\\)
-    end
-
     it "should not shell-escape files" do
       invocation_str = @editor.build_editor_invocation_string(@tf_path, 5, true)
       invocation_str.should =~ /hello world\.rb/


### PR DESCRIPTION
On (at least) mingw32 the manual replacement of slashes by backslashes which is removed by this PR does not work together with Shellwords.split.

Given the path `C:/foo/bar` is returned from `Pry::Editor#temp_file`. When sanitized in the current implementation it is changed to `C:\foo\bar`.

Within `Pry::Editor#open_editor`, `Shellwords.split` cripples this string to `C:foobar`.

This PR changes this to just pass the Posix-style path to windows, which is able to handle slashes on its own. Tested on Windows 2003, Windows 7, Windows 2012