### PR TITLE
Bulk conversion to expect syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ vendor
 Gemfile.lock
 *.swp
 **/*~
+.idea/

--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -335,6 +335,11 @@ class Pry
     end
     undef =~
 
+    # Check if the output of `#to_s` responds to missing methods.
+    def respond_to_missing?(name, include_all = false)
+      to_s.respond_to?(name, include_all)
+    end
+
     protected
 
     # An abstraction of the `dup.instance_eval` pattern used throughout this

--- a/lib/pry/test/helper.rb
+++ b/lib/pry/test/helper.rb
@@ -73,6 +73,12 @@ module PryTestHelpers
       e.define_singleton_method(:backtrace) { mock_backtrace }
     end
   end
+
+  def inner_scope
+    catch(:inner_scope) do
+      yield ->{ throw(:inner_scope, self) }
+    end
+  end
 end
 
 def pry_tester(*args, &block)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -17,7 +17,7 @@ describe Pry::Hooks do
           # irrelevant
         end
       end.parse_options(argv)
-      argv.include?('-v').should == false
+      expect(argv.include?('-v')).to eq(false)
     end
   end
 
@@ -31,7 +31,7 @@ describe Pry::Hooks do
         end
       end.parse_options(["--optiontest"])
 
-      run.should == true
+      expect(run).to eq(true)
     end
 
     it "should be able to add multiple options" do
@@ -48,8 +48,8 @@ describe Pry::Hooks do
         end
       end.parse_options(["--optiontest", "--optiontest2"])
 
-      run.should equal true
-      run2.should equal true
+      expect(run).to equal true
+      expect(run2).to equal true
     end
 
   end
@@ -64,7 +64,7 @@ describe Pry::Hooks do
         run = true if opts.present?(:optiontest)
       end.parse_options(["--optiontest"])
 
-      run.should == true
+      expect(run).to eq(true)
     end
 
     it "should be able to  process multiple options" do
@@ -80,8 +80,8 @@ describe Pry::Hooks do
         run2 = true if opts.present?(:optiontest2)
       end.parse_options(["--optiontest", "--optiontest2"])
 
-      run.should == true
-      run2.should == true
+      expect(run).to eq(true)
+      expect(run2).to eq(true)
     end
 
   end

--- a/spec/code_object_spec.rb
+++ b/spec/code_object_spec.rb
@@ -24,22 +24,22 @@ describe Pry::CodeObject do
 
     it 'should lookup methods' do
       m = Pry::CodeObject.lookup("@obj.ziggy", @p)
-      m.is_a?(Pry::Method).should == true
-      m.name.to_sym.should == :ziggy
+      expect(m.is_a?(Pry::Method)).to eq(true)
+      expect(m.name.to_sym).to eq(:ziggy)
     end
 
     it 'should lookup modules' do
       m = Pry::CodeObject.lookup("ClassyWassy", @p)
-      m.is_a?(Pry::WrappedModule).should == true
-      m.source.should =~ /piggy/
+      expect(m.is_a?(Pry::WrappedModule)).to eq(true)
+      expect(m.source).to match(/piggy/)
     end
 
     it 'should lookup procs' do
       my_proc = proc { :hello }
       @p.binding_stack = [binding]
       m = Pry::CodeObject.lookup("my_proc", @p)
-      m.is_a?(Pry::Method).should == true
-      m.source.should =~ /hello/
+      expect(m.is_a?(Pry::Method)).to eq(true)
+      expect(m.source).to match(/hello/)
     end
 
     describe 'commands lookup' do
@@ -53,8 +53,8 @@ describe Pry::CodeObject do
           "lobster"
         end
         m = Pry::CodeObject.lookup("jeremy-jones", @p)
-        (m <= Pry::Command).should == true
-        m.source.should =~ /lobster/
+        expect(m <= Pry::Command).to eq(true)
+        expect(m.source).to match(/lobster/)
       end
 
       describe "class commands" do
@@ -75,16 +75,16 @@ describe Pry::CodeObject do
         it 'should return Pry::ClassCommand class when looking up class command' do
           Pry.config.commands.add_command(LobsterLady)
           m = Pry::CodeObject.lookup("lobster-lady", @p)
-          (m <= Pry::ClassCommand).should == true
-          m.source.should =~ /class LobsterLady/
+          expect(m <= Pry::ClassCommand).to eq(true)
+          expect(m.source).to match(/class LobsterLady/)
           Pry.config.commands.delete("lobster-lady")
         end
 
         it 'should return Pry::WrappedModule when looking up command class directly (as a class, not as a command)' do
           Pry.config.commands.add_command(LobsterLady)
           m = Pry::CodeObject.lookup("LobsterLady", @p)
-          m.is_a?(Pry::WrappedModule).should == true
-          m.source.should =~ /class LobsterLady/
+          expect(m.is_a?(Pry::WrappedModule)).to eq(true)
+          expect(m.source).to match(/class LobsterLady/)
           Pry.config.commands.delete("lobster-lady")
         end
       end
@@ -94,12 +94,12 @@ describe Pry::CodeObject do
           "lobster"
         end
         m = Pry::CodeObject.lookup("jeremy-baby", @p)
-        (m <= Pry::Command).should == true
-        m.source.should =~ /lobster/
+        expect(m <= Pry::Command).to eq(true)
+        expect(m.source).to match(/lobster/)
       end
 
       it 'finds nothing when passing nil as the first argument' do
-        Pry::CodeObject.lookup(nil, @p).should == nil
+        expect(Pry::CodeObject.lookup(nil, @p)).to eq(nil)
       end
 
     end
@@ -113,8 +113,8 @@ describe Pry::CodeObject do
 
       @p.binding_stack = [binding]
       m = Pry::CodeObject.lookup("o#princess_bubblegum", @p)
-      m.is_a?(Pry::Method).should == true
-      m.source.should =~ /mathematic!/
+      expect(m.is_a?(Pry::Method)).to eq(true)
+      expect(m.source).to match(/mathematic!/)
     end
 
     it 'should lookup class methods defined on classes accessed via local variable' do
@@ -125,16 +125,16 @@ describe Pry::CodeObject do
       end
       @p.binding_stack = [binding]
       m = Pry::CodeObject.lookup("o.finn", @p)
-      m.is_a?(Pry::Method).should == true
-      m.source.should =~ /4 realzies/
+      expect(m.is_a?(Pry::Method)).to eq(true)
+      expect(m.source).to match(/4 realzies/)
     end
 
     it 'should lookup the class of an object (when given a variable)' do
       moddy = ClassyWassy.new
       @p.binding_stack = [binding]
       m = Pry::CodeObject.lookup("moddy", @p)
-      m.is_a?(Pry::WrappedModule).should == true
-      m.source.should =~ /piggy/
+      expect(m.is_a?(Pry::WrappedModule)).to eq(true)
+      expect(m.source).to match(/piggy/)
     end
 
     describe "inferring object from binding when lookup str is empty/nil" do
@@ -148,8 +148,8 @@ describe Pry::CodeObject do
           ["", nil].each do |v|
             @p.binding_stack = [@b1]
             m = Pry::CodeObject.lookup(v, @p)
-            m.is_a?(Pry::WrappedModule).should == true
-            m.name.should =~ /ClassyWassy/
+            expect(m.is_a?(Pry::WrappedModule)).to eq(true)
+            expect(m.name).to match(/ClassyWassy/)
           end
         end
 
@@ -157,8 +157,8 @@ describe Pry::CodeObject do
           ["", nil].each do |v|
             @p.binding_stack = [@b2]
             m = Pry::CodeObject.lookup(v, @p)
-            m.is_a?(Pry::WrappedModule).should == true
-            m.name.should =~ /ClassyWassy/
+            expect(m.is_a?(Pry::WrappedModule)).to eq(true)
+            expect(m.name).to match(/ClassyWassy/)
           end
         end
       end
@@ -170,8 +170,8 @@ describe Pry::CodeObject do
           ["", nil].each do |v|
             @p.binding_stack = [b]
             m = Pry::CodeObject.lookup(v, @p)
-            m.is_a?(Pry::Method).should == true
-            m.name.should =~ /piggy/
+            expect(m.is_a?(Pry::Method)).to eq(true)
+            expect(m.name).to match(/piggy/)
           end
         end
       end
@@ -193,14 +193,14 @@ describe Pry::CodeObject do
 
     it 'should lookup original class with :super => 0' do
       m = Pry::CodeObject.lookup("CuteSubclass", @p, :super => 0)
-      m.is_a?(Pry::WrappedModule).should == true
-      m.wrapped.should == CuteSubclass
+      expect(m.is_a?(Pry::WrappedModule)).to eq(true)
+      expect(m.wrapped).to eq(CuteSubclass)
     end
 
     it 'should lookup immediate super class with :super => 1' do
       m = Pry::CodeObject.lookup("CuteSubclass", @p, :super => 1)
-      m.is_a?(Pry::WrappedModule).should == true
-      m.wrapped.should == MyClassyWassy
+      expect(m.is_a?(Pry::WrappedModule)).to eq(true)
+      expect(m.wrapped).to eq(MyClassyWassy)
     end
 
     it 'should ignore :super parameter for commands' do
@@ -210,7 +210,7 @@ describe Pry::CodeObject do
       end
       p.binding_stack = [binding]
       m = Pry::CodeObject.lookup("jeremy-jones", p, :super => 10)
-      m.source.should =~ /lobster/
+      expect(m.source).to match(/lobster/)
     end
   end
 
@@ -246,20 +246,20 @@ describe Pry::CodeObject do
 
     it 'should look up classes before methods (at top-level)' do
       m = Pry::CodeObject.lookup("ClassyWassy", @p)
-      m.is_a?(Pry::WrappedModule).should == true
-      m.source.should =~ /piggy/
+      expect(m.is_a?(Pry::WrappedModule)).to eq(true)
+      expect(m.source).to match(/piggy/)
     end
 
     it 'should look up methods before classes when ending in () (at top-level)' do
       m = Pry::CodeObject.lookup("ClassyWassy()", @p)
-      m.is_a?(Pry::Method).should == true
-      m.source.should =~ /ducky/
+      expect(m.is_a?(Pry::Method)).to eq(true)
+      expect(m.source).to match(/ducky/)
     end
 
     it 'should look up classes before methods when namespaced' do
       m = Pry::CodeObject.lookup("ClassyWassy::Puff", @p)
-      m.is_a?(Pry::WrappedModule).should == true
-      m.source.should =~ /tiggy/
+      expect(m.is_a?(Pry::WrappedModule)).to eq(true)
+      expect(m.source).to match(/tiggy/)
     end
 
     it 'should look up locals before methods' do
@@ -267,7 +267,7 @@ describe Pry::CodeObject do
       b.eval("piggy = Puff.new")
       @p.binding_stack = [b]
       o = Pry::CodeObject.lookup("piggy", @p)
-      o.is_a?(Pry::WrappedModule).should == true
+      expect(o.is_a?(Pry::WrappedModule)).to eq(true)
     end
 
     # actually locals are never looked up (via co.default_lookup)  when they're classes, it
@@ -276,8 +276,8 @@ describe Pry::CodeObject do
       c = ClassyWassy
       @p.binding_stack = [binding]
       o = Pry::CodeObject.lookup("c", @p)
-      o.is_a?(Pry::WrappedModule).should == true
-      o.wrapped.should == ClassyWassy
+      expect(o.is_a?(Pry::WrappedModule)).to eq(true)
+      expect(o.wrapped).to eq(ClassyWassy)
     end
   end
 end

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -3,23 +3,23 @@ require_relative 'helper'
 describe Pry::Code do
   describe '.from_file' do
     specify 'read lines from a file on disk' do
-      Pry::Code.from_file('lib/pry.rb').length.should > 0
+      expect(Pry::Code.from_file('lib/pry.rb').length).to be > 0
     end
 
     specify 'read lines from Pry\'s line buffer' do
       pry_eval ':hay_guys'
-      Pry::Code.from_file('(pry)').grep(/:hay_guys/).length.should == 1
+      expect(Pry::Code.from_file('(pry)').grep(/:hay_guys/).length).to eq(1)
     end
 
     specify 'default to unknown' do
       temp_file('') do |f|
-        Pry::Code.from_file(f.path).code_type.should == :unknown
+        expect(Pry::Code.from_file(f.path).code_type).to eq(:unknown)
       end
     end
 
     specify 'check the extension' do
       temp_file('.c') do |f|
-        Pry::Code.from_file(f.path).code_type.should == :c
+        expect(Pry::Code.from_file(f.path).code_type).to eq(:c)
       end
     end
 
@@ -31,19 +31,19 @@ describe Pry::Code do
 
     specify 'check for files relative to origin pwd' do
       Dir.chdir('spec') do |f|
-        Pry::Code.from_file('spec/' + File.basename(__FILE__)).code_type.should == :ruby
+        expect(Pry::Code.from_file('spec/' + File.basename(__FILE__)).code_type).to eq(:ruby)
       end
     end
 
     specify 'check for Ruby files relative to origin pwd with `.rb` omitted' do
       Dir.chdir('spec') do |f|
-        Pry::Code.from_file('spec/' + File.basename(__FILE__, '.*')).code_type.should == :ruby
+        expect(Pry::Code.from_file('spec/' + File.basename(__FILE__, '.*')).code_type).to eq(:ruby)
       end
     end
 
     specify 'find files that are relative to the current working directory' do
       Dir.chdir('spec') do |f|
-        Pry::Code.from_file(File.basename(__FILE__)).code_type.should == :ruby
+        expect(Pry::Code.from_file(File.basename(__FILE__)).code_type).to eq(:ruby)
       end
     end
 
@@ -57,27 +57,27 @@ describe Pry::Code do
       end
 
       it 'finds files with `.rb` extension' do
-        Pry::Code.from_file('slinky.rb').code_type.should == :ruby
+        expect(Pry::Code.from_file('slinky.rb').code_type).to eq(:ruby)
       end
 
       it 'finds files with `.rb` omitted' do
-        Pry::Code.from_file('slinky').code_type.should == :ruby
+        expect(Pry::Code.from_file('slinky').code_type).to eq(:ruby)
       end
 
       it 'finds files in a relative directory with `.rb` extension' do
-        Pry::Code.from_file('../helper.rb').code_type.should == :ruby
+        expect(Pry::Code.from_file('../helper.rb').code_type).to eq(:ruby)
       end
 
       it 'finds files in a relative directory with `.rb` omitted' do
-        Pry::Code.from_file('../helper').code_type.should == :ruby
+        expect(Pry::Code.from_file('../helper').code_type).to eq(:ruby)
       end
 
       it "doesn't confuse files with the same name, but without an extension" do
-        Pry::Code.from_file('cat_load_path').code_type.should == :unknown
+        expect(Pry::Code.from_file('cat_load_path').code_type).to eq(:unknown)
       end
 
       it "doesn't confuse files with the same name, but with an extension" do
-        Pry::Code.from_file('cat_load_path.rb').code_type.should == :ruby
+        expect(Pry::Code.from_file('cat_load_path.rb').code_type).to eq(:ruby)
       end
     end
   end
@@ -85,7 +85,7 @@ describe Pry::Code do
   describe '.from_method' do
     specify 'read lines from a method\'s definition' do
       m = Pry::Method.from_obj(Pry, :load_history)
-      Pry::Code.from_method(m).length.should > 0
+      expect(Pry::Code.from_method(m).length).to be > 0
     end
   end
 
@@ -101,15 +101,15 @@ describe Pry::Code do
     end
 
     specify 'break a string into lines' do
-      Pry::Code.new(@str).length.should == 3
+      expect(Pry::Code.new(@str).length).to eq(3)
     end
 
     specify 'accept an array' do
-      Pry::Code.new(@array).length.should == 3
+      expect(Pry::Code.new(@array).length).to eq(3)
     end
 
     it 'an array or string specify produce an equivalent object' do
-      Pry::Code.new(@str).should == Pry::Code.new(@array)
+      expect(Pry::Code.new(@str)).to eq(Pry::Code.new(@array))
     end
   end
 
@@ -128,58 +128,58 @@ describe Pry::Code do
       describe '#between' do
         specify 'work with an inclusive range' do
           @code = @code.between(1..3)
-          @code.length.should == 3
-          @code.should =~ /\Aclass MyProgram/
-          @code.should =~ /world!'\Z/
+          expect(@code.length).to eq(3)
+          expect(@code).to match(/\Aclass MyProgram/)
+          expect(@code).to match(/world!'\Z/)
         end
 
         specify 'default to an inclusive range' do
           @code = @code.between(3, 5)
-          @code.length.should == 3
+          expect(@code.length).to eq(3)
         end
 
         specify 'work with an exclusive range' do
           @code = @code.between(2...4)
-          @code.length.should == 2
-          @code.should =~ /\A  def self/
-          @code.should =~ /world!'\Z/
+          expect(@code.length).to eq(2)
+          expect(@code).to match(/\A  def self/)
+          expect(@code).to match(/world!'\Z/)
         end
 
         specify 'use real line numbers for positive indices' do
           @code = @code.after(3, 3)
           @code = @code.between(4, 4)
-          @code.length.should == 1
-          @code.should =~ /\A  end\Z/
+          expect(@code.length).to eq(1)
+          expect(@code).to match(/\A  end\Z/)
         end
       end
 
       describe '#before' do
         specify 'work' do
           @code = @code.before(3, 1)
-          @code.should =~ /\A  def self\.main\Z/
+          expect(@code).to match(/\A  def self\.main\Z/)
         end
       end
 
       describe '#around' do
         specify 'work' do
           @code = @code.around(3, 1)
-          @code.length.should == 3
-          @code.should =~ /\A  def self/
-          @code.should =~ /  end\Z/
+          expect(@code.length).to eq(3)
+          expect(@code).to match(/\A  def self/)
+          expect(@code).to match(/  end\Z/)
         end
       end
 
       describe '#after' do
         specify 'work' do
           @code = @code.after(3, 1)
-          @code.should =~ /\A  end\Z/
+          expect(@code).to match(/\A  end\Z/)
         end
       end
 
       describe '#grep' do
         specify 'work' do
           @code = @code.grep(/end/)
-          @code.length.should == 2
+          expect(@code.length).to eq(2)
         end
       end
     end
@@ -188,39 +188,39 @@ describe Pry::Code do
       describe '#with_line_numbers' do
         specify 'show line numbers' do
           @code = @code.with_line_numbers
-          @code.should =~ /1:/
+          expect(@code).to match(/1:/)
         end
 
         specify 'disable line numbers when falsy' do
           @code = @code.with_line_numbers
           @code = @code.with_line_numbers(false)
-          @code.should_not =~ /1:/
+          expect(@code).not_to match(/1:/)
         end
       end
 
       describe '#with_marker' do
         specify 'show a marker in the right place' do
           @code = @code.with_marker(2)
-          @code.should =~ /^ =>   def self/
+          expect(@code).to match(/^ =>   def self/)
         end
 
         specify 'disable the marker when falsy' do
           @code = @code.with_marker(2)
           @code = @code.with_marker(false)
-          @code.should =~ /^  def self/
+          expect(@code).to match(/^  def self/)
         end
       end
 
       describe '#with_indentation' do
         specify 'indent the text' do
           @code = @code.with_indentation(2)
-          @code.should =~ /^    def self/
+          expect(@code).to match(/^    def self/)
         end
 
         specify 'disable the indentation when falsy' do
           @code = @code.with_indentation(2)
           @code = @code.with_indentation(false)
-          @code.should =~ /^  def self/
+          expect(@code).to match(/^  def self/)
         end
       end
     end
@@ -229,23 +229,23 @@ describe Pry::Code do
       describe 'grep and with_line_numbers' do
         specify 'work' do
           @code = @code.grep(/end/).with_line_numbers
-          @code.should =~ /\A4:   end/
-          @code.should =~ /5: end\Z/
+          expect(@code).to match(/\A4:   end/)
+          expect(@code).to match(/5: end\Z/)
         end
       end
 
       describe 'grep and before and with_line_numbers' do
         specify 'work' do
           @code = @code.grep(/e/).before(5, 5).with_line_numbers
-          @code.should =~ /\A2:   def self.main\n3:/
-          @code.should =~ /4:   end\Z/
+          expect(@code).to match(/\A2:   def self.main\n3:/)
+          expect(@code).to match(/4:   end\Z/)
         end
       end
 
       describe 'before and after' do
         specify 'work' do
           @code = @code.before(4, 2).after(2)
-          @code.should == "    puts 'Hello, world!'"
+          expect(@code).to eq("    puts 'Hello, world!'")
         end
       end
     end

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -2,46 +2,46 @@ require_relative 'helper'
 
 describe Pry::Code do
   describe '.from_file' do
-    should 'read lines from a file on disk' do
+    specify 'read lines from a file on disk' do
       Pry::Code.from_file('lib/pry.rb').length.should > 0
     end
 
-    should 'read lines from Pry\'s line buffer' do
+    specify 'read lines from Pry\'s line buffer' do
       pry_eval ':hay_guys'
       Pry::Code.from_file('(pry)').grep(/:hay_guys/).length.should == 1
     end
 
-    should 'default to unknown' do
+    specify 'default to unknown' do
       temp_file('') do |f|
         Pry::Code.from_file(f.path).code_type.should == :unknown
       end
     end
 
-    should 'check the extension' do
+    specify 'check the extension' do
       temp_file('.c') do |f|
         Pry::Code.from_file(f.path).code_type.should == :c
       end
     end
 
-    should 'raise an error if the file doesn\'t exist' do
+    specify 'raise an error if the file doesn\'t exist' do
       expect do
         Pry::Code.from_file('/knalkjsdnalsd/alkjdlkq')
       end.to raise_error MethodSource::SourceNotFoundError
     end
 
-    should 'check for files relative to origin pwd' do
+    specify 'check for files relative to origin pwd' do
       Dir.chdir('spec') do |f|
         Pry::Code.from_file('spec/' + File.basename(__FILE__)).code_type.should == :ruby
       end
     end
 
-    should 'check for Ruby files relative to origin pwd with `.rb` omitted' do
+    specify 'check for Ruby files relative to origin pwd with `.rb` omitted' do
       Dir.chdir('spec') do |f|
         Pry::Code.from_file('spec/' + File.basename(__FILE__, '.*')).code_type.should == :ruby
       end
     end
 
-    should 'find files that are relative to the current working directory' do
+    specify 'find files that are relative to the current working directory' do
       Dir.chdir('spec') do |f|
         Pry::Code.from_file(File.basename(__FILE__)).code_type.should == :ruby
       end
@@ -83,7 +83,7 @@ describe Pry::Code do
   end
 
   describe '.from_method' do
-    should 'read lines from a method\'s definition' do
+    specify 'read lines from a method\'s definition' do
       m = Pry::Method.from_obj(Pry, :load_history)
       Pry::Code.from_method(m).length.should > 0
     end
@@ -100,15 +100,15 @@ describe Pry::Code do
       @array = ['def hay', '  :guys', 'end']
     end
 
-    should 'break a string into lines' do
+    specify 'break a string into lines' do
       Pry::Code.new(@str).length.should == 3
     end
 
-    should 'accept an array' do
+    specify 'accept an array' do
       Pry::Code.new(@array).length.should == 3
     end
 
-    it 'an array or string should produce an equivalent object' do
+    it 'an array or string specify produce an equivalent object' do
       Pry::Code.new(@str).should == Pry::Code.new(@array)
     end
   end
@@ -126,26 +126,26 @@ describe Pry::Code do
 
     describe 'filters' do
       describe '#between' do
-        should 'work with an inclusive range' do
+        specify 'work with an inclusive range' do
           @code = @code.between(1..3)
           @code.length.should == 3
           @code.should =~ /\Aclass MyProgram/
           @code.should =~ /world!'\Z/
         end
 
-        should 'default to an inclusive range' do
+        specify 'default to an inclusive range' do
           @code = @code.between(3, 5)
           @code.length.should == 3
         end
 
-        should 'work with an exclusive range' do
+        specify 'work with an exclusive range' do
           @code = @code.between(2...4)
           @code.length.should == 2
           @code.should =~ /\A  def self/
           @code.should =~ /world!'\Z/
         end
 
-        should 'use real line numbers for positive indices' do
+        specify 'use real line numbers for positive indices' do
           @code = @code.after(3, 3)
           @code = @code.between(4, 4)
           @code.length.should == 1
@@ -154,14 +154,14 @@ describe Pry::Code do
       end
 
       describe '#before' do
-        should 'work' do
+        specify 'work' do
           @code = @code.before(3, 1)
           @code.should =~ /\A  def self\.main\Z/
         end
       end
 
       describe '#around' do
-        should 'work' do
+        specify 'work' do
           @code = @code.around(3, 1)
           @code.length.should == 3
           @code.should =~ /\A  def self/
@@ -170,14 +170,14 @@ describe Pry::Code do
       end
 
       describe '#after' do
-        should 'work' do
+        specify 'work' do
           @code = @code.after(3, 1)
           @code.should =~ /\A  end\Z/
         end
       end
 
       describe '#grep' do
-        should 'work' do
+        specify 'work' do
           @code = @code.grep(/end/)
           @code.length.should == 2
         end
@@ -186,12 +186,12 @@ describe Pry::Code do
 
     describe 'formatters' do
       describe '#with_line_numbers' do
-        should 'show line numbers' do
+        specify 'show line numbers' do
           @code = @code.with_line_numbers
           @code.should =~ /1:/
         end
 
-        should 'disable line numbers when falsy' do
+        specify 'disable line numbers when falsy' do
           @code = @code.with_line_numbers
           @code = @code.with_line_numbers(false)
           @code.should_not =~ /1:/
@@ -199,12 +199,12 @@ describe Pry::Code do
       end
 
       describe '#with_marker' do
-        should 'show a marker in the right place' do
+        specify 'show a marker in the right place' do
           @code = @code.with_marker(2)
           @code.should =~ /^ =>   def self/
         end
 
-        should 'disable the marker when falsy' do
+        specify 'disable the marker when falsy' do
           @code = @code.with_marker(2)
           @code = @code.with_marker(false)
           @code.should =~ /^  def self/
@@ -212,12 +212,12 @@ describe Pry::Code do
       end
 
       describe '#with_indentation' do
-        should 'indent the text' do
+        specify 'indent the text' do
           @code = @code.with_indentation(2)
           @code.should =~ /^    def self/
         end
 
-        should 'disable the indentation when falsy' do
+        specify 'disable the indentation when falsy' do
           @code = @code.with_indentation(2)
           @code = @code.with_indentation(false)
           @code.should =~ /^  def self/
@@ -227,7 +227,7 @@ describe Pry::Code do
 
     describe 'composition' do
       describe 'grep and with_line_numbers' do
-        should 'work' do
+        specify 'work' do
           @code = @code.grep(/end/).with_line_numbers
           @code.should =~ /\A4:   end/
           @code.should =~ /5: end\Z/
@@ -235,7 +235,7 @@ describe Pry::Code do
       end
 
       describe 'grep and before and with_line_numbers' do
-        should 'work' do
+        specify 'work' do
           @code = @code.grep(/e/).before(5, 5).with_line_numbers
           @code.should =~ /\A2:   def self.main\n3:/
           @code.should =~ /4:   end\Z/
@@ -243,7 +243,7 @@ describe Pry::Code do
       end
 
       describe 'before and after' do
-        should 'work' do
+        specify 'work' do
           @code = @code.before(4, 2).after(2)
           @code.should == "    puts 'Hello, world!'"
         end

--- a/spec/command_helpers_spec.rb
+++ b/spec/command_helpers_spec.rb
@@ -7,23 +7,23 @@ describe Pry::Helpers::CommandHelpers do
 
   describe "unindent" do
     it "should remove the same prefix from all lines" do
-      @helper.unindent(" one\n two\n").should == "one\ntwo\n"
+      expect(@helper.unindent(" one\n two\n")).to eq("one\ntwo\n")
     end
 
     it "should not be phased by empty lines" do
-      @helper.unindent(" one\n\n two\n").should == "one\n\ntwo\n"
+      expect(@helper.unindent(" one\n\n two\n")).to eq("one\n\ntwo\n")
     end
 
     it "should only remove a common prefix" do
-      @helper.unindent("  one\n two\n").should == " one\ntwo\n"
+      expect(@helper.unindent("  one\n two\n")).to eq(" one\ntwo\n")
     end
 
     it "should also remove tabs if present" do
-      @helper.unindent("\tone\n\ttwo\n").should == "one\ntwo\n"
+      expect(@helper.unindent("\tone\n\ttwo\n")).to eq("one\ntwo\n")
     end
 
     it "should ignore lines starting with --" do
-      @helper.unindent(" one\n--\n two\n").should == "one\n--\ntwo\n"
+      expect(@helper.unindent(" one\n--\n two\n")).to eq("one\n--\ntwo\n")
     end
   end
 end

--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -41,7 +41,7 @@ describe "commands" do
       end
 
       pry_tester(:commands => set).tap do |t|
-        t.eval('test-command').should == t.eval('test-alias')
+        expect(t.eval('test-command')).to eq(t.eval('test-alias'))
       end
     end
 
@@ -56,7 +56,7 @@ describe "commands" do
       t = pry_tester(:commands => set)
 
       t.process_command "test-alias hello baby duck"
-      t.last_output.should =~ /testing hello baby duck/
+      expect(t.last_output).to match(/testing hello baby duck/)
     end
 
     it 'should pass option arguments to original' do
@@ -69,7 +69,7 @@ describe "commands" do
       t = pry_tester(obj, :commands => set)
 
       t.process_command "test-alias -i"
-      t.last_output.should =~ /@x/
+      expect(t.last_output).to match(/@x/)
     end
 
     it 'should pass option arguments to original with additional parameters' do
@@ -81,7 +81,7 @@ describe "commands" do
       obj = Class.new { @x = Class.new { define_method(:plymouth) {} } }
       t = pry_tester(obj, :commands => set)
       t.process_command "test-alias @x"
-      t.last_output.should =~ /plymouth/
+      expect(t.last_output).to match(/plymouth/)
     end
 
     it 'should be able to alias a regex command' do
@@ -94,7 +94,7 @@ describe "commands" do
 
       t = pry_tester(:commands => set)
       t.process_command "test-alias"
-      t.last_output.should =~ /ducky/
+      expect(t.last_output).to match(/ducky/)
     end
 
     it 'should be able to make the alias a regex' do
@@ -109,7 +109,7 @@ describe "commands" do
         Pry.start self, :commands => set
       end
 
-      out1.string.should =~ /ducky/
+      expect(out1.string).to match(/ducky/)
     end
   end
 
@@ -127,9 +127,9 @@ describe "commands" do
         Pry.start(@o, :commands => set)
       end
 
-      Pad.bs1.size.should == 7
-      Pad.self.should == @o
-      Pad.bs2.size.should == 1
+      expect(Pad.bs1.size).to eq(7)
+      expect(Pad.self).to eq(@o)
+      expect(Pad.bs2.size).to eq(1)
     end
 
     it 'should allow running of cd command when contained in a single string' do
@@ -144,9 +144,9 @@ describe "commands" do
         Pry.start(@o, :commands => set)
       end
 
-      Pad.bs1.size.should == 7
-      Pad.self.should == @o
-      Pad.bs2.size.should == 1
+      expect(Pad.bs1.size).to eq(7)
+      expect(Pad.self).to eq(@o)
+      expect(Pad.bs2.size).to eq(1)
     end
 
     it 'should allow running of cd command when split into array' do
@@ -161,9 +161,9 @@ describe "commands" do
         Pry.start(@o, :commands => set)
       end
 
-      Pad.bs1.size.should == 7
-      Pad.self.should == @o
-      Pad.bs2.size.should == 1
+      expect(Pad.bs1.size).to eq(7)
+      expect(Pad.self).to eq(@o)
+      expect(Pad.bs2.size).to eq(1)
     end
 
     it 'should run a command from within a command' do
@@ -177,7 +177,7 @@ describe "commands" do
         end
       end
 
-      pry_tester(:commands => klass).eval('run_v').should =~ /v command/
+      expect(pry_tester(:commands => klass).eval('run_v')).to match(/v command/)
     end
 
     it 'should run a regex command from within a command' do
@@ -191,7 +191,7 @@ describe "commands" do
         end
       end
 
-      pry_tester(:commands => klass).eval('run_v').should =~ /v baby/
+      expect(pry_tester(:commands => klass).eval('run_v')).to match(/v baby/)
     end
 
     it 'should run a command from within a command with arguments' do
@@ -210,7 +210,7 @@ describe "commands" do
       end
 
       ["run_v_explicit_parameter", "run_v_embedded_parameter"].each do |cmd|
-        pry_tester(:commands => klass).eval(cmd).should =~ /v baby param/
+        expect(pry_tester(:commands => klass).eval(cmd)).to match(/v baby param/)
       end
     end
   end
@@ -220,14 +220,14 @@ describe "commands" do
       p = Pry.new(:output => @str_output)
       p.eval "def hello\npeter pan\n"
       p.run_command "amend-line !"
-      p.eval_string.should =~ /def hello/
-      p.eval_string.should_not =~ /peter pan/
+      expect(p.eval_string).to match(/def hello/)
+      expect(p.eval_string).not_to match(/peter pan/)
     end
 
     it 'should run a command in the context of a session' do
       pry_tester(Object.new).tap do |t|
         t.eval "@session_ivar = 10", "_pry_.run_command('ls')"
-        t.last_output.should =~ /@session_ivar/
+        expect(t.last_output).to match(/@session_ivar/)
       end
     end
   end
@@ -239,7 +239,7 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => set).eval('hello #{Pad.bong}').should =~ /bong/
+    expect(pry_tester(:commands => set).eval('hello #{Pad.bong}')).to match(/bong/)
   end
 
   # bug fix for https://github.com/pry/pry/issues/170
@@ -248,7 +248,7 @@ describe "commands" do
       pry
     end
 
-    @str_output.string.should_not =~ /SyntaxError/
+    expect(@str_output.string).not_to match(/SyntaxError/)
   end
 
   it 'should NOT interpolate ruby code into commands if :interpolate => false' do
@@ -258,8 +258,8 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => set).eval('hello #{Pad.bong}').
-      should =~ /Pad\.bong/
+    expect(pry_tester(:commands => set).eval('hello #{Pad.bong}')).
+      to match(/Pad\.bong/)
   end
 
   it 'should NOT try to interpolate pure ruby code (no commands) ' do
@@ -267,7 +267,7 @@ describe "commands" do
     expect { pry_eval 'raise \'#{aggy}\'' }.to raise_error RuntimeError
     expect { pry_eval 'raise #{aggy}'     }.to raise_error RuntimeError
 
-    pry_eval('format \'#{my_var}\'').should == "\#{my_var}"
+    expect(pry_eval('format \'#{my_var}\'')).to eq("\#{my_var}")
   end
 
   it 'should create a command with a space in its name zzz' do
@@ -277,8 +277,8 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => set).eval('hello baby').
-      should =~ /hello baby command/
+    expect(pry_tester(:commands => set).eval('hello baby')).
+      to match(/hello baby command/)
   end
 
   it 'should create a command with a space in its name and pass an argument' do
@@ -288,8 +288,8 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => set).eval('hello baby john').
-      should =~ /hello baby command john/
+    expect(pry_tester(:commands => set).eval('hello baby john')).
+      to match(/hello baby command john/)
   end
 
   it 'should create a regex command and be able to invoke it' do
@@ -300,7 +300,7 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => set).eval('hello1').should =~ /hello1/
+    expect(pry_tester(:commands => set).eval('hello1')).to match(/hello1/)
   end
 
   it 'should create a regex command and pass captures into the args list before regular arguments' do
@@ -310,7 +310,7 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => set).eval('hello1 baby').should =~ /hello 1 baby/
+    expect(pry_tester(:commands => set).eval('hello1 baby')).to match(/hello 1 baby/)
   end
 
   it 'should create a regex command and interpolate the captures' do
@@ -321,8 +321,8 @@ describe "commands" do
     end
 
     bong = "bong"
-    pry_tester(binding, :commands => set).eval('hello #{bong}').
-      should =~ /hello bong/
+    expect(pry_tester(binding, :commands => set).eval('hello #{bong}')).
+      to match(/hello bong/)
   end
 
   it 'should create a regex command and arg_string should be interpolated' do
@@ -336,9 +336,9 @@ describe "commands" do
     bong = 'bong'
     bang = 'bang'
 
-    pry_tester(binding, :commands => set).
-      eval('hellojohn #{bing} #{bong} #{bang}').
-      should =~ /hello john bing bong bang/
+    expect(pry_tester(binding, :commands => set).
+      eval('hellojohn #{bing} #{bong} #{bang}')).
+      to match(/hello john bing bong bang/)
   end
 
   it 'if a regex capture is missing it should be nil' do
@@ -348,11 +348,11 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => set).eval('hello baby').should =~ /hello nil baby/
+    expect(pry_tester(:commands => set).eval('hello baby')).to match(/hello nil baby/)
   end
 
   it 'should create a command in a nested context and that command should be accessible from the parent' do
-    pry_tester(Object.new).eval(*(<<-RUBY.split("\n"))).should =~ /instance variables:\s+@x/m
+    expect(pry_tester(Object.new).eval(*(<<-RUBY.split("\n")))).to match(/instance variables:\s+@x/m)
       @x = nil
       cd 7
       _pry_.commands.instance_eval { command('bing') { |arg| run arg } }
@@ -370,7 +370,7 @@ describe "commands" do
 
     t = pry_tester(:commands => klass)
     t.eval("hello\n")
-    t.last_command_result.should == :kept_hello
+    expect(t.last_command_result).to eq(:kept_hello)
   end
 
   it 'should define a command that does NOT keep its return value' do
@@ -381,8 +381,8 @@ describe "commands" do
     end
 
     t = pry_tester(:commands => klass)
-    t.eval("hello\n").should == ''
-    t.last_command_result.should == Pry::Command::VOID_VALUE
+    expect(t.eval("hello\n")).to eq('')
+    expect(t.last_command_result).to eq(Pry::Command::VOID_VALUE)
   end
 
   it 'should define a command that keeps its return value even when nil' do
@@ -394,7 +394,7 @@ describe "commands" do
 
     t = pry_tester(:commands => klass)
     t.eval("hello\n")
-    t.last_command_result.should == nil
+    expect(t.last_command_result).to eq(nil)
   end
 
   it 'should define a command that keeps its return value but does not return when value is void' do
@@ -404,7 +404,7 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => klass).eval("hello\n").empty?.should == true
+    expect(pry_tester(:commands => klass).eval("hello\n").empty?).to eq(true)
   end
 
   it 'a command (with :keep_retval => false) that replaces eval_string with a valid expression should not have the expression value suppressed' do
@@ -420,7 +420,7 @@ describe "commands" do
       Pry.start self, :commands => klass
     end
 
-    output.string.should =~ /6/
+    expect(output.string).to match(/6/)
   end
 
   it 'a command (with :keep_retval => true) that replaces eval_string with a valid expression should overwrite the eval_string with the return value' do
@@ -431,7 +431,7 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => klass).eval("def yo\nhello\n").should == 7
+    expect(pry_tester(:commands => klass).eval("def yo\nhello\n")).to eq(7)
   end
 
   it 'a command that return a value in a multi-line expression should clear the expression and return the value' do
@@ -441,7 +441,7 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => klass).eval("def yo\nhello\n").should == 5
+    expect(pry_tester(:commands => klass).eval("def yo\nhello\n")).to eq(5)
   end
 
   it 'should set the commands default, and the default should be overridable' do
@@ -458,8 +458,8 @@ describe "commands" do
     end
 
     Pry.config.commands = klass
-    pry_tester.eval("hello").should == "hello world\n"
-    pry_tester(:commands => other_klass).eval("goodbye").should == "goodbye world\n"
+    expect(pry_tester.eval("hello")).to eq("hello world\n")
+    expect(pry_tester(:commands => other_klass).eval("goodbye")).to eq("goodbye world\n")
   end
 
   it 'should inherit commands from Pry::Commands' do
@@ -468,10 +468,10 @@ describe "commands" do
       end
     end
 
-    klass.to_hash.include?("nesting").should == true
-    klass.to_hash.include?("jump-to").should == true
-    klass.to_hash.include?("cd").should == true
-    klass.to_hash.include?("v").should == true
+    expect(klass.to_hash.include?("nesting")).to eq(true)
+    expect(klass.to_hash.include?("jump-to")).to eq(true)
+    expect(klass.to_hash.include?("cd")).to eq(true)
+    expect(klass.to_hash.include?("v")).to eq(true)
   end
 
   it 'should change description of a command using desc' do
@@ -483,8 +483,8 @@ describe "commands" do
       desc "help", "blah"
     end
     commands = klass.to_hash
-    commands["help"].description.should_not == orig
-    commands["help"].description.should == "blah"
+    expect(commands["help"].description).not_to eq(orig)
+    expect(commands["help"].description).to eq("blah")
   end
 
   it 'should enable an inherited method to access opts and output and target, due to instance_exec' do
@@ -500,7 +500,7 @@ describe "commands" do
     mock_pry(Pry.binding_for('john'), "v", :print => proc {}, :commands => child_klass,
                                            :output => @str_output)
 
-    @str_output.string.should == "john\n"
+    expect(@str_output.string).to eq("john\n")
   end
 
   it 'should import commands from another command object' do
@@ -508,8 +508,8 @@ describe "commands" do
       import_from Pry::Commands, "ls", "jump-to"
     end
 
-    klass.to_hash.include?("ls").should == true
-    klass.to_hash.include?("jump-to").should == true
+    expect(klass.to_hash.include?("ls")).to eq(true)
+    expect(klass.to_hash.include?("jump-to")).to eq(true)
   end
 
   it 'should delete some inherited commands when using delete method' do
@@ -522,13 +522,13 @@ describe "commands" do
     end
 
     commands = klass.to_hash
-    commands.include?("nesting").should == true
-    commands.include?("jump-to").should == true
-    commands.include?("cd").should == true
-    commands.include?("v").should == true
-    commands.include?("show-doc").should == false
-    commands.include?("show-method").should == false
-    commands.include?("ls").should == false
+    expect(commands.include?("nesting")).to eq(true)
+    expect(commands.include?("jump-to")).to eq(true)
+    expect(commands.include?("cd")).to eq(true)
+    expect(commands.include?("v")).to eq(true)
+    expect(commands.include?("show-doc")).to eq(false)
+    expect(commands.include?("show-method")).to eq(false)
+    expect(commands.include?("ls")).to eq(false)
   end
 
   it 'should override some inherited commands' do
@@ -543,17 +543,17 @@ describe "commands" do
     end
 
     t = pry_tester(:commands => klass)
-    t.eval('jump-to').should == "jump-to the music\n"
-    t.eval('help').should == "help to the music\n"
+    expect(t.eval('jump-to')).to eq("jump-to the music\n")
+    expect(t.eval('help')).to eq("help to the music\n")
   end
 
   it 'should run a command with no parameter' do
-    pry_tester(:commands => @command_tester).eval('command1').
-      should == "command1\n"
+    expect(pry_tester(:commands => @command_tester).eval('command1')).
+      to eq("command1\n")
   end
 
   it 'should run a command with one parameter' do
-    pry_tester(:commands => @command_tester).eval('command2 horsey').
-      should == "horsey\n"
+    expect(pry_tester(:commands => @command_tester).eval('command2 horsey')).
+      to eq("horsey\n")
   end
 end

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -48,11 +48,10 @@ describe Pry::CommandSet do
   end
 
   it 'should pass arguments of the command to the block' do
-    @set.command 'foo' do |*args|
-      args.should == [1, 2, 3]
-    end
-
-    @set.run_command @ctx, 'foo', 1, 2, 3
+    expect { |probe|
+      @set.command('foo', &probe)
+      @set.run_command(@ctx, 'foo', 1, 2, 3)
+    }.to yield_with_args(1, 2, 3)
   end
 
   it 'should use the first argument as context' do

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -15,21 +15,21 @@ describe Pry::CommandSet do
 
   describe "[]=" do
     it "removes a command from the command set" do
-      @set["help"].should_not == nil
+      expect(@set["help"]).not_to eq(nil)
       @set["help"] = nil
-      @set["help"].should == nil
+      expect(@set["help"]).to eq(nil)
       expect { @set.run_command(TOPLEVEL_BINDING, "help") }.to raise_error Pry::NoCommandError
     end
 
     it "replaces a command" do
       old_help = @set["help"]
       @set["help"] = @set["pry-version"]
-      @set["help"].should_not == old_help
+      expect(@set["help"]).not_to eq(old_help)
     end
 
     it "rebinds the command with key" do
       @set["help-1"] = @set["help"]
-      @set["help-1"].match.should == "help-1"
+      expect(@set["help-1"].match).to eq("help-1")
     end
 
     it "raises a TypeError when command is not a subclass of Pry::Command" do
@@ -44,7 +44,7 @@ describe Pry::CommandSet do
     end
 
     @set.run_command @ctx, 'foo'
-    run.should == true
+    expect(run).to eq(true)
   end
 
   it 'should pass arguments of the command to the block' do
@@ -95,7 +95,7 @@ describe Pry::CommandSet do
     @set.import_from(other_set, 'foo')
 
     @set.run_command @ctx, 'foo'
-    run.should == true
+    expect(run).to eq(true)
 
     expect { @set.run_command @ctx, 'bar' }.to raise_error Pry::NoCommandError
   end
@@ -108,7 +108,7 @@ describe Pry::CommandSet do
       command('bar') {}
     end
 
-    @set.import(other_set).should == @set
+    expect(@set.import(other_set)).to eq(@set)
   end
 
   it 'should return command set after import_from' do
@@ -119,7 +119,7 @@ describe Pry::CommandSet do
       command('bar') {}
     end
 
-    @set.import_from(other_set, 'foo').should == @set
+    expect(@set.import_from(other_set, 'foo')).to eq(@set)
   end
 
   it 'should be able to import some commands from other sets using listing name' do
@@ -132,7 +132,7 @@ describe Pry::CommandSet do
     @set.import_from(other_set, 'foo')
 
     @set.run_command @ctx, /^foo1/
-    run.should == true
+    expect(run).to eq(true)
   end
 
   it 'should be able to import a whole set' do
@@ -147,7 +147,7 @@ describe Pry::CommandSet do
 
     @set.run_command @ctx, 'foo'
     @set.run_command @ctx, 'bar'
-    run.should == [true, true]
+    expect(run).to eq([true, true])
   end
 
   it 'should be able to import sets at creation' do
@@ -155,12 +155,12 @@ describe Pry::CommandSet do
     @set.command('foo') { run = true }
 
     Pry::CommandSet.new(@set).run_command @ctx, 'foo'
-    run.should == true
+    expect(run).to eq(true)
   end
 
   it 'should set the descriptions of commands' do
     @set.command('foo', 'some stuff') {}
-    @set['foo'].description.should == 'some stuff'
+    expect(@set['foo'].description).to eq('some stuff')
   end
 
   describe "aliases" do
@@ -169,11 +169,11 @@ describe Pry::CommandSet do
       @set.command('foo', 'stuff') { run = true }
 
       @set.alias_command 'bar', 'foo'
-      @set['bar'].match.should == 'bar'
-      @set['bar'].description.should == 'Alias for `foo`'
+      expect(@set['bar'].match).to eq('bar')
+      expect(@set['bar'].description).to eq('Alias for `foo`')
 
       @set.run_command @ctx, 'bar'
-      run.should == true
+      expect(run).to eq(true)
     end
 
     it "should be able to alias command with command_prefix" do
@@ -184,11 +184,11 @@ describe Pry::CommandSet do
         @set.alias_command 'owlet', 'owl'
 
         Pry.config.command_prefix = '%'
-        @set['%owlet'].match.should == 'owlet'
-        @set['%owlet'].description.should == 'Alias for `owl`'
+        expect(@set['%owlet'].match).to eq('owlet')
+        expect(@set['%owlet'].description).to eq('Alias for `owl`')
 
         @set.run_command @ctx, 'owlet'
-        run.should == true
+        expect(run).to eq(true)
       ensure
         Pry.config.command_prefix = ''
       end
@@ -199,12 +199,12 @@ describe Pry::CommandSet do
       @set.command('foo', 'stuff', :shellwords => true, :interpolate => false) { run = true }
 
       @set.alias_command 'bar', 'foo'
-      @set['bar'].options[:shellwords].should == @set['foo'].options[:shellwords]
-      @set['bar'].options[:interpolate].should == @set['foo'].options[:interpolate]
+      expect(@set['bar'].options[:shellwords]).to eq(@set['foo'].options[:shellwords])
+      expect(@set['bar'].options[:interpolate]).to eq(@set['foo'].options[:interpolate])
 
       # however some options should not be inherited
-      @set['bar'].options[:listing].should_not ==  @set['foo'].options[:listing]
-      @set['bar'].options[:listing].should == "bar"
+      expect(@set['bar'].options[:listing]).not_to eq(@set['foo'].options[:listing])
+      expect(@set['bar'].options[:listing]).to eq("bar")
     end
 
     it 'should be able to specify alias\'s description when aliasing' do
@@ -212,11 +212,11 @@ describe Pry::CommandSet do
       @set.command('foo', 'stuff') { run = true }
 
       @set.alias_command 'bar', 'foo', :desc => "tobina"
-      @set['bar'].match.should == 'bar'
-      @set['bar'].description.should == "tobina"
+      expect(@set['bar'].match).to eq('bar')
+      expect(@set['bar'].description).to eq("tobina")
 
       @set.run_command @ctx, 'bar'
-      run.should == true
+      expect(run).to eq(true)
     end
 
     it "should be able to alias a command by its invocation line" do
@@ -224,11 +224,11 @@ describe Pry::CommandSet do
       @set.command(/^foo1/, 'stuff', :listing => 'foo') { run = true }
 
       @set.alias_command 'bar', 'foo1'
-      @set['bar'].match.should == 'bar'
-      @set['bar'].description.should == 'Alias for `foo1`'
+      expect(@set['bar'].match).to eq('bar')
+      expect(@set['bar'].description).to eq('Alias for `foo1`')
 
       @set.run_command @ctx, 'bar'
-      run.should == true
+      expect(run).to eq(true)
     end
 
     it "should be able to specify options when creating alias" do
@@ -236,7 +236,7 @@ describe Pry::CommandSet do
       @set.command(/^foo1/, 'stuff', :listing => 'foo') { run = true }
 
       @set.alias_command /^b.r/, 'foo1', :listing => "bar"
-      @set.to_hash[/^b.r/].options[:listing].should == "bar"
+      expect(@set.to_hash[/^b.r/].options[:listing]).to eq("bar")
     end
 
     it "should set description to default if description parameter is nil" do
@@ -244,7 +244,7 @@ describe Pry::CommandSet do
       @set.command(/^foo1/, 'stuff', :listing => 'foo') { run = true }
 
       @set.alias_command "bar", 'foo1'
-      @set["bar"].description.should == "Alias for `foo1`"
+      expect(@set["bar"].description).to eq("Alias for `foo1`")
     end
   end
 
@@ -252,32 +252,32 @@ describe Pry::CommandSet do
     @set.command('foo', 'bar') {}
     @set.desc 'foo', 'baz'
 
-    @set['foo'].description.should == 'baz'
+    expect(@set['foo'].description).to eq('baz')
   end
 
   it 'should get the descriptions of commands' do
     @set.command('foo', 'bar') {}
-    @set.desc('foo').should == 'bar'
+    expect(@set.desc('foo')).to eq('bar')
   end
 
   it 'should get the descriptions of commands, by listing' do
     @set.command(/^foo1/, 'bar', :listing => 'foo') {}
-    @set.desc('foo').should == 'bar'
+    expect(@set.desc('foo')).to eq('bar')
   end
 
   it 'should return Pry::Command::VOID_VALUE for commands by default' do
     @set.command('foo') { 3 }
-    @set.run_command(@ctx, 'foo').should == Pry::Command::VOID_VALUE
+    expect(@set.run_command(@ctx, 'foo')).to eq(Pry::Command::VOID_VALUE)
   end
 
   it 'should be able to keep return values' do
     @set.command('foo', '', :keep_retval => true) { 3 }
-    @set.run_command(@ctx, 'foo').should == 3
+    expect(@set.run_command(@ctx, 'foo')).to eq(3)
   end
 
   it 'should be able to keep return values, even if return value is nil' do
     @set.command('foo', '', :keep_retval => true) { nil }
-    @set.run_command(@ctx, 'foo').should == nil
+    expect(@set.run_command(@ctx, 'foo')).to eq(nil)
   end
 
   it 'should be able to have its own helpers' do
@@ -285,9 +285,9 @@ describe Pry::CommandSet do
     @set.helpers { def my_helper; end }
 
     @set.run_command(@ctx, 'foo')
-    Pry::Command.subclass('foo', '', {}, Module.new)
-                .new({:target => binding})
-                .should_not(respond_to :my_helper)
+    expect(Pry::Command.subclass('foo', '', {}, Module.new)
+                .new({:target => binding}))
+                .not_to(respond_to :my_helper)
   end
 
   it 'should not recreate a new helper module when helpers is called' do
@@ -335,12 +335,12 @@ describe Pry::CommandSet do
 
   it 'should provide a :listing for a command that defaults to its name' do
     @set.command 'foo', "" do;end
-    @set['foo'].options[:listing].should == 'foo'
+    expect(@set['foo'].options[:listing]).to eq('foo')
   end
 
   it 'should provide a :listing for a command that differs from its name' do
     @set.command 'foo', "", :listing => 'bar' do;end
-    @set['foo'].options[:listing].should == 'bar'
+    expect(@set['foo'].options[:listing]).to eq('bar')
   end
 
   it "should provide a 'help' command" do
@@ -357,7 +357,7 @@ describe Pry::CommandSet do
       @set.command('foo') { run = true }
       @set.rename_command('bar', 'foo')
       @set.run_command(@ctx, 'bar')
-      run.should == true
+      expect(run).to eq(true)
     end
 
     it 'should accept listing name when renaming a command' do
@@ -365,7 +365,7 @@ describe Pry::CommandSet do
       @set.command('foo', "", :listing => 'love') { run = true }
       @set.rename_command('bar', 'love')
       @set.run_command(@ctx, 'bar')
-      run.should == true
+      expect(run).to eq(true)
     end
 
     it 'should raise exception trying to rename non-existent command' do
@@ -383,9 +383,9 @@ describe Pry::CommandSet do
       listing = "bing"
       @set.command('foo') { }
       @set.rename_command('bar', 'foo', :description => desc, :listing => listing, :keep_retval => true)
-      @set['bar'].description.should           == desc
-      @set['bar'].options[:listing].should     == listing
-      @set['bar'].options[:keep_retval].should == true
+      expect(@set['bar'].description).to           eq(desc)
+      expect(@set['bar'].options[:listing]).to     eq(listing)
+      expect(@set['bar'].options[:keep_retval]).to eq(true)
     end
   end
 
@@ -397,7 +397,7 @@ describe Pry::CommandSet do
         @set.before_command('foo') { foo << 2 }
         @set.run_command(@ctx, 'foo')
 
-        foo.should == [2, 1]
+        expect(foo).to eq([2, 1])
       end
 
       it 'should be called before the original command, using listing name' do
@@ -406,7 +406,7 @@ describe Pry::CommandSet do
         @set.before_command('foo') { foo << 2 }
         @set.run_command(@ctx, /^foo1/)
 
-        foo.should == [2, 1]
+        expect(foo).to eq([2, 1])
       end
 
       it 'should share the context with the original command' do
@@ -417,8 +417,8 @@ describe Pry::CommandSet do
         @set.before_command('foo') { before_val = target }
         @set.run_command(@ctx, 'foo')
 
-        before_val.should == @ctx[:target]
-        orig_val.should == @ctx[:target]
+        expect(before_val).to eq(@ctx[:target])
+        expect(orig_val).to eq(@ctx[:target])
       end
 
       it 'should work when applied multiple times' do
@@ -429,7 +429,7 @@ describe Pry::CommandSet do
         @set.before_command('foo') { foo << 4 }
         @set.run_command(@ctx, 'foo')
 
-        foo.should == [4, 3, 2, 1]
+        expect(foo).to eq([4, 3, 2, 1])
       end
 
     end
@@ -441,7 +441,7 @@ describe Pry::CommandSet do
         @set.after_command('foo') { foo << 2 }
         @set.run_command(@ctx, 'foo')
 
-        foo.should == [1, 2]
+        expect(foo).to eq([1, 2])
       end
 
       it 'should be called after the original command, using listing name' do
@@ -450,7 +450,7 @@ describe Pry::CommandSet do
         @set.after_command('foo') { foo << 2 }
         @set.run_command(@ctx, /^foo1/)
 
-        foo.should == [1, 2]
+        expect(foo).to eq([1, 2])
       end
 
       it 'should share the context with the original command' do
@@ -461,14 +461,14 @@ describe Pry::CommandSet do
         @set.after_command('foo') { after_val = target }
         @set.run_command(@ctx, 'foo')
 
-        after_val.should == @ctx[:target]
-        orig_val.should == @ctx[:target]
+        expect(after_val).to eq(@ctx[:target])
+        expect(orig_val).to eq(@ctx[:target])
       end
 
       it 'should determine the return value for the command' do
         @set.command('foo', 'bar', :keep_retval => true) { 1 }
         @set.after_command('foo') { 2 }
-        @set.run_command(@ctx, 'foo').should == 2
+        expect(@set.run_command(@ctx, 'foo')).to eq(2)
       end
 
       it 'should work when applied multiple times' do
@@ -479,7 +479,7 @@ describe Pry::CommandSet do
         @set.after_command('foo') { foo << 4 }
         @set.run_command(@ctx, 'foo')
 
-        foo.should == [1, 2, 3, 4]
+        expect(foo).to eq([1, 2, 3, 4])
       end
     end
 
@@ -491,7 +491,7 @@ describe Pry::CommandSet do
         @set.before_command('foo') { foo << 3 }
         @set.run_command(@ctx, 'foo')
 
-        foo.should == [3, 1, 2]
+        expect(foo).to eq([3, 1, 2])
       end
 
     end
@@ -501,44 +501,44 @@ describe Pry::CommandSet do
   describe 'find_command' do
     it 'should find commands with the right string' do
       cmd = @set.command('rincewind'){ }
-      @set.find_command('rincewind').should == cmd
+      expect(@set.find_command('rincewind')).to eq(cmd)
     end
 
     it 'should not find commands with spaces before' do
       cmd = @set.command('luggage'){ }
-      @set.find_command(' luggage').should == nil
+      expect(@set.find_command(' luggage')).to eq(nil)
     end
 
     it 'should find commands with arguments after' do
       cmd = @set.command('vetinari'){ }
-      @set.find_command('vetinari --knock 3').should == cmd
+      expect(@set.find_command('vetinari --knock 3')).to eq(cmd)
     end
 
     it 'should find commands with names containing spaces' do
       cmd = @set.command('nobby nobbs'){ }
-      @set.find_command('nobby nobbs --steal petty-cash').should == cmd
+      expect(@set.find_command('nobby nobbs --steal petty-cash')).to eq(cmd)
     end
 
     it 'should find command defined by regex' do
       cmd = @set.command(/(capt|captain) vimes/i){ }
-      @set.find_command('Capt Vimes').should == cmd
+      expect(@set.find_command('Capt Vimes')).to eq(cmd)
     end
 
     it 'should find commands defined by regex with arguments' do
       cmd = @set.command(/(cpl|corporal) Carrot/i){ }
-      @set.find_command('cpl carrot --write-home').should == cmd
+      expect(@set.find_command('cpl carrot --write-home')).to eq(cmd)
     end
 
     it 'should not find commands by listing' do
       cmd = @set.command(/werewol(f|ve)s?/, 'only once a month', :listing => "angua"){ }
-      @set.find_command('angua').should == nil
+      expect(@set.find_command('angua')).to eq(nil)
     end
 
     it 'should not find commands without command_prefix' do
       begin
         Pry.config.command_prefix = '%'
         cmd = @set.command('detritus'){ }
-        @set.find_command('detritus').should == nil
+        expect(@set.find_command('detritus')).to eq(nil)
       ensure
         Pry.config.command_prefix = ''
       end
@@ -548,7 +548,7 @@ describe Pry::CommandSet do
       begin
         Pry.config.command_prefix = '%'
         cmd = @set.command('colon', 'Sergeant Fred', :use_prefix => false){ }
-        @set.find_command('colon').should == cmd
+        expect(@set.find_command('colon')).to eq(cmd)
       ensure
         Pry.config.command_prefix = ''
       end
@@ -557,24 +557,24 @@ describe Pry::CommandSet do
     it "should find the command that has the longest match" do
       cmd = @set.command(/\.(.*)/){ }
       cmd2 = @set.command(/\.\|\|(.*)/){ }
-      @set.find_command('.||').should == cmd2
+      expect(@set.find_command('.||')).to eq(cmd2)
     end
 
     it "should find the command that has the longest name" do
       cmd = @set.command(/\.(.*)/){ }
       cmd2 = @set.command('.||'){ }
-      @set.find_command('.||').should == cmd2
+      expect(@set.find_command('.||')).to eq(cmd2)
     end
   end
 
   describe '.valid_command?' do
     it 'should be true for commands that can be found' do
       cmd = @set.command('archchancellor')
-      @set.valid_command?('archchancellor of_the?(:University)').should == true
+      expect(@set.valid_command?('archchancellor of_the?(:University)')).to eq(true)
     end
 
     it 'should be false for commands that can\'' do
-      @set.valid_command?('def monkey(ape)').should == false
+      expect(@set.valid_command?('def monkey(ape)')).to eq(false)
     end
 
     it 'should not cause argument interpolation' do
@@ -587,9 +587,9 @@ describe Pry::CommandSet do
 
     it 'should return Result.new(false) if there is no matching command' do
      result = @set.process_line('1 + 42')
-     result.command?.should == false
-     result.void_command?.should == false
-     result.retval.should == nil
+     expect(result.command?).to eq(false)
+     expect(result.void_command?).to eq(false)
+     expect(result.retval).to eq(nil)
     end
 
     it 'should return Result.new(true, VOID) if the command is not keep_retval' do
@@ -598,9 +598,9 @@ describe Pry::CommandSet do
       end
 
       result = @set.process_line('mrs-cake')
-      result.command?.should == true
-      result.void_command?.should == true
-      result.retval.should == Pry::Command::VOID_VALUE
+      expect(result.command?).to eq(true)
+      expect(result.void_command?).to eq(true)
+      expect(result.retval).to eq(Pry::Command::VOID_VALUE)
     end
 
     it 'should return Result.new(true, retval) if the command is keep_retval' do
@@ -609,9 +609,9 @@ describe Pry::CommandSet do
       end
 
       result = @set.process_line('magrat')
-      result.command?.should == true
-      result.void_command?.should == false
-      result.retval.should == 42
+      expect(result.command?).to eq(true)
+      expect(result.void_command?).to eq(false)
+      expect(result.retval).to eq(42)
     end
 
     it 'should pass through context' do
@@ -649,12 +649,12 @@ describe Pry::CommandSet do
     describe '.complete' do
       it "should list all command names" do
         @set.create_command('susan'){ }
-        @set.complete('sus').should.include 'susan '
+        expect(@set.complete('sus')).to.include 'susan '
       end
 
       it "should delegate to commands" do
         @set.create_command('susan'){ def complete(search); ['--foo']; end }
-        @set.complete('susan ').should == ['--foo']
+        expect(@set.complete('susan ')).to eq(['--foo'])
       end
     end
   end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -301,53 +301,52 @@ describe "Pry::Command" do
 
   describe 'tokenize' do
     it 'should interpolate string with #{} in them' do
-      cmd = @set.command 'random-dent' do |*args|
-        args.should == ["3", "8"]
-      end
+      expect { |probe|
+        cmd = @set.command('random-dent', &probe)
 
-      foo = 5
-
-      cmd.new(:target => binding).process_line 'random-dent #{1 + 2} #{3 + foo}'
+        foo = 5
+        cmd.new(:target => binding).process_line 'random-dent #{1 + 2} #{3 + foo}'
+      }.to yield_with_args('3', '8')
     end
 
     it 'should not fail if interpolation is not needed and target is not set' do
-      cmd = @set.command 'the-book' do |*args|
-        args.should == ['--help']
-      end
+      expect { |probe|
+        cmd = @set.command('the-book', &probe)
 
-      cmd.new.process_line 'the-book --help'
+        cmd.new.process_line 'the-book --help'
+      }.to yield_with_args('--help')
     end
 
     it 'should not interpolate commands with :interpolate => false' do
-      cmd = @set.command 'thor', 'norse god', :interpolate => false do |*args|
-        args.should == ['%(#{foo})']
-      end
+      expect { |probe|
+        cmd = @set.command('thor', 'norse god', :interpolate => false, &probe)
 
-      cmd.new.process_line 'thor %(#{foo})'
+        cmd.new.process_line 'thor %(#{foo})'
+      }.to yield_with_args('%(#{foo})')
     end
 
     it 'should use shell-words to split strings' do
-      cmd = @set.command 'eccentrica' do |*args|
-        args.should == ['gallumbits', 'eroticon', '6']
-      end
+      expect { |probe|
+        cmd = @set.command('eccentrica', &probe)
 
-      cmd.new.process_line %(eccentrica "gallumbits" 'erot''icon' 6)
+        cmd.new.process_line %(eccentrica "gallumbits" 'erot''icon' 6)
+      }.to yield_with_args('gallumbits', 'eroticon', '6')
     end
 
     it 'should split on spaces if shellwords is not used' do
-      cmd = @set.command 'bugblatter-beast', 'would eat its grandmother', :shellwords => false do |*args|
-        args.should == ['"of', 'traal"']
-      end
+      expect { |probe|
+        cmd = @set.command('bugblatter-beast', 'would eat its grandmother', :shellwords => false, &probe)
 
-      cmd.new.process_line %(bugblatter-beast "of traal")
+        cmd.new.process_line %(bugblatter-beast "of traal")
+      }.to yield_with_args('"of', 'traal"')
     end
 
     it 'should add captures to arguments for regex commands' do
-      cmd = @set.command /perfectly (normal)( beast)?/i do |*args|
-        args.should == ['Normal', ' Beast', '(honest!)']
-      end
+      expect { |probe|
+        cmd = @set.command(/perfectly (normal)( beast)?/i, &probe)
 
-      cmd.new.process_line %(Perfectly Normal Beast (honest!))
+        cmd.new.process_line %(Perfectly Normal Beast (honest!))
+      }.to yield_with_args('Normal', ' Beast', '(honest!)')
     end
   end
 

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -14,7 +14,7 @@ describe "Pry::Command" do
         #
       end
 
-      mock_command(cmd, %w(hello world)).output.should =~ /install-command ford-prefect/
+      expect(mock_command(cmd, %w(hello world)).output).to match(/install-command ford-prefect/)
     end
 
     it 'should abort early if arguments are required' do
@@ -32,7 +32,7 @@ describe "Pry::Command" do
         end
       end
 
-      mock_command(cmd).return.should == Pry::Command::VOID_VALUE
+      expect(mock_command(cmd).return).to eq(Pry::Command::VOID_VALUE)
     end
 
     it 'should return the return value with keep_retval' do
@@ -42,7 +42,7 @@ describe "Pry::Command" do
         end
       end
 
-      mock_command(cmd).return.should == 5
+      expect(mock_command(cmd).return).to eq(5)
     end
 
     it 'should call hooks in the right order' do
@@ -67,7 +67,7 @@ describe "Pry::Command" do
         output.puts 5 + i.to_i
       end
 
-      mock_command(cmd, %w(2)).output.should == "3\n4\n5\n6\n7\n"
+      expect(mock_command(cmd, %w(2)).output).to eq("3\n4\n5\n6\n7\n")
     end
 
     # TODO: This strikes me as rather silly...
@@ -82,7 +82,7 @@ describe "Pry::Command" do
         10
       end
 
-      mock_command(cmd).return.should == 10
+      expect(mock_command(cmd).return).to eq(10)
     end
   end
 
@@ -92,7 +92,7 @@ describe "Pry::Command" do
         #
       end
 
-      mock_command(@set['help'], %w(oolon-colluphid), :command_set => @set).output.should =~ /Raving Atheist/
+      expect(mock_command(@set['help'], %w(oolon-colluphid), :command_set => @set).output).to match(/Raving Atheist/)
     end
 
     it 'should use slop to generate the help for classy commands' do
@@ -102,7 +102,7 @@ describe "Pry::Command" do
         end
       end
 
-      mock_command(@set['help'], %w(eddie), :command_set => @set).output.should =~ /Over-cheerful/
+      expect(mock_command(@set['help'], %w(eddie), :command_set => @set).output).to match(/Over-cheerful/)
     end
 
     it 'should provide --help for classy commands' do
@@ -112,7 +112,7 @@ describe "Pry::Command" do
         end
       end
 
-      mock_command(cmd, %w(--help)).output.should =~ /--retaliate/
+      expect(mock_command(cmd, %w(--help)).output).to match(/--retaliate/)
     end
 
     it 'should provide a -h for classy commands' do
@@ -122,7 +122,7 @@ describe "Pry::Command" do
         end
       end
 
-      mock_command(cmd, %w(--help)).output.should =~ /Total Perspective Vortex/
+      expect(mock_command(cmd, %w(--help)).output).to match(/Total Perspective Vortex/)
     end
 
     it 'should use the banner provided' do
@@ -132,7 +132,7 @@ describe "Pry::Command" do
         BANNER
       end
 
-      mock_command(cmd, %w(--help)).output.should =~ /Who\'s merest/
+      expect(mock_command(cmd, %w(--help)).output).to match(/Who\'s merest/)
     end
   end
 
@@ -186,7 +186,7 @@ describe "Pry::Command" do
         end
       end
 
-      mock_command(cmd).output.should == "setup\nsubcommands\noptions\nprocess\n"
+      expect(mock_command(cmd).output).to eq("setup\nsubcommands\noptions\nprocess\n")
     end
 
     it 'should raise a command error if process is not overridden' do
@@ -206,7 +206,7 @@ describe "Pry::Command" do
         end
       end
 
-      mock_command(cmd).return.should == 5
+      expect(mock_command(cmd).return).to eq(5)
     end
 
     it 'should provide opts and args as provided by slop' do
@@ -230,8 +230,8 @@ describe "Pry::Command" do
         command_options :listing => 'number-one'
       end
 
-      cmd.command_options[:shellwords].should == false
-      cmd.command_options[:listing].should == 'number-one'
+      expect(cmd.command_options[:shellwords]).to eq(false)
+      expect(cmd.command_options[:listing]).to eq('number-one')
     end
 
     it "should create subcommands" do
@@ -292,9 +292,9 @@ describe "Pry::Command" do
 
       it 'subclasses should inherit options, match and description from superclass' do
         k = Class.new(@x)
-        k.options.should == @x.options
-        k.match.should == @x.match
-        k.description.should == @x.description
+        expect(k.options).to eq(@x.options)
+        expect(k.match).to eq(@x.match)
+        expect(k.description).to eq(@x.description)
       end
     end
   end
@@ -364,7 +364,7 @@ describe "Pry::Command" do
       output = StringIO.new
       cmd.new(:target => binding, :output => output).process_line %(frankie mouse)
 
-      output.string.should =~ /command .* conflicts/
+      expect(output.string).to match(/command .* conflicts/)
 
       Pry.config.collision_warning = old
     end
@@ -380,7 +380,7 @@ describe "Pry::Command" do
       output = StringIO.new
       cmd.new(:target => binding, :output => output).process_line %(frankie = mouse)
 
-      output.string.should =~ /command .* conflicts/
+      expect(output.string).to match(/command .* conflicts/)
 
       Pry.config.collision_warning = old
     end
@@ -420,7 +420,7 @@ describe "Pry::Command" do
         end
       EOS
 
-      @context.instance_variable_get(:@x).should == :jesus
+      expect(@context.instance_variable_get(:@x)).to eq(:jesus)
     end
 
     it 'should accept normal parameters along with block' do
@@ -434,25 +434,25 @@ describe "Pry::Command" do
 
       @t.eval 'walking-spanish john carl| { :jesus }'
 
-      @context.instance_variable_get(:@x).should == "john"
-      @context.instance_variable_get(:@y).should == "carl"
-      @context.instance_variable_get(:@block_var).should == :jesus
+      expect(@context.instance_variable_get(:@x)).to eq("john")
+      expect(@context.instance_variable_get(:@y)).to eq("carl")
+      expect(@context.instance_variable_get(:@block_var)).to eq(:jesus)
     end
 
     describe "single line blocks" do
       it 'should accept blocks with do ; end' do
         @t.eval 'walking-spanish | do ; :jesus; end'
-        @context.instance_variable_get(:@x).should == :jesus
+        expect(@context.instance_variable_get(:@x)).to eq(:jesus)
       end
 
       it 'should accept blocks with do; end' do
         @t.eval 'walking-spanish | do; :jesus; end'
-        @context.instance_variable_get(:@x).should == :jesus
+        expect(@context.instance_variable_get(:@x)).to eq(:jesus)
       end
 
       it 'should accept blocks with { }' do
         @t.eval 'walking-spanish | { :jesus }'
-        @context.instance_variable_get(:@x).should == :jesus
+        expect(@context.instance_variable_get(:@x)).to eq(:jesus)
       end
     end
 
@@ -467,7 +467,7 @@ describe "Pry::Command" do
 
           @t.eval 'walking-spanish john| { :jesus }'
 
-          @context.instance_variable_get(:@arg_string).should == @context.instance_variable_get(:@x)
+          expect(@context.instance_variable_get(:@arg_string)).to eq(@context.instance_variable_get(:@x))
         end
 
         it 'should remove block-related content from arg_string (with no normal args)' do
@@ -477,7 +477,7 @@ describe "Pry::Command" do
 
           @t.eval 'walking-spanish | { :jesus }'
 
-          @context.instance_variable_get(:@arg_string).should == ""
+          expect(@context.instance_variable_get(:@arg_string)).to eq("")
         end
 
         it 'should NOT remove block-related content from arg_string when :takes_block => false' do
@@ -488,7 +488,7 @@ describe "Pry::Command" do
 
           @t.eval "walking-spanish #{block_string}"
 
-          @context.instance_variable_get(:@arg_string).should == block_string
+          expect(@context.instance_variable_get(:@arg_string)).to eq(block_string)
         end
       end
 
@@ -502,8 +502,8 @@ describe "Pry::Command" do
 
             @t.eval 'walking-spanish | { :jesus }'
 
-            @context.instance_variable_get(:@x).should == nil
-            @context.instance_variable_get(:@y).should == nil
+            expect(@context.instance_variable_get(:@x)).to eq(nil)
+            expect(@context.instance_variable_get(:@y)).to eq(nil)
           end
 
           it "should NOT remove block-related content from arguments if :takes_block => false" do
@@ -514,8 +514,8 @@ describe "Pry::Command" do
 
             @t.eval 'walking-spanish | { :jesus }'
 
-            @context.instance_variable_get(:@x).should == "|"
-            @context.instance_variable_get(:@y).should == "{"
+            expect(@context.instance_variable_get(:@x)).to eq("|")
+            expect(@context.instance_variable_get(:@y)).to eq("{")
           end
         end
 
@@ -530,8 +530,8 @@ describe "Pry::Command" do
 
             @t.eval 'walking-spanish | { :jesus }'
 
-            @context.instance_variable_get(:@x).should == nil
-            @context.instance_variable_get(:@y).should == nil
+            expect(@context.instance_variable_get(:@x)).to eq(nil)
+            expect(@context.instance_variable_get(:@y)).to eq(nil)
           end
 
           it "should NOT remove block-related content from arguments if :takes_block => false" do
@@ -544,8 +544,8 @@ describe "Pry::Command" do
 
             @t.eval 'walking-spanish | { :jesus }'
 
-            @context.instance_variable_get(:@x).should == "|"
-            @context.instance_variable_get(:@y).should == "{"
+            expect(@context.instance_variable_get(:@x)).to eq("|")
+            expect(@context.instance_variable_get(:@y)).to eq("{")
           end
         end
       end
@@ -560,7 +560,7 @@ describe "Pry::Command" do
 
           @t.eval 'walking-spanish | { |x, y| [x, y] }'
 
-          @context.instance_variable_get(:@x).should == [1, 2]
+          expect(@context.instance_variable_get(:@x)).to eq([1, 2])
         end
       end
 
@@ -578,7 +578,7 @@ describe "Pry::Command" do
             end
           EOS
 
-          @context.instance_variable_get(:@x).should == [1, 2]
+          expect(@context.instance_variable_get(:@x)).to eq([1, 2])
         end
       end
     end
@@ -586,7 +586,7 @@ describe "Pry::Command" do
     describe "closure behaviour" do
       it 'should close over locals in the definition context' do
         @t.eval 'var = :hello', 'walking-spanish | { var }'
-        @context.instance_variable_get(:@x).should == :hello
+        expect(@context.instance_variable_get(:@x)).to eq(:hello)
       end
     end
 
@@ -599,7 +599,7 @@ describe "Pry::Command" do
 
           @t.eval 'walking-spanish | { :jesus }'
 
-          @context.instance_variable_get(:@x).should == :jesus
+          expect(@context.instance_variable_get(:@x)).to eq(:jesus)
         end
       end
 
@@ -624,7 +624,7 @@ describe "Pry::Command" do
 
           @t.eval 'walking-spanish | { :jesus }'
 
-          @context.instance_variable_get(:@x).should == :jesus
+          expect(@context.instance_variable_get(:@x)).to eq(:jesus)
         end
       end
     end
@@ -652,11 +652,11 @@ describe "Pry::Command" do
     end
 
     it "allows creation of custom subclasses of Pry::Command" do
-      pry_eval('my---test').should =~ /my-testmy-test/
+      expect(pry_eval('my---test')).to match(/my-testmy-test/)
     end
 
     it "shows the source of the process method" do
-      pry_eval('show-source my-test').should =~ /output.puts command_name/
+      expect(pry_eval('show-source my-test')).to match(/output.puts command_name/)
     end
 
     describe "command options hash" do
@@ -671,7 +671,7 @@ describe "Pry::Command" do
           :use_prefix        => true,
           :takes_block       => false
         }
-        MyTestCommand.options.should == options_hash
+        expect(MyTestCommand.options).to eq(options_hash)
       end
 
       describe ":listing option" do
@@ -682,7 +682,7 @@ describe "Pry::Command" do
           end
           Pry.config.commands.add_command HappyNewYear
 
-          HappyNewYear.options[:listing].should == 'happy-new-year'
+          expect(HappyNewYear.options[:listing]).to eq('happy-new-year')
 
           Pry.config.commands.delete 'happy-new-year'
         end
@@ -695,7 +695,7 @@ describe "Pry::Command" do
           end
           Pry.config.commands.add_command MerryChristmas
 
-          MerryChristmas.options[:listing].should == 'happy-holidays'
+          expect(MerryChristmas.options[:listing]).to eq('happy-holidays')
 
           Pry.config.commands.delete 'merry-christmas'
         end
@@ -707,7 +707,7 @@ describe "Pry::Command" do
           end
           Pry.config.commands.add_command CoolWinter
 
-          CoolWinter.options[:listing].should == '/.*winter/'
+          expect(CoolWinter.options[:listing]).to eq('/.*winter/')
 
           Pry.config.commands.delete /.*winter/
         end
@@ -746,25 +746,25 @@ describe "Pry::Command" do
 
     it 'should save state for the command on the Pry#command_state hash' do
       @t.eval 'litella'
-      @t.pry.command_state["litella"].my_state.should == 1
+      expect(@t.pry.command_state["litella"].my_state).to eq(1)
     end
 
     it 'should ensure state is maintained between multiple invocations of command' do
       @t.eval 'litella'
       @t.eval 'litella'
-      @t.pry.command_state["litella"].my_state.should == 2
+      expect(@t.pry.command_state["litella"].my_state).to eq(2)
     end
 
     it 'should ensure state with same name stored seperately for each command' do
       @t.eval 'litella', 'sanders'
 
-      @t.pry.command_state["litella"].my_state.should == 1
-      @t.pry.command_state["sanders"].my_state.should =="wood"
+      expect(@t.pry.command_state["litella"].my_state).to eq(1)
+      expect(@t.pry.command_state["sanders"].my_state).to eq("wood")
     end
 
     it 'should ensure state is properly saved for regex commands' do
       @t.eval 'hello-world', 'Hello-world'
-      @t.pry.command_state[/[Hh]ello-world/].my_state.should == 4
+      expect(@t.pry.command_state[/[Hh]ello-world/].my_state).to eq(4)
     end
   end
 
@@ -779,7 +779,7 @@ describe "Pry::Command" do
           end
         end
 
-        @set.complete('torrid ').should.include('--test ')
+        expect(@set.complete('torrid ')).to.include('--test ')
       end
     end
   end
@@ -794,17 +794,17 @@ describe "Pry::Command" do
     end
 
     it 'should be correct for default commands' do
-      @set["help"].group.should == "Help"
+      expect(@set["help"].group).to eq("Help")
     end
 
     it 'should not change once it is initialized' do
       @set["magic"].group("-==CD COMMAND==-")
-      @set["magic"].group.should == "Not for a public use"
+      expect(@set["magic"].group).to eq("Not for a public use")
     end
 
     it 'should not disappear after the call without parameters' do
       @set["magic"].group
-      @set["magic"].group.should == "Not for a public use"
+      expect(@set["magic"].group).to eq("Not for a public use")
     end
   end
 end

--- a/spec/commands/amend_line_spec.rb
+++ b/spec/commands/amend_line_spec.rb
@@ -13,7 +13,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line   puts :blah'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def hello
         puts :blah
     STR
@@ -28,7 +28,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 1 def goodbye'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def goodbye
         puts :bing
         puts :bang
@@ -44,7 +44,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 0 def goodbye'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def goodbye
         puts :bing
         puts :bang
@@ -60,7 +60,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line -1   puts :bink'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def hello
         puts :bing
         puts :bink
@@ -68,7 +68,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line -2   puts :bink'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def hello
         puts :bink
         puts :bink
@@ -85,7 +85,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line -3..-2   puts :bink'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def hello
         puts :bink
         puts :boat
@@ -101,7 +101,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line   puts "#{goodbye}"'
 
-    @t.eval_string.should == unindent(<<-'STR')
+    expect(@t.eval_string).to eq unindent(<<-'STR')
       def hello
         puts :bing
         puts "#{goodbye}"
@@ -117,8 +117,8 @@ describe "amend-line" do
       error = e
     end
 
-    error.should_not equal nil
-    error.message.should =~ /No input to amend/
+    expect(error).not_to equal nil
+    expect(error.message).to match(/No input to amend/)
   end
 
   it 'should correctly amend the specified range of lines' do
@@ -131,7 +131,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 2..3   puts :bong'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def hello
         puts :bong
         puts :heart
@@ -149,7 +149,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 3 !'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def hello
         puts :bing
         puts :boast
@@ -168,7 +168,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 2..4 !'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def hello
         puts :heart
     STR
@@ -185,7 +185,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line !'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def hello
         puts :bing
         puts :bang
@@ -204,7 +204,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 2..-2   puts :bong'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def hello
         puts :bong
         puts :heart
@@ -220,7 +220,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 2 >  puts :inserted'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def hello
         puts :inserted
         puts :bing
@@ -237,7 +237,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 2..21 >  puts :inserted'
 
-    @t.eval_string.should == unindent(<<-STR)
+    expect(@t.eval_string).to eq unindent(<<-STR)
       def hello
         puts :inserted
         puts :bing

--- a/spec/commands/bang_spec.rb
+++ b/spec/commands/bang_spec.rb
@@ -12,13 +12,13 @@ describe "!" do
     STR
 
     @t.process_command '!'
-    @t.last_output.should =~ /Input buffer cleared!/
-    @t.eval_string.should == ''
+    expect(@t.last_output).to match(/Input buffer cleared!/)
+    expect(@t.eval_string).to eq('')
   end
 
   it 'should not clear the input buffer for negation' do
     @t.push '! false'
-    @t.last_output.should =~ /true/
-    @t.eval_string.should == ''
+    expect(@t.last_output).to match(/true/)
+    expect(@t.eval_string).to eq('')
   end
 end

--- a/spec/commands/cat/file_formatter_spec.rb
+++ b/spec/commands/cat/file_formatter_spec.rb
@@ -13,32 +13,32 @@ describe Pry::Command::Cat::FileFormatter do
         file_with_embedded_line = "C:/Ruby193/pry_instance.rb"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "C:/Ruby193/pry_instance.rb"
-        line_num.should == nil
+        expect(file_name).to eq("C:/Ruby193/pry_instance.rb")
+        expect(line_num).to eq(nil)
       end
 
       it "should parse '/'style absolute path with line_num" do
         file_with_embedded_line = "C:/Ruby193/pry_instance.rb:2"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "C:/Ruby193/pry_instance.rb"
-        line_num.should == 2
+        expect(file_name).to eq("C:/Ruby193/pry_instance.rb")
+        expect(line_num).to eq(2)
       end
 
       it "should parse '\\'style absolute path without line_num" do
         file_with_embedded_line = "C:\\Ruby193\\pry_instance.rb"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "C:\\Ruby193\\pry_instance.rb"
-        line_num.should == nil
+        expect(file_name).to eq("C:\\Ruby193\\pry_instance.rb")
+        expect(line_num).to eq(nil)
       end
 
       it "should parse '\\'style absolute path with line_num" do
         file_with_embedded_line = "C:\\Ruby193\\pry_instance.rb:2"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "C:\\Ruby193\\pry_instance.rb"
-        line_num.should == 2
+        expect(file_name).to eq("C:\\Ruby193\\pry_instance.rb")
+        expect(line_num).to eq(2)
       end
     end
 
@@ -47,16 +47,16 @@ describe Pry::Command::Cat::FileFormatter do
         file_with_embedded_line = "/Ruby193/pry_instance.rb"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "/Ruby193/pry_instance.rb"
-        line_num.should == nil
+        expect(file_name).to eq("/Ruby193/pry_instance.rb")
+        expect(line_num).to eq(nil)
       end
 
       it "should parse absolute path with line_num" do
         file_with_embedded_line = "/Ruby193/pry_instance.rb:2"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "/Ruby193/pry_instance.rb"
-        line_num.should == 2
+        expect(file_name).to eq("/Ruby193/pry_instance.rb")
+        expect(line_num).to eq(2)
       end
     end
 
@@ -64,16 +64,16 @@ describe Pry::Command::Cat::FileFormatter do
       file_with_embedded_line = "pry_instance.rb"
       ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
       file_name, line_num = ff.file_and_line
-      file_name.should == "pry_instance.rb"
-      line_num.should == nil
+      expect(file_name).to eq("pry_instance.rb")
+      expect(line_num).to eq(nil)
     end
 
     it "should parse relative path with line_num" do
       file_with_embedded_line = "pry_instance.rb:2"
       ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
       file_name, line_num = ff.file_and_line
-      file_name.should == "pry_instance.rb"
-      line_num.should == 2
+      expect(file_name).to eq("pry_instance.rb")
+      expect(line_num).to eq(2)
     end
   end
 end

--- a/spec/commands/cat_spec.rb
+++ b/spec/commands/cat_spec.rb
@@ -23,7 +23,7 @@ describe "cat" do
 
   describe "with --in" do
     it 'should display the last few expressions with indices' do
-      @t.eval('10', '20', 'cat --in').should == unindent(<<-STR)
+      expect(@t.eval('10', '20', 'cat --in')).to eq unindent(<<-STR)
         1:
           10
         2:
@@ -34,13 +34,13 @@ describe "cat" do
 
   describe "with --in 1" do
     it 'should display the first expression with no index' do
-      @t.eval('10', '20', 'cat --in 1').should == "10\n"
+      expect(@t.eval('10', '20', 'cat --in 1')).to eq("10\n")
     end
   end
 
   describe "with --in -1" do
     it 'should display the last expression with no index' do
-      @t.eval('10', '20', 'cat --in -1').should == "20\n"
+      expect(@t.eval('10', '20', 'cat --in -1')).to eq("20\n")
     end
   end
 
@@ -50,7 +50,7 @@ describe "cat" do
       @t.insert_nil_input # normally happens when a command is executed
       @t.eval ':hello'
 
-      @t.eval('cat --in 1..3').should == unindent(<<-EOS)
+      expect(@t.eval('cat --in 1..3')).to eq unindent(<<-EOS)
         1:
           10
         3:
@@ -80,7 +80,7 @@ describe "cat" do
             _pry_.last_exception = e
           end
         EOS
-        @t.eval('cat --ex').should =~ /\d+:(\s*) this raises error/
+        expect(@t.eval('cat --ex')).to match(/\d+:(\s*) this raises error/)
       end
 
       it 'cat --ex should correctly display code that generated exception' do
@@ -89,7 +89,7 @@ describe "cat" do
         rescue => e
           @t.last_exception = e
         end
-        @t.eval('cat --ex').should =~ /this method is broken/
+        expect(@t.eval('cat --ex')).to match(/this method is broken/)
       end
     end
   end
@@ -100,7 +100,7 @@ describe "cat" do
         f << "bt number 1"
         f.flush
         @t.last_exception = mock_exception("#{f.path}:1", 'x', 'x')
-        @t.eval('cat --ex').should =~ /bt number 1/
+        expect(@t.eval('cat --ex')).to match(/bt number 1/)
       end
     end
 
@@ -109,7 +109,7 @@ describe "cat" do
         f << "bt number 1"
         f.flush
         @t.last_exception = mock_exception("#{f.path}:1", 'x', 'x')
-        @t.eval('cat --ex 0').should =~ /bt number 1/
+        expect(@t.eval('cat --ex 0')).to match(/bt number 1/)
       end
     end
 
@@ -118,7 +118,7 @@ describe "cat" do
         f << "bt number 2"
         f.flush
         @t.last_exception = mock_exception('x', "#{f.path}:1", 'x')
-        @t.eval('cat --ex 1').should =~ /bt number 2/
+        expect(@t.eval('cat --ex 1')).to match(/bt number 2/)
       end
     end
 
@@ -127,7 +127,7 @@ describe "cat" do
         f << "bt number 3"
         f.flush
         @t.last_exception = mock_exception('x', 'x', "#{f.path}:1")
-        @t.eval('cat --ex 2').should =~ /bt number 3/
+        expect(@t.eval('cat --ex 2')).to match(/bt number 3/)
       end
     end
 
@@ -147,10 +147,10 @@ describe "cat" do
       @t.last_exception = mock_exception(*temp_files.map { |f| "#{f.path}:1" })
 
       3.times do |i|
-        @t.eval('cat --ex').should =~ /bt number #{i}/
+        expect(@t.eval('cat --ex')).to match(/bt number #{i}/)
       end
 
-      @t.eval('cat --ex').should =~ /bt number 0/
+      expect(@t.eval('cat --ex')).to match(/bt number 0/)
 
       temp_files.each do |file|
         file.close(true)

--- a/spec/commands/cd_spec.rb
+++ b/spec/commands/cd_spec.rb
@@ -28,7 +28,7 @@ describe 'cd' do
 
   describe 'state' do
     it 'should not to be set up in fresh instance' do
-      @t.command_state.should equal nil
+      expect(@t.command_state).to equal nil
     end
   end
 
@@ -46,11 +46,11 @@ describe 'cd' do
       it 'should not toggle and should keep correct stacks' do
         expect { @t.eval 'cd %' }.to raise_error Pry::CommandError
 
-        @t.old_stack.should == []
+        expect(@t.old_stack).to eq([])
         @t.assert_binding_stack [@o]
 
         @t.eval 'cd -'
-        @t.old_stack.should == []
+        expect(@t.old_stack).to eq([])
         @t.assert_binding_stack [@o]
       end
     end
@@ -148,42 +148,42 @@ describe 'cd' do
 
   it 'should cd into simple input' do
     @t.eval 'cd :mon_ouie'
-    @t.eval('self').should == :mon_ouie
+    expect(@t.eval('self')).to eq(:mon_ouie)
   end
 
   it 'should break out of session with cd ..' do
     @t.eval 'cd :outer', 'cd :inner'
-    @t.eval('self').should == :inner
+    expect(@t.eval('self')).to eq(:inner)
 
     @t.eval 'cd ..'
-    @t.eval('self').should == :outer
+    expect(@t.eval('self')).to eq(:outer)
   end
 
   it "should not leave the REPL session when given 'cd ..'" do
     @t.eval 'cd ..'
-    @t.eval('self').should == @o
+    expect(@t.eval('self')).to eq(@o)
   end
 
   it 'should break out to outer-most session with cd /' do
     @t.eval 'cd :inner'
-    @t.eval('self').should == :inner
+    expect(@t.eval('self')).to eq(:inner)
 
     @t.eval 'cd 5'
-    @t.eval('self').should == 5
+    expect(@t.eval('self')).to eq(5)
 
     @t.eval 'cd /'
-    @t.eval('self').should == @o
+    expect(@t.eval('self')).to eq(@o)
   end
 
   it 'should break out to outer-most session with just cd (no args)' do
     @t.eval 'cd :inner'
-    @t.eval('self').should == :inner
+    expect(@t.eval('self')).to eq(:inner)
 
     @t.eval 'cd 5'
-    @t.eval('self').should == 5
+    expect(@t.eval('self')).to eq(5)
 
     @t.eval 'cd'
-    @t.eval('self').should == @o
+    expect(@t.eval('self')).to eq(@o)
   end
 
   it 'should cd into an object and its ivar using cd obj/@ivar syntax' do
@@ -218,7 +218,7 @@ describe 'cd' do
 
   it 'should start a session on TOPLEVEL_BINDING with cd ::' do
     @t.eval 'cd ::'
-    @t.eval('self').should == TOPLEVEL_BINDING.eval('self')
+    expect(@t.eval('self')).to eq(TOPLEVEL_BINDING.eval('self'))
   end
 
   it 'should cd into complex input (with spaces)' do
@@ -227,7 +227,7 @@ describe 'cd' do
     end
 
     @t.eval 'cd hello 1, 2, 3'
-    @t.eval('self').should == :mon_ouie
+    expect(@t.eval('self')).to eq(:mon_ouie)
   end
 
   it 'should not cd into complex input when it encounters an exception' do
@@ -238,12 +238,12 @@ describe 'cd' do
 
   it 'can cd into an expression containing a string with slashes in it' do
     @t.eval 'cd ["http://google.com"]'
-    @t.eval('self').should == ["http://google.com"]
+    expect(@t.eval('self')).to eq(["http://google.com"])
   end
 
   it 'can cd into an expression with division in it' do
     @t.eval 'cd (10/2)/even?'
-    @t.eval('self').should == false
+    expect(@t.eval('self')).to eq(false)
   end
 
   # Regression test for ticket #516.

--- a/spec/commands/disable_pry_spec.rb
+++ b/spec/commands/disable_pry_spec.rb
@@ -14,8 +14,8 @@ describe "disable-pry" do
   end
 
   it "should set DISABLE_PRY" do
-    ENV['DISABLE_PRY'].should == nil
+    expect(ENV['DISABLE_PRY']).to eq(nil)
     expect { @t.process_command 'disable-pry' }.to throw_symbol :breakout
-    ENV['DISABLE_PRY'].should == 'true'
+    expect(ENV['DISABLE_PRY']).to eq('true')
   end
 end

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -43,32 +43,32 @@ describe "edit" do
 
     it "should invoke Pry.config.editor with absolutified filenames" do
       pry_eval 'edit lib/pry.rb'
-      @file.should == File.expand_path('lib/pry.rb')
+      expect(@file).to eq(File.expand_path('lib/pry.rb'))
 
       pry_eval "edit #@tf_path"
-      @file.should == @tf_path
+      expect(@file).to eq(@tf_path)
     end
 
     it "should guess the line number from a colon" do
       pry_eval 'edit lib/pry.rb:10'
-      @line.should == 10
+      expect(@line).to eq(10)
     end
 
     it "should use the line number from -l" do
       pry_eval 'edit -l 10 lib/pry.rb'
-      @line.should == 10
+      expect(@line).to eq(10)
     end
 
     it "should not delete the file!" do
       pry_eval 'edit Rakefile'
-      File.exist?(@file).should == true
+      expect(File.exist?(@file)).to eq(true)
     end
 
     it "works with files that contain blanks in their names" do
       tf_path = File.join(File.dirname(@tf_path), 'swoop and doop.rb')
       FileUtils.touch(tf_path)
       pry_eval "edit #{ tf_path }"
-      @file.should == tf_path
+      expect(@file).to eq(tf_path)
       FileUtils.rm(tf_path)
     end
 
@@ -84,7 +84,7 @@ describe "edit" do
           nil
         }
         pry_eval "edit #@tf_path"
-        Pad.required.should == true
+        expect(Pad.required).to eq(true)
       end
     end
 
@@ -104,7 +104,7 @@ describe "edit" do
 
           pry_eval "edit #{path}"
 
-          Pad.counter.should == counter + 1
+          expect(Pad.counter).to eq(counter + 1)
         end
       end
 
@@ -115,7 +115,7 @@ describe "edit" do
 
           pry_eval "edit #{path}"
 
-          Pad.counter.should == counter
+          expect(Pad.counter).to eq(counter)
         end
       end
 
@@ -124,7 +124,7 @@ describe "edit" do
           counter = Pad.counter
           path    = tf.path
 
-          Pad.counter.should == counter
+          expect(Pad.counter).to eq(counter)
         end
       end
 
@@ -135,7 +135,7 @@ describe "edit" do
 
           pry_eval "edit -r #{path}"
 
-          Pad.counter.should == counter + 1
+          expect(Pad.counter).to eq(counter + 1)
         end
       end
     end
@@ -151,9 +151,9 @@ describe "edit" do
 
       it "should pass the editor a reloading arg" do
         pry_eval 'edit lib/pry.rb'
-        @reloading.should == true
+        expect(@reloading).to eq(true)
         pry_eval 'edit -n lib/pry.rb'
-        @reloading.should == false
+        expect(@reloading).to eq(false)
       end
     end
   end
@@ -196,11 +196,11 @@ describe "edit" do
           nil
         }
 
-        defined?(FOO).should equal nil
+        expect(defined?(FOO)).to equal nil
 
         @t.eval 'edit --ex'
 
-        FOO.should == 'BAR'
+        expect(FOO).to eq('BAR')
       end
 
       # regression test (this used to edit the current method instead
@@ -220,7 +220,7 @@ describe "edit" do
           Object.new.pry
         end
 
-        source_location.should == [@path, 3]
+        expect(source_location).to eq([@path, 3])
         Pad.clear
       end
 
@@ -230,11 +230,11 @@ describe "edit" do
           nil
         }
 
-        defined?(FOO2).should equal nil
+        expect(defined?(FOO2)).to equal nil
 
         @t.eval 'edit -n --ex'
 
-        defined?(FOO2).should equal nil
+        expect(defined?(FOO2)).to equal nil
       end
 
       describe "with --patch" do
@@ -246,15 +246,15 @@ describe "edit" do
             nil
           }
 
-          defined?(FOO3).should equal nil
+          expect(defined?(FOO3)).to equal nil
 
           @t.eval 'edit --ex --patch'
 
-          FOO3.should == 'PIYO'
+          expect(FOO3).to eq('PIYO')
 
           @tf.rewind
-          @tf.read.should == "1\n2\nraise RuntimeError"
-          @patched_def.should == "FOO3 = 'PIYO'"
+          expect(@tf.read).to eq("1\n2\nraise RuntimeError")
+          expect(@patched_def).to eq("FOO3 = 'PIYO'")
         end
       end
     end
@@ -272,26 +272,26 @@ describe "edit" do
 
       it 'should start on first level of backtrace with just --ex' do
         @t.eval 'edit -n --ex'
-        @__ex_file__.should == "a"
-        @__ex_line__.should == 1
+        expect(@__ex_file__).to eq("a")
+        expect(@__ex_line__).to eq(1)
       end
 
       it 'should start editor on first level of backtrace with --ex 0' do
         @t.eval 'edit -n --ex 0'
-        @__ex_file__.should == "a"
-        @__ex_line__.should == 1
+        expect(@__ex_file__).to eq("a")
+        expect(@__ex_line__).to eq(1)
       end
 
       it 'should start editor on second level of backtrace with --ex 1' do
         @t.eval 'edit -n --ex 1'
-        @__ex_file__.should == "b"
-        @__ex_line__.should == 2
+        expect(@__ex_file__).to eq("b")
+        expect(@__ex_line__).to eq(2)
       end
 
       it 'should start editor on third level of backtrace with --ex 2' do
         @t.eval 'edit -n --ex 2'
-        @__ex_file__.should == "c"
-        @__ex_line__.should == 3
+        expect(@__ex_file__).to eq("c")
+        expect(@__ex_line__).to eq(3)
       end
 
       it 'should display error message when backtrace level is invalid' do
@@ -308,29 +308,29 @@ describe "edit" do
     it "should edit the current expression if it's incomplete" do
       @t.push 'def a'
       @t.process_command 'edit'
-      @contents.should == "def a\n"
+      expect(@contents).to eq("def a\n")
     end
 
     it "should edit the previous expression if the current is empty" do
       @t.eval 'def a; 2; end', 'edit'
-      @contents.should == "def a; 2; end\n"
+      expect(@contents).to eq("def a; 2; end\n")
     end
 
     it "should use a blank file if -t is specified" do
       @t.eval 'def a; 5; end', 'edit -t'
-      @contents.should == "\n"
+      expect(@contents).to eq("\n")
     end
 
     it "should use a blank file if -t given, even during an expression" do
       @t.push 'def a;'
       @t.process_command 'edit -t'
-      @contents.should == "\n"
+      expect(@contents).to eq("\n")
     end
 
     it "should position the cursor at the end of the expression" do
       @t.eval "def a; 2;\nend"
       @t.process_command 'edit'
-      @line.should == 2
+      expect(@line).to eq(2)
     end
 
     it "should evaluate the expression" do
@@ -339,7 +339,7 @@ describe "edit" do
         nil
       }
       @t.process_command 'edit'
-      @t.eval_string.should == "'FOO'\n"
+      expect(@t.eval_string).to eq("'FOO'\n")
     end
 
     it "should ignore -n for tempfiles" do
@@ -348,7 +348,7 @@ describe "edit" do
         nil
       }
       @t.process_command "edit -n"
-      @t.eval_string.should == "'FOO'\n"
+      expect(@t.eval_string).to eq("'FOO'\n")
     end
 
     it "should not evaluate a file with -n" do
@@ -358,8 +358,8 @@ describe "edit" do
       }
       begin
         @t.process_command 'edit -n spec/fixtures/foo.rb'
-        File.read("spec/fixtures/foo.rb").should == "'FOO'\n"
-        @t.eval_string.should == ''
+        expect(File.read("spec/fixtures/foo.rb")).to eq("'FOO'\n")
+        expect(@t.eval_string).to eq('')
       ensure
         FileUtils.rm "spec/fixtures/foo.rb"
       end
@@ -369,22 +369,22 @@ describe "edit" do
   describe "with --in" do
     it "should edit the nth line of _in_" do
       pry_eval '10', '11', 'edit --in -2'
-      @contents.should == "10\n"
+      expect(@contents).to eq("10\n")
     end
 
     it "should edit the last line if no argument is given" do
       pry_eval '10', '11', 'edit --in'
-      @contents.should == "11\n"
+      expect(@contents).to eq("11\n")
     end
 
     it "should edit a range of lines if a range is given" do
       pry_eval "10", "11", "edit -i 1,2"
-      @contents.should == "10\n11\n"
+      expect(@contents).to eq("10\n11\n")
     end
 
     it "should edit a multi-line expression as it occupies one line of _in_" do
       pry_eval "class Fixnum\n  def invert; -self; end\nend", "edit -i 1"
-      @contents.should == "class Fixnum\n  def invert; -self; end\nend\n"
+      expect(@contents).to eq("class Fixnum\n  def invert; -self; end\nend\n")
     end
 
     it "should not work with a filename" do
@@ -414,18 +414,18 @@ describe "edit" do
       klass    = Class.new do
         def m; 1; end
       end
-      klass.new.m.should == 1
+      expect(klass.new.m).to eq(1)
 
       # now patch it
       use_editor(tester, replace_all: 'def m; 2; end').eval('edit --patch klass#m')
-      klass.new.m.should == 2
+      expect(klass.new.m).to eq(2)
 
       # edit by name, no --patch
       use_editor(tester, replace_all: 'def m; 3; end').eval("edit klass#m")
-      klass.new.m.should == 3
+      expect(klass.new.m).to eq(3)
 
       # original file is unchanged
-      File.readlines(filename)[line-1].strip.should == 'def m; 1; end'
+      expect(File.readlines(filename)[line-1].strip).to eq('def m; 1; end')
     end
 
     it 'can repeatedly edit methods that were defined in the console' do
@@ -434,15 +434,15 @@ describe "edit" do
       tester.eval("klass = Class.new do\n"\
                   "  def m; 1; end\n"\
                   "end")
-      tester.eval("klass.new.m").should == 1
+      expect(tester.eval("klass.new.m")).to eq(1)
 
       # first edit
       use_editor(tester, replace_all: 'def m; 2; end').eval('edit klass#m')
-      tester.eval('klass.new.m').should == 2
+      expect(tester.eval('klass.new.m')).to eq(2)
 
       # repeat edit
       use_editor(tester, replace_all: 'def m; 3; end').eval('edit klass#m')
-      tester.eval('klass.new.m').should == 3
+      expect(tester.eval('klass.new.m')).to eq(3)
     end
   end
 
@@ -513,33 +513,33 @@ describe "edit" do
         it "should correctly find a class method" do
           pry_eval 'edit X.x'
 
-          @file.should == @tempfile_path
-          @line.should == 14
+          expect(@file).to eq(@tempfile_path)
+          expect(@line).to eq(14)
 
         end
 
         it "should correctly find an instance method" do
           pry_eval 'edit X#x'
-          @file.should == @tempfile_path
-          @line.should == 18
+          expect(@file).to eq(@tempfile_path)
+          expect(@line).to eq(18)
         end
 
         it "should correctly find a method on an instance" do
           pry_eval 'x = X.new', 'edit x.x'
-          @file.should == @tempfile_path
-          @line.should == 18
+          expect(@file).to eq(@tempfile_path)
+          expect(@line).to eq(18)
         end
 
         it "should correctly find a method from a module" do
           pry_eval 'edit X#a'
-          @file.should == @tempfile_path
-          @line.should == 2
+          expect(@file).to eq(@tempfile_path)
+          expect(@line).to eq(2)
         end
 
         it "should correctly find an aliased method" do
           pry_eval 'edit X#c'
-          @file.should == @tempfile_path
-          @line.should == 22
+          expect(@file).to eq(@tempfile_path)
+          expect(@line).to eq(22)
         end
       end
 
@@ -562,44 +562,44 @@ describe "edit" do
           class << X
             X.method(:x).owner.should == self
           end
-          X.method(:x).receiver.should == X
-          X.x.should == :maybe
+          expect(X.method(:x).receiver).to eq(X)
+          expect(X.x).to eq(:maybe)
         end
 
         it "should successfully replace an instance method" do
           pry_eval 'edit -p X#x'
 
-          X.instance_method(:x).owner.should == X
-          X.new.x.should == :maybe
+          expect(X.instance_method(:x).owner).to eq(X)
+          expect(X.new.x).to eq(:maybe)
         end
 
         it "should successfully replace a method on an instance" do
           pry_eval 'instance = X.new', 'edit -p instance.x'
 
           instance = X.new
-          instance.method(:x).owner.should == X
-          instance.x.should == :maybe
+          expect(instance.method(:x).owner).to eq(X)
+          expect(instance.x).to eq(:maybe)
         end
 
         it "should successfully replace a method from a module" do
           pry_eval 'edit -p X#a'
 
-          X.instance_method(:a).owner.should == A
-          X.new.a.should == :maybe
+          expect(X.instance_method(:a).owner).to eq(A)
+          expect(X.new.a).to eq(:maybe)
         end
 
         it "should successfully replace a method with a question mark" do
           pry_eval 'edit -p X#y?'
 
-          X.instance_method(:y?).owner.should == X
-          X.new.y?.should == :maybe
+          expect(X.instance_method(:y?).owner).to eq(X)
+          expect(X.new.y?).to eq(:maybe)
         end
 
         it "should preserve module nesting" do
           pry_eval 'edit -p X::B#foo'
 
-          X::B.instance_method(:foo).owner.should == X::B
-          X::B.new.foo.should == :nawt
+          expect(X::B.instance_method(:foo).owner).to eq(X::B)
+          expect(X::B.new.foo).to eq(:nawt)
         end
 
         describe "monkey-patching" do
@@ -638,54 +638,54 @@ describe "edit" do
             def_before, def_after =
               apply_monkey_patch(X.method(:x), "#@edit X.x")
 
-            def_before.should   == ':double_yup'
-            def_after.should    == ':double_yup'
-            @patched_def.should == ':maybe'
+            expect(def_before).to   eq(':double_yup')
+            expect(def_after).to    eq(':double_yup')
+            expect(@patched_def).to eq(':maybe')
           end
 
           it "should work for an instance method" do
             def_before, def_after =
               apply_monkey_patch(X.instance_method(:x), "#@edit X#x")
 
-            def_before.should   == ':nope'
-            def_after.should    == ':nope'
-            @patched_def.should == ':maybe'
+            expect(def_before).to   eq(':nope')
+            expect(def_after).to    eq(':nope')
+            expect(@patched_def).to eq(':maybe')
           end
 
           it "should work for a method on an instance" do
             def_before, def_after =
               apply_monkey_patch(X.instance_method(:x), 'instance = X.new', "#@edit instance.x")
 
-            def_before.should   == ':nope'
-            def_after.should    == ':nope'
-            @patched_def.should == ':maybe'
+            expect(def_before).to   eq(':nope')
+            expect(def_after).to    eq(':nope')
+            expect(@patched_def).to eq(':maybe')
           end
 
           it "should work for a method from a module" do
             def_before, def_after =
               apply_monkey_patch(X.instance_method(:a), "#@edit X#a")
 
-            def_before.should   == ':yup'
-            def_after.should    == ':yup'
-            @patched_def.should == ':maybe'
+            expect(def_before).to   eq(':yup')
+            expect(def_after).to    eq(':yup')
+            expect(@patched_def).to eq(':maybe')
           end
 
           it "should work for a method with a question mark" do
             def_before, def_after =
               apply_monkey_patch(X.instance_method(:y?), "#@edit X#y?")
 
-            def_before.should   == ':because'
-            def_after.should    == ':because'
-            @patched_def.should == ':maybe'
+            expect(def_before).to   eq(':because')
+            expect(def_after).to    eq(':because')
+            expect(@patched_def).to eq(':maybe')
           end
 
           it "should work with nesting" do
             def_before, def_after =
               apply_monkey_patch(X::B.instance_method(:foo), "#@edit X::B#foo")
 
-            def_before.should   == ':possibly'
-            def_after.should    == ':possibly'
-            @patched_def.should == ':maybe'
+            expect(def_before).to   eq(':possibly')
+            expect(def_after).to    eq(':possibly')
+            expect(@patched_def).to eq(':maybe')
           end
         end
       end
@@ -708,10 +708,10 @@ describe "edit" do
           pry_eval 'edit -p X#c'
 
 
-          Pry::Method.from_str("X#c").alias?.should == true
+          expect(Pry::Method.from_str("X#c").alias?).to eq(true)
 
-          X.new.b.should == :kinda
-          X.new.c.should == :kindaaa
+          expect(X.new.b).to eq(:kinda)
+          expect(X.new.c).to eq(:kindaaa)
           $x = nil
         end
       end
@@ -727,9 +727,9 @@ describe "edit" do
 
         it "should pass the editor a reloading arg" do
           pry_eval 'edit X.x'
-          @reloading.should == true
+          expect(@reloading).to eq(true)
           pry_eval 'edit -n X.x'
-          @reloading.should == false
+          expect(@reloading).to eq(false)
         end
       end
     end
@@ -758,7 +758,7 @@ describe "edit" do
 
     it 'should edit method context' do
       Pry.config.editor = lambda do |file, line|
-        [file, line].should == BinkyWink.instance_method(:m2).source_location
+        expect([file, line]).to eq(BinkyWink.instance_method(:m2).source_location)
         nil
       end
 
@@ -768,7 +768,7 @@ describe "edit" do
 
     it 'errors when cannot find method context' do
       Pry.config.editor = lambda do |file, line|
-        [file, line].should == BinkyWink.instance_method(:m1).source_location
+        expect([file, line]).to eq(BinkyWink.instance_method(:m1).source_location)
         nil
       end
 

--- a/spec/commands/exit_all_spec.rb
+++ b/spec/commands/exit_all_spec.rb
@@ -4,24 +4,24 @@ describe "exit-all" do
   before { @pry = Pry.new }
 
   it "should break out of the repl and return nil" do
-    @pry.eval("exit-all").should equal false
-    @pry.exit_value.should equal nil
+    expect(@pry.eval("exit-all")).to equal false
+    expect(@pry.exit_value).to equal nil
   end
 
   it "should break out of the repl wth a user specified value" do
-    @pry.eval("exit-all 'message'").should equal false
-    @pry.exit_value.should == "message"
+    expect(@pry.eval("exit-all 'message'")).to equal false
+    expect(@pry.exit_value).to eq("message")
   end
 
   it "should break out of the repl even if multiple bindings still on stack" do
-    ["cd 1", "cd 2"].each { |line| @pry.eval(line).should equal true }
-    @pry.eval("exit-all 'message'").should equal false
-    @pry.exit_value.should == "message"
+    ["cd 1", "cd 2"].each { |line| expect(@pry.eval(line)).to equal true }
+    expect(@pry.eval("exit-all 'message'")).to equal false
+    expect(@pry.exit_value).to eq("message")
   end
 
   it "should have empty binding_stack after breaking out of the repl" do
-    ["cd 1", "cd 2"].each { |line| @pry.eval(line).should equal true }
-    @pry.eval("exit-all").should equal false
-    @pry.binding_stack.should be_empty
+    ["cd 1", "cd 2"].each { |line| expect(@pry.eval(line)).to equal true }
+    expect(@pry.eval("exit-all")).to equal false
+    expect(@pry.binding_stack).to be_empty
   end
 end

--- a/spec/commands/exit_program_spec.rb
+++ b/spec/commands/exit_program_spec.rb
@@ -9,7 +9,7 @@ describe "exit-program" do
     begin
       pry_eval 'exit-program 66'
     rescue SystemExit => e
-      e.status.should == 66
+      expect(e.status).to eq(66)
     else
       raise "Failed to raise SystemExit"
     end

--- a/spec/commands/exit_spec.rb
+++ b/spec/commands/exit_spec.rb
@@ -5,24 +5,24 @@ describe "exit" do
 
   it "should pop a binding" do
     @pry.eval "cd :inner"
-    @pry.evaluate_ruby("self").should == :inner
+    expect(@pry.evaluate_ruby("self")).to eq(:inner)
     @pry.eval "exit"
-    @pry.evaluate_ruby("self").should == :outer
+    expect(@pry.evaluate_ruby("self")).to eq(:outer)
   end
 
   it "should break out of the repl when binding_stack has only one binding" do
-    @pry.eval("exit").should equal false
-    @pry.exit_value.should equal nil
+    expect(@pry.eval("exit")).to equal false
+    expect(@pry.exit_value).to equal nil
   end
 
   it "should break out of the repl and return user-given value" do
-    @pry.eval("exit :john").should equal false
-    @pry.exit_value.should == :john
+    expect(@pry.eval("exit :john")).to equal false
+    expect(@pry.exit_value).to eq(:john)
   end
 
   it "should break out of the repl even after an exception" do
     @pry.eval "exit = 42"
-    @pry.output.string.should =~ /^SyntaxError/
-    @pry.eval("exit").should equal false
+    expect(@pry.output.string).to match(/^SyntaxError/)
+    expect(@pry.eval("exit")).to equal false
   end
 end

--- a/spec/commands/find_method_spec.rb
+++ b/spec/commands/find_method_spec.rb
@@ -18,25 +18,29 @@ describe "find-method" do
 
   describe "find matching methods by name regex (-n option)" do
     it "should find a method by regex" do
-      pry_eval(binding, "find-method hell MyKlass").should =~
+      expect(pry_eval(binding, "find-method hell MyKlass")).to match(
         /MyKlass.*?hello/m
+      )
     end
 
     it "should NOT match a method that does not match the regex" do
-      pry_eval(binding, "find-method hell MyKlass").should_not =~
+      expect(pry_eval(binding, "find-method hell MyKlass")).not_to match(
         /MyKlass.*?goodbye/m
+      )
     end
   end
 
   describe "find matching methods by content regex (-c option)" do
     it "should find a method by regex" do
-      pry_eval(binding, "find-method -c timothy MyKlass").should =~
+      expect(pry_eval(binding, "find-method -c timothy MyKlass")).to match(
         /MyKlass.*?hello/m
+      )
     end
 
     it "should NOT match a method that does not match the regex" do
-      pry_eval(binding, "find-method timothy MyKlass").should_not =~
+      expect(pry_eval(binding, "find-method timothy MyKlass")).not_to match(
         /MyKlass.*?goodbye/m
+      )
     end
   end
 
@@ -46,16 +50,17 @@ describe "find-method" do
       raise "mooo"
     end
 
-    pry_eval(binding, "find-method -c timothy MyKlass").should =~
+    expect(pry_eval(binding, "find-method -c timothy MyKlass")).to match(
       /MyKlass.*?hello/m
+    )
   end
 
   it "should escape regexes correctly" do
     good = /tea_time\?/
     bad  = /tea_tim\?/
-    pry_eval(binding, 'find-method tea_time? MyKlass').should =~ good
-    pry_eval(binding, 'find-method tea_time? MyKlass').should =~ good
-    pry_eval(binding, 'find-method tea_time\? MyKlass').should_not =~ bad
-    pry_eval(binding, 'find-method tea_time\? MyKlass').should =~ good
+    expect(pry_eval(binding, 'find-method tea_time? MyKlass')).to match(good)
+    expect(pry_eval(binding, 'find-method tea_time? MyKlass')).to match(good)
+    expect(pry_eval(binding, 'find-method tea_time\? MyKlass')).not_to match(bad)
+    expect(pry_eval(binding, 'find-method tea_time\? MyKlass')).to match(good)
   end
 end

--- a/spec/commands/gem_list_spec.rb
+++ b/spec/commands/gem_list_spec.rb
@@ -7,17 +7,17 @@ describe "gem-list" do
 
   it 'should work arglessly' do
     list = pry_eval('gem-list')
-    list.should =~ /slop \(/
-    list.should =~ /rspec \(/
+    expect(list).to match(/slop \(/)
+    expect(list).to match(/rspec \(/)
   end
 
   it 'should find arg' do
     prylist = pry_eval('gem-list slop')
-    prylist.should =~ /slop \(/
-    prylist.should_not =~ /rspec/
+    expect(prylist).to match(/slop \(/)
+    expect(prylist).not_to match(/rspec/)
   end
 
   it 'should return non-results as silence' do
-    pry_eval('gem-list aoeuoueouaou').should be_empty
+    expect(pry_eval('gem-list aoeuoueouaou')).to be_empty
   end
 end

--- a/spec/commands/gist_spec.rb
+++ b/spec/commands/gist_spec.rb
@@ -6,7 +6,7 @@ require_relative '../helper'
 
 describe 'gist' do
   it 'has a dependency on the jist gem' do
-    Pry::Command::Gist.command_options[:requires_gem].should == "gist"
+    expect(Pry::Command::Gist.command_options[:requires_gem]).to eq("gist")
   end
 
   before do
@@ -27,6 +27,6 @@ describe 'gist' do
 
   it 'nominally logs in' do
     pry_eval 'gist --login'
-    Pad.gist_calls[:login!].should_not be_nil
+    expect(Pad.gist_calls[:login!]).not_to be_nil
   end
 end

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -13,17 +13,17 @@ describe "help" do
   end
 
   it 'should display help for a specific command' do
-    pry_eval('help ls').should =~ /Usage: ls/
+    expect(pry_eval('help ls')).to match(/Usage: ls/)
   end
 
   it 'should display help for a regex command with a "listing"' do
     @set.command /bar(.*)/, "Test listing", :listing => "foo" do; end
-    pry_eval('help foo').should =~ /Test listing/
+    expect(pry_eval('help foo')).to match(/Test listing/)
   end
 
   it 'should display help for a command with a spaces in its name' do
     @set.command "cmd with spaces", "desc of a cmd with spaces" do; end
-    pry_eval('help "cmd with spaces"').should =~ /desc of a cmd with spaces/
+    expect(pry_eval('help "cmd with spaces"')).to match(/desc of a cmd with spaces/)
   end
 
   it 'should display help for all commands with a description' do
@@ -33,9 +33,9 @@ describe "help" do
     @set.command "d", "" do;end
 
     output = pry_eval('help')
-    output.should =~ /Test listing/
-    output.should =~ /Description for b/
-    output.should =~ /No description/
+    expect(output).to match(/Test listing/)
+    expect(output).to match(/Description for b/)
+    expect(output).to match(/No description/)
   end
 
   it "should sort the output of the 'help' command" do
@@ -51,6 +51,6 @@ describe "help" do
              doc.index("gaa"),
              doc.index("maa")]
 
-    order.should == order.sort
+    expect(order).to eq(order.sort)
   end
 end

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -24,7 +24,7 @@ describe "hist" do
     @t.push_binding o
     @t.eval 'hist --replay -1'
 
-    o.instance_variable_get(:@z).should == 30
+    expect(o.instance_variable_get(:@z)).to eq(30)
   end
 
   it 'should replay a range of history correctly (range of items)' do
@@ -34,7 +34,7 @@ describe "hist" do
 
     @t.push_binding o
     @t.eval 'hist --replay 0..2'
-    @t.eval('[@x, @y]').should == [10, 20]
+    expect(@t.eval('[@x, @y]')).to eq([10, 20])
   end
 
   # this is to prevent a regression where input redirection is
@@ -46,7 +46,7 @@ describe "hist" do
 
     @t.eval("hist --replay 0..2")
     stack = @t.eval("Pad.stack = _pry_.binding_stack.dup")
-    stack.map{ |b| b.eval("self") }.should == [TOPLEVEL_BINDING.eval("self"), 1, 2]
+    expect(stack.map{ |b| b.eval("self") }).to eq([TOPLEVEL_BINDING.eval("self"), 1, 2])
   end
 
   it 'should grep for correct lines in history' do
@@ -60,13 +60,13 @@ describe "hist" do
     @hist.push "def boink 2"
     @hist.push "place holder"
 
-    @t.eval('hist --grep o').should =~ /\d:.*?box\n\d:.*?button\n\d:.*?orange/
+    expect(@t.eval('hist --grep o')).to match(/\d:.*?box\n\d:.*?button\n\d:.*?orange/)
 
     # test more than one word in a regex match (def blah)
-    @t.eval('hist --grep def blah').should =~ /def blah 1/
+    expect(@t.eval('hist --grep def blah')).to match(/def blah 1/)
 
     # test more than one word with leading white space in a regex match (def boink)
-    @t.eval('hist --grep      def boink').should =~ /def boink 2/
+    expect(@t.eval('hist --grep      def boink')).to match(/def boink 2/)
   end
 
   it 'should return last N lines in history with --tail switch' do
@@ -75,14 +75,14 @@ describe "hist" do
     end
 
     out = @t.eval 'hist --tail 3'
-    out.each_line.count.should == 3
-    out.should =~ /x\n\d+:.*y\n\d+:.*z/
+    expect(out.each_line.count).to eq(3)
+    expect(out).to match(/x\n\d+:.*y\n\d+:.*z/)
   end
 
   it "should start from beginning if tail number is longer than history" do
     @hist.push 'Hyacinth'
     out = @t.eval 'hist --tail'
-    out.should =~ /Hyacinth/
+    expect(out).to match(/Hyacinth/)
   end
 
   it 'should apply --tail after --grep' do
@@ -93,8 +93,8 @@ describe "hist" do
     @hist.push "puts  5"
 
     out = @t.eval 'hist --tail 2 --grep print'
-    out.each_line.count.should == 2
-    out.should =~ /\d:.*?print 2\n\d:.*?print 4/
+    expect(out.each_line.count).to eq(2)
+    expect(out).to match(/\d:.*?print 2\n\d:.*?print 4/)
   end
 
   it 'should apply --head after --grep' do
@@ -105,8 +105,8 @@ describe "hist" do
     @hist.push "print 5"
 
     out = @t.eval 'hist --head 2 --grep print'
-    out.each_line.count.should == 2
-    out.should =~ /\d:.*?print 2\n\d:.*?print 4/
+    expect(out.each_line.count).to eq(2)
+    expect(out).to match(/\d:.*?print 2\n\d:.*?print 4/)
   end
 
   # strangeness in this test is due to bug in Readline::HISTORY not
@@ -117,8 +117,8 @@ describe "hist" do
     end
 
     out = @t.eval 'hist --head 4'
-    out.each_line.count.should == 4
-    out.should =~ /a\n\d+:.*b\n\d+:.*c/
+    expect(out.each_line.count).to eq(4)
+    expect(out).to match(/a\n\d+:.*b\n\d+:.*c/)
   end
 
   # strangeness in this test is due to bug in Readline::HISTORY not
@@ -129,14 +129,14 @@ describe "hist" do
     end
 
     out = @t.eval 'hist --show 1..4'
-    out.each_line.count.should == 4
-    out.should =~ /b\n\d+:.*c\n\d+:.*d/
+    expect(out.each_line.count).to eq(4)
+    expect(out).to match(/b\n\d+:.*c\n\d+:.*d/)
   end
 
   it "should store a call with `--replay` flag" do
     @t.eval ":banzai"
     @t.eval "hist --replay 1"
-    @t.eval("hist").should =~ /hist --replay 1/
+    expect(@t.eval("hist")).to match(/hist --replay 1/)
   end
 
   it "should not contain lines produced by `--replay` flag" do
@@ -146,7 +146,7 @@ describe "hist" do
     @t.eval("hist --replay 1..3")
 
     output = @t.eval("hist")
-    output.should == "1: :banzai\n2: :geronimo\n3: :huzzah\n4: hist --replay 1..3\n"
+    expect(output).to eq("1: :banzai\n2: :geronimo\n3: :huzzah\n4: hist --replay 1..3\n")
   end
 
   it "should raise CommandError when index of `--replay` points out to another `hist --replay`" do
@@ -161,14 +161,14 @@ describe "hist" do
     @t.eval "a += 1"
     @t.eval "hist --replay 2"
     expect { @t.eval "hist --replay 3" }.to raise_error Pry::CommandError
-    @t.eval("a").should == 2
-    @t.eval("hist").lines.to_a.size.should == 5
+    expect(@t.eval("a")).to eq(2)
+    expect(@t.eval("hist").lines.to_a.size).to eq(5)
   end
 
   it "excludes Pry commands from the history with `-e` switch" do
     @hist.push('a = 20')
     @hist.push('ls')
-    pry_eval('hist -e').should == "1: a = 20\n"
+    expect(pry_eval('hist -e')).to eq("1: a = 20\n")
   end
 
   describe "sessions" do
@@ -186,7 +186,7 @@ describe "hist" do
       @hist.push('hello')
       @hist.push('world')
 
-      @t.eval('hist').should =~ /1:\shello\n2:\sworld/
+      expect(@t.eval('hist')).to match(/1:\shello\n2:\sworld/)
     end
 
     it "displays all history (including the current sesion) with `--all` switch" do
@@ -194,8 +194,8 @@ describe "hist" do
       @hist.push('world')
 
       output = @t.eval('hist --all')
-      output.should =~ /1:\s:athos\n2:\s:porthos\n3:\s:aramis\n/
-      output.should =~ /4:\sgoodbye\n5:\sworld/
+      expect(output).to match(/1:\s:athos\n2:\s:porthos\n3:\s:aramis\n/)
+      expect(output).to match(/4:\sgoodbye\n5:\sworld/)
     end
   end
 end

--- a/spec/commands/jump_to_spec.rb
+++ b/spec/commands/jump_to_spec.rb
@@ -2,14 +2,14 @@ require_relative '../helper'
 
 describe "jump-to" do
   it 'should jump to the proper binding index in the stack' do
-    pry_eval('cd 1', 'cd 2', 'jump-to 1', 'self').should == 1
+    expect(pry_eval('cd 1', 'cd 2', 'jump-to 1', 'self')).to eq(1)
   end
 
   it 'should print error when trying to jump to a non-existent binding index' do
-    pry_eval("cd 1", "cd 2", "jump-to 100").should =~ /Invalid nest level/
+    expect(pry_eval("cd 1", "cd 2", "jump-to 100")).to match(/Invalid nest level/)
   end
 
   it 'should print error when trying to jump to the same binding index' do
-    pry_eval("cd 1", "cd 2", "jump-to 2").should =~ /Already/
+    expect(pry_eval("cd 1", "cd 2", "jump-to 2")).to match(/Already/)
   end
 end

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -3,80 +3,80 @@ require_relative '../helper'
 describe "ls" do
   describe "below ceiling" do
     it "should stop before Object by default" do
-      pry_eval("cd Class.new{ def goo; end }.new", "ls").should_not =~ /Object/
-      pry_eval("cd Class.new{ def goo; end }", "ls -M").should_not =~ /Object/
+      expect(pry_eval("cd Class.new{ def goo; end }.new", "ls")).not_to match(/Object/)
+      expect(pry_eval("cd Class.new{ def goo; end }", "ls -M")).not_to match(/Object/)
     end
 
     it "should include object if -v is given" do
-      pry_eval("cd Class.new{ def goo; end }.new", "ls -m -v").should =~ /Object/
-      pry_eval("cd Class.new{ def goo; end }", "ls -vM").should =~ /Object/
+      expect(pry_eval("cd Class.new{ def goo; end }.new", "ls -m -v")).to match(/Object/)
+      expect(pry_eval("cd Class.new{ def goo; end }", "ls -vM")).to match(/Object/)
     end
 
     it "should include super-classes by default" do
-      pry_eval(
+      expect(pry_eval(
         "cd Class.new(Class.new{ def goo; end; public :goo }).new",
-        "ls").should =~ /goo/
+        "ls")).to match(/goo/)
 
-      pry_eval(
+      expect(pry_eval(
         "cd Class.new(Class.new{ def goo; end; public :goo })",
-        "ls -M").should =~ /goo/
+        "ls -M")).to match(/goo/)
     end
 
     it "should not include super-classes when -q is given" do
-      pry_eval("cd Class.new(Class.new{ def goo; end }).new", "ls -q").should_not =~ /goo/
-      pry_eval("cd Class.new(Class.new{ def goo; end })", "ls -M -q").should_not =~ /goo/
+      expect(pry_eval("cd Class.new(Class.new{ def goo; end }).new", "ls -q")).not_to match(/goo/)
+      expect(pry_eval("cd Class.new(Class.new{ def goo; end })", "ls -M -q")).not_to match(/goo/)
     end
   end
 
   describe "help" do
     it 'should show help with -h' do
-      pry_eval("ls -h").should =~ /Usage: ls/
+      expect(pry_eval("ls -h")).to match(/Usage: ls/)
     end
   end
 
   describe "BasicObject" do
     it "should work on BasicObject" do
-      pry_eval("ls BasicObject.new").should =~ /BasicObject#methods:.*__send__/m
+      expect(pry_eval("ls BasicObject.new")).to match(/BasicObject#methods:.*__send__/m)
     end
 
     it "should work on subclasses of BasicObject" do
-      pry_eval(
+      expect(pry_eval(
         "class LessBasic < BasicObject; def jaroussky; 5; end; end",
         "ls LessBasic.new"
-      ).should =~ /LessBasic#methods:.*jaroussky/m
+      )).to match(/LessBasic#methods:.*jaroussky/m)
     end
   end
 
   describe "immediates" do
     it "should work on Fixnum" do
-      pry_eval("ls 5").should =~ /Fixnum#methods:.*modulo/m
+      expect(pry_eval("ls 5")).to match(/Fixnum#methods:.*modulo/m)
     end
   end
 
   describe "methods" do
     it "should show public methods by default" do
       output = pry_eval("ls Class.new{ def goo; end; public :goo }.new")
-      output.should =~ /methods: goo/
+      expect(output).to match(/methods: goo/)
     end
 
     it "should not show protected/private by default" do
-      pry_eval("ls -M Class.new{ def goo; end; private :goo }").should_not =~ /goo/
-      pry_eval("ls Class.new{ def goo; end; protected :goo }.new").should_not =~ /goo/
+      expect(pry_eval("ls -M Class.new{ def goo; end; private :goo }")).not_to match(/goo/)
+      expect(pry_eval("ls Class.new{ def goo; end; protected :goo }.new")).not_to match(/goo/)
     end
 
     it "should show public methods with -p" do
-      pry_eval("ls -p Class.new{ def goo; end }.new").should =~ /methods: goo/
+      expect(pry_eval("ls -p Class.new{ def goo; end }.new")).to match(/methods: goo/)
     end
 
     it "should show protected/private methods with -p" do
-      pry_eval("ls -pM Class.new{ def goo; end; protected :goo }").should =~ /methods: goo/
-      pry_eval("ls -p Class.new{ def goo; end; private :goo }.new").should =~ /methods: goo/
+      expect(pry_eval("ls -pM Class.new{ def goo; end; protected :goo }")).to match(/methods: goo/)
+      expect(pry_eval("ls -p Class.new{ def goo; end; private :goo }.new")).to match(/methods: goo/)
     end
 
     it "should work for objects with an overridden method method" do
       require 'net/http'
       # This doesn't actually touch the network, promise!
-      pry_eval("ls Net::HTTP::Get.new('localhost')").should =~ /Net::HTTPGenericRequest#methods/
+      expect(pry_eval("ls Net::HTTP::Get.new('localhost')")).to match(/Net::HTTPGenericRequest#methods/)
     end
 
     it "should work for objects which instance_variables returns array of symbol but there is no Symbol#downcase" do
@@ -105,7 +105,7 @@ describe "ls" do
     unless Pry::Helpers::BaseHelpers.rbx?
       it "should handle classes that (pathologically) define .ancestors" do
         output = pry_eval("ls Class.new{ def self.ancestors; end; def hihi; end }")
-        output.should =~ /hihi/
+        expect(output).to match(/hihi/)
       end
     end
   end
@@ -113,38 +113,38 @@ describe "ls" do
   describe 'with -l' do
     focus 'should find locals and sort by descending size' do
       result = pry_eval(Object.new, "aa = 'asdf'; bb = 'xyz'", 'ls -l')
-      result.should_not =~ /=>/
-      result.should_not =~ /0x\d{5}/
-      result.should =~ /asdf.*xyz/m
+      expect(result).not_to match(/=>/)
+      expect(result).not_to match(/0x\d{5}/)
+      expect(result).to match(/asdf.*xyz/m)
     end
     it 'should not list pry noise' do
-      pry_eval('ls -l').should_not =~ /_(?:dir|file|ex|pry|out|in)_/
+      expect(pry_eval('ls -l')).not_to match(/_(?:dir|file|ex|pry|out|in)_/)
     end
   end
 
   describe "when inside Modules" do
     it "should still work" do
-      pry_eval(
+      expect(pry_eval(
         "cd Module.new{ def foobie; end; public :foobie }",
-        "ls -M").should =~ /foobie/
+        "ls -M")).to match(/foobie/)
     end
 
     it "should work for ivars" do
-      pry_eval(
+      expect(pry_eval(
         "module StigmaT1sm; def foobie; @@gharble = 456; end; end",
         "Object.new.tap{ |o| o.extend(StigmaT1sm) }.foobie",
         "cd StigmaT1sm",
-        "ls -i").should =~ /@@gharble/
+        "ls -i")).to match(/@@gharble/)
     end
 
     it "should include instance methods by default" do
       output = pry_eval(
         "ls Module.new{ def shinanagarns; 4; end; public :shinanagarns }")
-      output.should =~ /shinanagarns/
+      expect(output).to match(/shinanagarns/)
     end
 
     it "should behave normally when invoked on Module itself" do
-      pry_eval("ls Module").should_not =~ /Pry/
+      expect(pry_eval("ls Module")).not_to match(/Pry/)
     end
   end
 
@@ -152,20 +152,20 @@ describe "ls" do
     it "works on top-level" do
       toplevel_consts = pry_eval('ls -c')
       [/RUBY_PLATFORM/, /ARGF/, /STDOUT/].each do |const|
-        toplevel_consts.should =~ const
+        expect(toplevel_consts).to match(const)
       end
     end
 
     it "should show constants defined on the current module" do
-      pry_eval("class TempFoo1; BARGHL = 1; end", "ls TempFoo1").should =~ /BARGHL/
+      expect(pry_eval("class TempFoo1; BARGHL = 1; end", "ls TempFoo1")).to match(/BARGHL/)
     end
 
     it "should not show constants defined on parent modules by default" do
-      pry_eval("class TempFoo2; LHGRAB = 1; end; class TempFoo3 < TempFoo2; BARGHL = 1; end", "ls TempFoo3").should_not =~ /LHGRAB/
+      expect(pry_eval("class TempFoo2; LHGRAB = 1; end; class TempFoo3 < TempFoo2; BARGHL = 1; end", "ls TempFoo3")).not_to match(/LHGRAB/)
     end
 
     it "should show constants defined on ancestors with -v" do
-      pry_eval("class TempFoo4; LHGRAB = 1; end; class TempFoo5 < TempFoo4; BARGHL = 1; end", "ls -v TempFoo5").should =~ /LHGRAB/
+      expect(pry_eval("class TempFoo4; LHGRAB = 1; end; class TempFoo5 < TempFoo4; BARGHL = 1; end", "ls -v TempFoo5")).to match(/LHGRAB/)
     end
 
     it "should not autoload constants!" do
@@ -174,22 +174,22 @@ describe "ls" do
     end
 
     it "should show constants for an object's class regardless of mixins" do
-      pry_eval(
+      expect(pry_eval(
         "cd Pry.new",
         "extend Module.new",
         "ls -c"
-      ).should match(/Method/)
+      )).to match(/Method/)
     end
   end
 
   describe "grep" do
     it "should reduce the number of outputted things" do
-      pry_eval("ls -c Object").should =~ /ArgumentError/
-      pry_eval("ls -c Object --grep Run").should_not =~ /ArgumentError/
+      expect(pry_eval("ls -c Object")).to match(/ArgumentError/)
+      expect(pry_eval("ls -c Object --grep Run")).not_to match(/ArgumentError/)
     end
 
     it "should still output matching things" do
-      pry_eval("ls -c Object --grep Run").should =~ /RuntimeError/
+      expect(pry_eval("ls -c Object --grep Run")).to match(/RuntimeError/)
     end
   end
 
@@ -198,33 +198,33 @@ describe "ls" do
       # rubinius has a bug that means local_variables of "main" aren't reported inside eval()
       unless Pry::Helpers::BaseHelpers.rbx?
         it "should show local variables" do
-          pry_eval("ls").should =~ /_pry_/
-          pry_eval("arbitrar = 1", "ls").should =~ /arbitrar/
+          expect(pry_eval("ls")).to match(/_pry_/)
+          expect(pry_eval("arbitrar = 1", "ls")).to match(/arbitrar/)
         end
       end
     end
 
     describe "when in a class" do
       it "should show constants" do
-        pry_eval("class GeFromulate1; FOOTIFICATE=1.3; end", "cd GeFromulate1", "ls").should =~ /FOOTIFICATE/
+        expect(pry_eval("class GeFromulate1; FOOTIFICATE=1.3; end", "cd GeFromulate1", "ls")).to match(/FOOTIFICATE/)
       end
 
       it "should show class variables" do
-        pry_eval("class GeFromulate2; @@flurb=1.3; end", "cd GeFromulate2", "ls").should =~ /@@flurb/
+        expect(pry_eval("class GeFromulate2; @@flurb=1.3; end", "cd GeFromulate2", "ls")).to match(/@@flurb/)
       end
 
       it "should show methods" do
-        pry_eval("class GeFromulate3; def self.mooflight; end ; end", "cd GeFromulate3", "ls").should =~ /mooflight/
+        expect(pry_eval("class GeFromulate3; def self.mooflight; end ; end", "cd GeFromulate3", "ls")).to match(/mooflight/)
       end
     end
 
     describe "when in an object" do
       it "should show methods" do
-        pry_eval("cd Class.new{ def self.fooerise; end; self }", "ls").should =~ /fooerise/
+        expect(pry_eval("cd Class.new{ def self.fooerise; end; self }", "ls")).to match(/fooerise/)
       end
 
       it "should show instance variables" do
-        pry_eval("cd Class.new", "@alphooent = 1", "ls").should =~ /@alphooent/
+        expect(pry_eval("cd Class.new", "@alphooent = 1", "ls")).to match(/@alphooent/)
       end
     end
   end
@@ -232,13 +232,13 @@ describe "ls" do
   if Pry::Helpers::BaseHelpers.jruby?
     describe 'on java objects' do
       it 'should omit java-esque aliases by default' do
-        pry_eval('ls java.lang.Thread.current_thread').should =~ /\bthread_group\b/
-        pry_eval('ls java.lang.Thread.current_thread').should_not =~ /\bgetThreadGroup\b/
+        expect(pry_eval('ls java.lang.Thread.current_thread')).to match(/\bthread_group\b/)
+        expect(pry_eval('ls java.lang.Thread.current_thread')).not_to match(/\bgetThreadGroup\b/)
       end
 
       it 'should include java-esque aliases if requested' do
-        pry_eval('ls java.lang.Thread.current_thread -J').should =~ /\bthread_group\b/
-        pry_eval('ls java.lang.Thread.current_thread -J').should =~ /\bgetThreadGroup\b/
+        expect(pry_eval('ls java.lang.Thread.current_thread -J')).to match(/\bthread_group\b/)
+        expect(pry_eval('ls java.lang.Thread.current_thread -J')).to match(/\bgetThreadGroup\b/)
       end
     end
   end

--- a/spec/commands/play_spec.rb
+++ b/spec/commands/play_spec.rb
@@ -39,7 +39,7 @@ describe "play" do
   describe "playing a file" do
     it 'should play a file' do
       @t.process_command 'play spec/fixtures/whereami_helper.rb'
-      @t.eval_string.should == unindent(<<-STR)
+      expect(@t.eval_string).to eq unindent(<<-STR)
         class Cor
           def a; end
           def b; end
@@ -52,7 +52,7 @@ describe "play" do
 
     it 'should output file contents with print option' do
       @t.process_command 'play --print spec/fixtures/whereami_helper.rb'
-      @t.last_output.should == unindent(<<-STR)
+      expect(@t.last_output).to eq unindent(<<-STR)
         1: class Cor
         2:   def a; end
         3:   def b; end
@@ -78,7 +78,7 @@ describe "play" do
       end
 
       @t.process_command 'play -d test_method'
-      @t.eval_string.should == unindent(<<-STR)
+      expect(@t.eval_string).to eq unindent(<<-STR)
         @v = 10
         @y = 20
       STR
@@ -94,7 +94,7 @@ describe "play" do
       end
 
       @t.process_command 'play -d test_method --lines 2..3'
-      @t.eval_string.should == unindent(<<-STR)
+      expect(@t.eval_string).to eq unindent(<<-STR)
         @v = 10
         @y = 20
       STR
@@ -106,7 +106,7 @@ describe "play" do
 
     it 'should play a method (a single line)' do
       @t.process_command 'play test_method --lines 2'
-      @t.eval_string.should == ":test_method_content\n"
+      expect(@t.eval_string).to eq(":test_method_content\n")
     end
 
     it 'should properly reindent lines' do
@@ -115,7 +115,7 @@ describe "play" do
       end
 
       @t.process_command 'play test_method --lines 2'
-      @t.eval_string.should == "'hello world'\n"
+      expect(@t.eval_string).to eq("'hello world'\n")
     end
 
     it 'should APPEND to the input buffer when playing a method line, not replace it' do
@@ -125,7 +125,7 @@ describe "play" do
 
       @t.process_command 'play test_method --lines 2'
 
-      @t.eval_string.should == unindent(<<-STR)
+      expect(@t.eval_string).to eq unindent(<<-STR)
         def another_test_method
           :test_method_content
       STR
@@ -140,7 +140,7 @@ describe "play" do
       end
 
       @t.process_command 'play test_method --lines 3..4'
-      @t.eval_string.should == unindent(<<-STR, 0)
+      expect(@t.eval_string).to eq unindent(<<-STR, 0)
         @var1 = 20
         @var2 = 30
       STR
@@ -155,8 +155,8 @@ describe "play" do
           binding.pry
         end
 
-        [a, b, c].all? { |v| v.should == 2 }
-        d.should == 1
+        [a, b, c].all? { |v| expect(v).to eq(2) }
+        expect(d).to eq(1)
       end
     end
 
@@ -170,7 +170,7 @@ describe "play" do
         end
 
         @t.process_command 'play test_method -e 2'
-        @t.eval_string.should == unindent(<<-STR, 0)
+        expect(@t.eval_string).to eq unindent(<<-STR, 0)
           @s = [
             1,2,3,
             4,5,6

--- a/spec/commands/raise_up_spec.rb
+++ b/spec/commands/raise_up_spec.rb
@@ -29,8 +29,8 @@ describe "raise-up" do
       Pry.start(:outer)
     end
 
-    Pad.inner.should == :inner
-    Pad.outer.should == :outer
+    expect(Pad.inner).to eq(:inner)
+    expect(Pad.outer).to eq(:outer)
   end
 
   it "should raise the most recently raised exception" do
@@ -45,9 +45,9 @@ describe "raise-up" do
       expect { Pry.start(:outer) }.to raise_error NoMethodError
     end
 
-    Pad.deep.should  == :deep
-    Pad.inner.should == :inner
-    Pad.outer.should == :outer
+    expect(Pad.deep).to  eq(:deep)
+    expect(Pad.inner).to eq(:inner)
+    expect(Pad.outer).to eq(:outer)
   end
 
   it "should jump immediately out of nested contexts with !" do

--- a/spec/commands/reload_code_spec.rb
+++ b/spec/commands/reload_code_spec.rb
@@ -19,7 +19,7 @@ describe "reload_code" do
     end
 
     it 'reloads pry commmand' do
-      pry_eval("reload-code reload-code").should =~ /reload-code was reloaded!/
+      expect(pry_eval("reload-code reload-code")).to match(/reload-code was reloaded!/)
     end
 
     it 'raises an error when pry command not found' do

--- a/spec/commands/save_file_spec.rb
+++ b/spec/commands/save_file_spec.rb
@@ -21,7 +21,7 @@ describe "save-file" do
         @t.eval("save-file '#{path}' --to '#{@path}'")
 
        
-        File.read(@path).should == File.read(path)
+        expect(File.read(@path)).to eq(File.read(path))
       end
     end
   end
@@ -30,25 +30,25 @@ describe "save-file" do
     it 'should save input expressions to a file (single expression)' do
       @t.eval ':horse_nostrils'
       @t.eval "save-file -i 1 --to '#{@path}'"
-      File.read(@path).should == ":horse_nostrils\n"
+      expect(File.read(@path)).to eq(":horse_nostrils\n")
     end
 
     it "should display a success message on save" do
       @t.eval ':horse_nostrils'
-      @t.eval("save-file -i 1 --to '#{@path}'").should =~ /successfully saved/
+      expect(@t.eval("save-file -i 1 --to '#{@path}'")).to match(/successfully saved/)
     end
 
     it 'should save input expressions to a file (range)' do
       @t.eval ':or_nostrils', ':sucking_up_all_the_oxygen', ':or_whatever'
       @t.eval "save-file -i 1..2 --to '#{@path}'"
-      File.read(@path).should == ":or_nostrils\n:sucking_up_all_the_oxygen\n"
+      expect(File.read(@path)).to eq(":or_nostrils\n:sucking_up_all_the_oxygen\n")
     end
 
     it 'should save multi-ranged input expressions' do
       @t.eval ':or_nostrils', ':sucking_up_all_the_oxygen', ':or_whatever',
       ':baby_ducks', ':cannot_escape'
       @t.eval "save-file -i 1..2 -i 4..5 --to '#{@path}'"
-      File.read(@path).should == ":or_nostrils\n:sucking_up_all_the_oxygen\n:baby_ducks\n:cannot_escape\n"
+      expect(File.read(@path)).to eq(":or_nostrils\n:sucking_up_all_the_oxygen\n:baby_ducks\n:cannot_escape\n")
     end
   end
 
@@ -68,19 +68,20 @@ describe "save-file" do
     describe "single method" do
       it 'should save a method to a file' do
         @t.eval "save-file --to '#{@path}' baby"
-        File.read(@path).should == Pry::Method.from_obj(@o, :baby).source
+        expect(File.read(@path)).to eq(Pry::Method.from_obj(@o, :baby).source)
       end
 
       it "should display a success message on save" do
-        @t.eval("save-file --to '#{@path}' baby").should =~ /successfully saved/
+        expect(@t.eval("save-file --to '#{@path}' baby")).to match(/successfully saved/)
       end
 
       it 'should save a method to a file truncated by --lines' do
         @t.eval "save-file --to '#{@path}' baby --lines 2..4"
 
         # must add 1 as first line of method is 1
-        File.read(@path).should ==
+        expect(File.read(@path)).to eq(
           Pry::Method.from_obj(@o, :baby).source.lines.to_a[1..5].join
+        )
       end
     end
 
@@ -121,7 +122,7 @@ describe "save-file" do
       @t.eval ':sucking_up_all_the_oxygen'
       @t.eval "save-file -i 2 --to '#{@path}'"
 
-      File.read(@path).should == ":sucking_up_all_the_oxygen\n"
+      expect(File.read(@path)).to eq(":sucking_up_all_the_oxygen\n")
     end
   end
 
@@ -133,8 +134,9 @@ describe "save-file" do
       @t.eval ':sucking_up_all_the_oxygen'
       @t.eval "save-file -i 2 --to '#{@path}' -a"
 
-      File.read(@path).should ==
+      expect(File.read(@path)).to eq(
         ":horse_nostrils\n:sucking_up_all_the_oxygen\n"
+      )
     end
   end
 
@@ -142,7 +144,7 @@ describe "save-file" do
     it 'should save a command to a file' do
       @t.eval "save-file --to '#{@path}' show-source"
       cmd_source = Pry.config.commands["show-source"].source
-      File.read(@path).should == cmd_source
+      expect(File.read(@path)).to eq(cmd_source)
     end
   end
 

--- a/spec/commands/shell_command_spec.rb
+++ b/spec/commands/shell_command_spec.rb
@@ -21,7 +21,7 @@ describe "Command::ShellCommand" do
         expect(Dir).to receive(:pwd).at_least(:once).and_return("initial_path") # called once in MRI, 2x in RBX
 
         @t.eval ".cd new_path"
-        @t.command_state.old_pwd.should == "initial_path"
+        expect(@t.command_state.old_pwd).to eq("initial_path")
       end
 
       describe "given a path" do

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -15,7 +15,7 @@ describe "show-doc" do
   end
 
   it 'should output a method\'s documentation' do
-    pry_eval(binding, "show-doc @o.sample_method").should =~ /sample doc/
+    expect(pry_eval(binding, "show-doc @o.sample_method")).to match(/sample doc/)
   end
 
   it 'should raise exception when cannot find docs' do
@@ -23,11 +23,11 @@ describe "show-doc" do
   end
 
   it 'should output a method\'s documentation with line numbers' do
-    pry_eval(binding, "show-doc @o.sample_method -l").should =~ /\d: sample doc/
+    expect(pry_eval(binding, "show-doc @o.sample_method -l")).to match(/\d: sample doc/)
   end
 
   it 'should output a method\'s documentation with line numbers (base one)' do
-    pry_eval(binding, "show-doc @o.sample_method -b").should =~ /1: sample doc/
+    expect(pry_eval(binding, "show-doc @o.sample_method -b")).to match(/1: sample doc/)
   end
 
   it 'should output a method\'s documentation if inside method without needing to use method name' do
@@ -69,17 +69,17 @@ describe "show-doc" do
 
     it "finds super method docs" do
       output = pry_eval(binding, 'show-doc --super @o.initialize')
-      output.should =~ /grungy initialize/
+      expect(output).to match(/grungy initialize/)
     end
 
     it "traverses ancestor chain and finds super method docs" do
       output = pry_eval(binding, 'show-doc -ss @o.initialize')
-      output.should =~ /classy initialize/
+      expect(output).to match(/classy initialize/)
     end
 
     it "traverses ancestor chain even higher and finds super method doc" do
       output = pry_eval(binding, 'show-doc @o.initialize -sss')
-      output.should =~ /daddy initialize/
+      expect(output).to match(/daddy initialize/)
     end
 
     it "finds super method docs without explicit method argument" do
@@ -91,7 +91,7 @@ describe "show-doc" do
       end
 
       output = fatty.initialize
-      output.should =~ /grungy initialize/
+      expect(output).to match(/grungy initialize/)
     end
 
     it "finds super method docs without `--super` but with the `super` keyword" do
@@ -109,7 +109,7 @@ describe "show-doc" do
       end
 
       output = fatty.initialize
-      output.should =~ /grungy initialize/
+      expect(output).to match(/grungy initialize/)
     end
   end
 
@@ -126,11 +126,11 @@ describe "show-doc" do
 
       begin
         t = pry_tester(binding)
-        t.eval("show-doc c#initialize").should =~ /c.new :foo/
+        expect(t.eval("show-doc c#initialize")).to match(/c.new :foo/)
         Pry.config.color = true
         # I don't want the test to rely on which colour codes are there, just to
         # assert that "something" is being colourized.
-        t.eval("show-doc c#initialize").should_not =~ /c.new :foo/
+        expect(t.eval("show-doc c#initialize")).not_to match(/c.new :foo/)
       ensure
         Pry.config.color = false
       end
@@ -146,11 +146,11 @@ describe "show-doc" do
 
       begin
         t = pry_tester(binding)
-        t.eval("show-doc c#initialize").should =~ /c.new\(:foo\)/
+        expect(t.eval("show-doc c#initialize")).to match(/c.new\(:foo\)/)
         Pry.config.color = true
         # I don't want the test to rely on which colour codes are there, just to
         # assert that "something" is being colourized.
-        t.eval("show-doc c#initialize").should_not =~ /c.new\(:foo\)/
+        expect(t.eval("show-doc c#initialize")).not_to match(/c.new\(:foo\)/)
       ensure
         Pry.config.color = false
       end
@@ -170,8 +170,8 @@ describe "show-doc" do
       begin
         t = pry_tester(binding)
         Pry.config.color = true
-        t.eval("show-doc c#decolumnize").should =~ /ls -l \$HOME/
-        t.eval("show-doc c#decolumnize").should_not =~ /`ls -l \$HOME`/
+        expect(t.eval("show-doc c#decolumnize")).to match(/ls -l \$HOME/)
+        expect(t.eval("show-doc c#decolumnize")).not_to match(/`ls -l \$HOME`/)
       ensure
         Pry.config.color = false
       end
@@ -182,7 +182,7 @@ describe "show-doc" do
     it "should show documentation for object" do
       # this is a documentation
       hello = proc { puts 'hello world!' }
-      mock_pry(binding, "show-doc hello").should =~ /this is a documentation/
+      expect(mock_pry(binding, "show-doc hello")).to match(/this is a documentation/)
     end
   end
 
@@ -222,23 +222,27 @@ describe "show-doc" do
 
     describe "basic functionality, should show docs for top-level module definitions" do
       it 'should show docs for a class' do
-        pry_eval("show-doc ShowSourceTestClass").should =~
+        expect(pry_eval("show-doc ShowSourceTestClass")).to match(
           /god this is boring1/
+        )
       end
 
       it 'should show docs for a module' do
-        pry_eval("show-doc ShowSourceTestModule").should =~
+        expect(pry_eval("show-doc ShowSourceTestModule")).to match(
           /god this is boring2/
+        )
       end
 
       it 'should show docs for a class when Const = Class.new syntax is used' do
-        pry_eval("show-doc ShowSourceTestClassWeirdSyntax").should =~
+        expect(pry_eval("show-doc ShowSourceTestClassWeirdSyntax")).to match(
           /god this is boring3/
+        )
       end
 
       it 'should show docs for a module when Const = Module.new syntax is used' do
-        pry_eval("show-doc ShowSourceTestModuleWeirdSyntax").should =~
+        expect(pry_eval("show-doc ShowSourceTestModuleWeirdSyntax")).to match(
           /god this is boring4/
+        )
       end
     end
 
@@ -252,7 +256,7 @@ describe "show-doc" do
             end
           end
         RUBY
-        t.eval('show-doc TobinaMyDog').should =~ /hello tobina/
+        expect(t.eval('show-doc TobinaMyDog')).to match(/hello tobina/)
         Object.remove_const :TobinaMyDog
       end
     end
@@ -273,7 +277,7 @@ describe "show-doc" do
           end
         end
 
-        pry_eval(AlphaClass, "show-doc BetaClass").should =~ /nested beta/
+        expect(pry_eval(AlphaClass, "show-doc BetaClass")).to match(/nested beta/)
       end
     end
 
@@ -287,8 +291,9 @@ describe "show-doc" do
           end
         end
 
-        pry_eval("show-doc AlphaClass::BetaClass").should =~
+        expect(pry_eval("show-doc AlphaClass::BetaClass")).to match(
           /nested beta/
+        )
       end
     end
 
@@ -301,8 +306,8 @@ describe "show-doc" do
         end
 
         result = pry_eval("show-doc TestClassForShowSource -a")
-        result.should =~ /used by/
-        result.should =~ /local monkeypatch/
+        expect(result).to match(/used by/)
+        expect(result).to match(/local monkeypatch/)
       end
 
       describe "messages relating to -a" do
@@ -313,8 +318,8 @@ describe "show-doc" do
           end
 
           result = pry_eval("show-doc TestClassForCandidatesOrder")
-          result.should =~ /Number of monkeypatches: 2/
-          result.should =~ /The first definition/
+          expect(result).to match(/Number of monkeypatches: 2/)
+          expect(result).to match(/The first definition/)
         end
 
         it 'indicates all available monkeypatches can be shown with -a ' \
@@ -326,7 +331,7 @@ describe "show-doc" do
           end
 
           result = pry_eval('show-doc TestClassForShowSource')
-          result.should =~ /available monkeypatches/
+          expect(result).to match(/available monkeypatches/)
         end
 
         it 'shouldnt say anything about monkeypatches when only one candidate exists for selected class' do
@@ -336,7 +341,7 @@ describe "show-doc" do
           end
 
           result = pry_eval('show-doc Aarrrrrghh')
-          result.should_not =~ /available monkeypatches/
+          expect(result).not_to match(/available monkeypatches/)
           Object.remove_const(:Aarrrrrghh)
         end
       end
@@ -359,7 +364,7 @@ describe "show-doc" do
       end
 
       it 'should return doc for current module' do
-        pry_eval(TestHost::M, "show-doc").should =~ /hello there froggy/
+        expect(pry_eval(TestHost::M, "show-doc")).to match(/hello there froggy/)
       end
     end
 
@@ -389,8 +394,8 @@ describe "show-doc" do
 
       it 'should return doc for first valid module' do
         result = pry_eval("show-doc TestHost::M")
-        result.should =~ /goodbye/
-        result.should_not =~ /hello/
+        expect(result).to match(/goodbye/)
+        expect(result).not_to match(/hello/)
       end
     end
   end
@@ -409,17 +414,17 @@ describe "show-doc" do
     end
 
     it 'should display help for a specific command' do
-      pry_eval('show-doc ls').should =~ /Usage: ls/
+      expect(pry_eval('show-doc ls')).to match(/Usage: ls/)
     end
 
     it 'should display help for a regex command with a "listing"' do
       @set.command /bar(.*)/, "Test listing", :listing => "foo" do; end
-      pry_eval('show-doc foo').should =~ /Test listing/
+      expect(pry_eval('show-doc foo')).to match(/Test listing/)
     end
 
     it 'should display help for a command with a spaces in its name' do
       @set.command "command with spaces", "description of a command with spaces" do; end
-      pry_eval('show-doc command with spaces').should =~ /description of a command with spaces/
+      expect(pry_eval('show-doc command with spaces')).to match(/description of a command with spaces/)
     end
 
     describe "class commands" do
@@ -441,12 +446,12 @@ describe "show-doc" do
       end
 
       it 'should display "help" when looking up by command name' do
-        pry_eval('show-doc lobster-lady').should =~ /nada/
+        expect(pry_eval('show-doc lobster-lady')).to match(/nada/)
         Pry.config.commands.delete("lobster-lady")
       end
 
       it 'should display actual preceding comment for a class command, when class is used (rather than command name) when looking up' do
-        pry_eval('show-doc LobsterLady').should =~ /pretty pink pincers/
+        expect(pry_eval('show-doc LobsterLady')).to match(/pretty pink pincers/)
         Pry.config.commands.delete("lobster-lady")
       end
     end
@@ -456,8 +461,8 @@ describe "show-doc" do
     it 'should set _file_ and _dir_ to file containing method source' do
       t = pry_tester
       t.process_command "show-doc TestClassForShowSource#alpha"
-      t.pry.last_file.should =~ /show_source_doc_examples/
-      t.pry.last_dir.should =~ /fixtures/
+      expect(t.pry.last_file).to match(/show_source_doc_examples/)
+      expect(t.pry.last_dir).to match(/fixtures/)
     end
   end
 
@@ -485,7 +490,7 @@ describe "show-doc" do
         it 'shows superclass doc' do
           t = pry_tester
           t.process_command "show-doc Jesus::Jangle"
-          t.last_output.should =~ /doink-doc/
+          expect(t.last_output).to match(/doink-doc/)
         end
 
         it 'errors when class has no superclass to show' do
@@ -496,19 +501,19 @@ describe "show-doc" do
         it 'shows warning when reverting to superclass docs' do
           t = pry_tester
           t.process_command "show-doc Jesus::Jangle"
-          t.last_output.should =~ /Warning.*?Cannot find.*?Jesus::Jangle.*Showing.*Jesus::Jingle instead/
+          expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Jangle.*Showing.*Jesus::Jingle instead/)
         end
 
         it 'shows nth level superclass docs (when no intermediary superclasses have code either)' do
           t = pry_tester
           t.process_command "show-doc Jesus::Bangle"
-          t.last_output.should =~ /doink-doc/
+          expect(t.last_output).to match(/doink-doc/)
         end
 
         it 'shows correct warning when reverting to nth level superclass' do
           t = pry_tester
           t.process_command "show-doc Jesus::Bangle"
-          t.last_output.should =~ /Warning.*?Cannot find.*?Jesus::Bangle.*Showing.*Jesus::Jingle instead/
+          expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Bangle.*Showing.*Jesus::Jingle instead/)
         end
       end
 
@@ -540,13 +545,13 @@ describe "show-doc" do
         it 'shows included module doc' do
           t = pry_tester
           t.process_command "show-doc Jesus::Beta"
-          t.last_output.should =~ /alpha-doc/
+          expect(t.last_output).to match(/alpha-doc/)
         end
 
         it 'shows warning when reverting to included module doc' do
           t = pry_tester
           t.process_command "show-doc Jesus::Beta"
-          t.last_output.should =~ /Warning.*?Cannot find.*?Jesus::Beta.*Showing.*Jesus::Alpha instead/
+          expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Beta.*Showing.*Jesus::Alpha instead/)
         end
 
         it 'errors when module has no included module to show' do
@@ -557,13 +562,13 @@ describe "show-doc" do
         it 'shows nth level included module doc (when no intermediary modules have code either)' do
           t = pry_tester
           t.process_command "show-doc Jesus::Gamma"
-          t.last_output.should =~ /alpha-doc/
+          expect(t.last_output).to match(/alpha-doc/)
         end
 
         it 'shows correct warning when reverting to nth level included module' do
           t = pry_tester
           t.process_command "show-source Jesus::Gamma"
-          t.last_output.should =~ /Warning.*?Cannot find.*?Jesus::Gamma.*Showing.*Jesus::Alpha instead/
+          expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Gamma.*Showing.*Jesus::Alpha instead/)
         end
       end
     end

--- a/spec/commands/show_input_spec.rb
+++ b/spec/commands/show_input_spec.rb
@@ -12,6 +12,6 @@ describe "show-input" do
     STR
 
     @t.process_command 'show-input'
-    @t.last_output.should =~ /\A\d+: def hello\n\d+:   puts :bing/
+    expect(@t.last_output).to match(/\A\d+: def hello\n\d+:   puts :bing/)
   end
 end

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -16,19 +16,19 @@ describe "show-source" do
   end
 
   it "should output a method's source" do
-    pry_eval(binding, 'show-source @o.sample_method').should =~ /def @o.sample/
+    expect(pry_eval(binding, 'show-source @o.sample_method')).to match(/def @o.sample/)
   end
 
   it "should output help" do
-    pry_eval('show-source -h').should =~ /Usage:\s+show-source/
+    expect(pry_eval('show-source -h')).to match(/Usage:\s+show-source/)
   end
 
   it "should output a method's source with line numbers" do
-    pry_eval(binding, 'show-source -l @o.sample_method').should =~ /\d+: def @o.sample/
+    expect(pry_eval(binding, 'show-source -l @o.sample_method')).to match(/\d+: def @o.sample/)
   end
 
   it "should output a method's source with line numbers starting at 1" do
-    pry_eval(binding, 'show-source -b @o.sample_method').should =~ /1: def @o.sample/
+    expect(pry_eval(binding, 'show-source -b @o.sample_method')).to match(/1: def @o.sample/)
   end
 
   it "should output a method's source if inside method and no name given" do
@@ -52,7 +52,7 @@ describe "show-source" do
     end
 
     out = pry_eval(binding, "show-source @o.foo('bar', 'baz bam').foo")
-    out.should =~ /Mr flibble/
+    expect(out).to match(/Mr flibble/)
   end
 
   it "should find methods even if the object overrides method method" do
@@ -62,12 +62,12 @@ describe "show-source" do
       end
     }
 
-    pry_eval(binding, "show-source c.new.method").should =~ /98/
+    expect(pry_eval(binding, "show-source c.new.method")).to match(/98/)
   end
 
   it "should not show the source when a non-extant method is requested" do
     c = Class.new{ def method; 98; end }
-    mock_pry(binding, "show-source c#wrongmethod").should =~ /Couldn't locate/
+    expect(mock_pry(binding, "show-source c#wrongmethod")).to match(/Couldn't locate/)
   end
 
   it "should find instance_methods if the class overrides instance_method" do
@@ -79,13 +79,13 @@ describe "show-source" do
       def self.instance_method; 789; end
     }
 
-    pry_eval(binding, "show-source c#method").should =~ /98/
+    expect(pry_eval(binding, "show-source c#method")).to match(/98/)
   end
 
   it "should find instance methods with self#moo" do
     c = Class.new{ def moo; "ve over!"; end }
 
-    pry_eval(binding, "cd c", "show-source self#moo").should =~ /ve over/
+    expect(pry_eval(binding, "cd c", "show-source self#moo")).to match(/ve over/)
   end
 
   it "should not find instance methods with self.moo" do
@@ -97,7 +97,7 @@ describe "show-source" do
   it "should find normal methods with self.moo" do
     c = Class.new{ def self.moo; "ve over!"; end }
 
-    pry_eval(binding, 'cd c', 'show-source self.moo').should =~ /ve over/
+    expect(pry_eval(binding, 'cd c', 'show-source self.moo')).to match(/ve over/)
   end
 
   it "should not find normal methods with self#moo" do
@@ -109,13 +109,13 @@ describe "show-source" do
   it "should find normal methods (i.e non-instance methods) by default" do
     c = Class.new{ def self.moo; "ve over!"; end }
 
-    pry_eval(binding, "cd c", "show-source moo").should =~ /ve over/
+    expect(pry_eval(binding, "cd c", "show-source moo")).to match(/ve over/)
   end
 
   it "should find instance methods if no normal methods available" do
     c = Class.new{ def moo; "ve over!"; end }
 
-    pry_eval(binding, "cd c", "show-source moo").should =~ /ve over/
+    expect(pry_eval(binding, "cd c", "show-source moo")).to match(/ve over/)
   end
 
   describe "with -e option" do
@@ -147,21 +147,21 @@ describe "show-source" do
 
   it "should output the source of a method defined inside Pry" do
     out = pry_eval("def dyn_method\n:test\nend", 'show-source dyn_method')
-    out.should =~ /def dyn_method/
+    expect(out).to match(/def dyn_method/)
     Object.remove_method :dyn_method
   end
 
   it 'should output source for an instance method defined inside pry' do
     pry_tester.tap do |t|
       t.eval "class Test::A\n  def yo\n  end\nend"
-      t.eval('show-source Test::A#yo').should =~ /def yo/
+      expect(t.eval('show-source Test::A#yo')).to match(/def yo/)
     end
   end
 
   it 'should output source for a repl method defined using define_method' do
     pry_tester.tap do |t|
       t.eval "class Test::A\n  define_method(:yup) {}\nend"
-      t.eval('show-source Test::A#yup').should =~ /define_method\(:yup\)/
+      expect(t.eval('show-source Test::A#yup')).to match(/define_method\(:yup\)/)
     end
   end
 
@@ -172,7 +172,7 @@ describe "show-source" do
       end
     }
     out = pry_eval(command_definition, 'show-source hubba-hubba')
-    out.should =~ /what she said/
+    expect(out).to match(/what she said/)
     Pry.config.commands.delete "hubba-hubba"
   end
 
@@ -196,7 +196,7 @@ describe "show-source" do
         :wibble
       end
 
-      pry_eval(binding, "show-source --super o.foo").should =~ /:super_wibble/
+      expect(pry_eval(binding, "show-source --super o.foo")).to match(/:super_wibble/)
     end
 
     it "finds super methods without explicit method argument" do
@@ -206,7 +206,7 @@ describe "show-source" do
         pry_eval(binding, 'show-source --super')
       end
 
-      o.foo.should =~ /:super_wibble/
+      expect(o.foo).to match(/:super_wibble/)
     end
 
     it "finds super methods with multiple --super " do
@@ -223,7 +223,7 @@ describe "show-source" do
         pry_eval(binding, 'show-source --super --super')
       end
 
-      o.foo.should =~ /:super_wibble/
+      expect(o.foo).to match(/:super_wibble/)
     end
   end
 
@@ -231,25 +231,25 @@ describe "show-source" do
     it "should output source defined inside pry" do
       pry_tester.tap do |t|
         t.eval "hello = proc { puts 'hello world!' }"
-        t.eval("show-source hello").should =~ /proc \{ puts/
+        expect(t.eval("show-source hello")).to match(/proc \{ puts/)
       end
     end
 
     it "should output source for procs/lambdas stored in variables" do
       hello = proc { puts 'hello world!' }
-      pry_eval(binding, 'show-source hello').should =~ /proc \{ puts/
+      expect(pry_eval(binding, 'show-source hello')).to match(/proc \{ puts/)
     end
 
     it "should output source for procs/lambdas stored in constants" do
       HELLO = proc { puts 'hello world!' }
-      pry_eval(binding, "show-source HELLO").should =~ /proc \{ puts/
+      expect(pry_eval(binding, "show-source HELLO")).to match(/proc \{ puts/)
       Object.remove_const(:HELLO)
     end
 
     it "should output source for method objects" do
       def @o.hi; puts 'hi world'; end
       meth = @o.method(:hi)
-      pry_eval(binding, "show-source meth").should =~ /puts 'hi world'/
+      expect(pry_eval(binding, "show-source meth")).to match(/puts 'hi world'/)
     end
 
     describe "on variables that shadow methods" do
@@ -271,13 +271,13 @@ describe "show-source" do
 
         it "source of variable should take precedence over method that is being shadowed" do
           source = @t.eval('show-source hello')
-          source.should_not =~ /def hello/
-          source.should =~ /proc \{ ' smile ' \}/
+          expect(source).not_to match(/def hello/)
+          expect(source).to match(/proc \{ ' smile ' \}/)
         end
 
         it "source of method being shadowed should take precedence over variable
           if given self.meth_name syntax" do
-          @t.eval('show-source self.hello').should =~ /def hello/
+          expect(@t.eval('show-source self.hello')).to match(/def hello/)
         end
       end
     end
@@ -297,14 +297,14 @@ describe "show-source" do
 
       it "should output source of its class if variable doesn't respond to source_location" do
         test_host = TestHost.new
-        pry_eval(binding, 'show-source test_host').
-          should =~ /class TestHost\n.*def hello/
+        expect(pry_eval(binding, 'show-source test_host')).
+          to match(/class TestHost\n.*def hello/)
       end
 
       it "should output source of its class if constant doesn't respond to source_location" do
         TEST_HOST = TestHost.new
-        pry_eval(binding, 'show-source TEST_HOST').
-          should =~ /class TestHost\n.*def hello/
+        expect(pry_eval(binding, 'show-source TEST_HOST')).
+          to match(/class TestHost\n.*def hello/)
         Object.remove_const(:TEST_HOST)
       end
     end
@@ -354,38 +354,38 @@ describe "show-source" do
 
       describe "basic functionality, should find top-level module definitions" do
         it 'should show source for a class' do
-          pry_eval('show-source ShowSourceTestClass').
-            should =~ /class ShowSourceTestClass.*?def alpha/m
+          expect(pry_eval('show-source ShowSourceTestClass')).
+            to match(/class ShowSourceTestClass.*?def alpha/m)
         end
 
         it 'should show source for a super class' do
-          pry_eval('show-source -s ShowSourceTestClass').
-            should =~ /class ShowSourceTestSuperClass.*?def alpha/m
+          expect(pry_eval('show-source -s ShowSourceTestClass')).
+            to match(/class ShowSourceTestSuperClass.*?def alpha/m)
         end
 
         it 'should show source for a module' do
-          pry_eval('show-source ShowSourceTestModule').
-            should =~ /module ShowSourceTestModule/
+          expect(pry_eval('show-source ShowSourceTestModule')).
+            to match(/module ShowSourceTestModule/)
         end
 
         it 'should show source for an ancestor module' do
-          pry_eval('show-source -s ShowSourceTestModule').
-            should =~ /module ShowSourceTestSuperModule/
+          expect(pry_eval('show-source -s ShowSourceTestModule')).
+            to match(/module ShowSourceTestSuperModule/)
         end
 
         it 'should show source for a class when Const = Class.new syntax is used' do
-          pry_eval('show-source ShowSourceTestClassWeirdSyntax').
-            should =~ /ShowSourceTestClassWeirdSyntax = Class.new/
+          expect(pry_eval('show-source ShowSourceTestClassWeirdSyntax')).
+            to match(/ShowSourceTestClassWeirdSyntax = Class.new/)
         end
 
         it 'should show source for a super class when Const = Class.new syntax is used' do
-          pry_eval('show-source -s ShowSourceTestClassWeirdSyntax').
-            should =~ /class Object/
+          expect(pry_eval('show-source -s ShowSourceTestClassWeirdSyntax')).
+            to match(/class Object/)
         end
 
         it 'should show source for a module when Const = Module.new syntax is used' do
-          pry_eval('show-source ShowSourceTestModuleWeirdSyntax').
-            should =~ /ShowSourceTestModuleWeirdSyntax = Module.new/
+          expect(pry_eval('show-source ShowSourceTestModuleWeirdSyntax')).
+            to match(/ShowSourceTestModuleWeirdSyntax = Module.new/)
         end
       end
 
@@ -410,11 +410,11 @@ describe "show-source" do
 
       describe "in REPL" do
         it 'should find class defined in repl' do
-          pry_eval('show-source TobinaMyDog').should =~ /class TobinaMyDog/
+          expect(pry_eval('show-source TobinaMyDog')).to match(/class TobinaMyDog/)
         end
 
         it 'should find superclass defined in repl' do
-          pry_eval('show-source -s TobinaMyDog').should =~ /class Dog/
+          expect(pry_eval('show-source -s TobinaMyDog')).to match(/class Dog/)
         end
       end
 
@@ -433,7 +433,7 @@ describe "show-source" do
             end
           end
 
-          pry_eval(AlphaClass, 'show-source BetaClass').should =~ /def beta/
+          expect(pry_eval(AlphaClass, 'show-source BetaClass')).to match(/def beta/)
         end
       end
 
@@ -446,7 +446,7 @@ describe "show-source" do
             end
           end
 
-          pry_eval('show-source AlphaClass::BetaClass').should =~ /class Beta/
+          expect(pry_eval('show-source AlphaClass::BetaClass')).to match(/class Beta/)
         end
       end
 
@@ -461,8 +461,8 @@ describe "show-source" do
           end
 
           result = pry_eval('show-source TestClassForShowSource -a')
-          result.should =~ /def alpha/
-          result.should =~ /def beta/
+          expect(result).to match(/def alpha/)
+          expect(result).to match(/def beta/)
         end
 
         it 'should show the source for a class_eval-based monkeypatch' do
@@ -472,7 +472,7 @@ describe "show-source" do
           end
 
           result = pry_eval('show-source TestClassForShowSourceClassEval -a')
-          result.should =~ /def class_eval_method/
+          expect(result).to match(/def class_eval_method/)
         end
 
         it 'should ignore -a when object is not a module' do
@@ -483,7 +483,7 @@ describe "show-source" do
           end
 
           result = pry_eval('show-source TestClassForShowSourceClassEval#class_eval_method -a')
-          result.should =~ /bing/
+          expect(result).to match(/bing/)
         end
 
         it 'should show the source for an instance_eval-based monkeypatch' do
@@ -493,7 +493,7 @@ describe "show-source" do
           end
 
           result = pry_eval('show-source TestClassForShowSourceInstanceEval -a')
-          result.should =~ /def instance_eval_method/
+          expect(result).to match(/def instance_eval_method/)
         end
 
         describe "messages relating to -a" do
@@ -504,7 +504,7 @@ describe "show-source" do
             end
 
             result = pry_eval('show-source TestClassForShowSource')
-            result.should =~ /available monkeypatches/
+            expect(result).to match(/available monkeypatches/)
           end
 
           it 'shouldnt say anything about monkeypatches when only one candidate exists for selected class' do
@@ -513,7 +513,7 @@ describe "show-source" do
             end
 
             result = pry_eval('show-source Aarrrrrghh')
-            result.should_not =~ /available monkeypatches/
+            expect(result).not_to match(/available monkeypatches/)
             Object.remove_const(:Aarrrrrghh)
           end
         end
@@ -545,9 +545,9 @@ describe "show-source" do
         describe "inside a module" do
           it 'should display module source by default' do
             out = pry_eval(TestHost::M, 'show-source')
-            out.should =~ /class M/
-            out.should =~ /def alpha/
-            out.should =~ /def beta/
+            expect(out).to match(/class M/)
+            expect(out).to match(/def alpha/)
+            expect(out).to match(/def beta/)
           end
 
           it 'should be unable to find module source if no methods defined' do
@@ -556,22 +556,22 @@ describe "show-source" do
 
           it 'should display method code (rather than class) if Pry started inside method binding' do
             out = TestHost::D.invoked_in_method
-            out.should =~ /invoked_in_method/
-            out.should_not =~ /module D/
+            expect(out).to match(/invoked_in_method/)
+            expect(out).not_to match(/module D/)
           end
 
           it 'should display class source when inside instance' do
             out = pry_eval(TestHost::M.new, 'show-source')
-            out.should =~ /class M/
-            out.should =~ /def alpha/
-            out.should =~ /def beta/
+            expect(out).to match(/class M/)
+            expect(out).to match(/def alpha/)
+            expect(out).to match(/def beta/)
           end
 
           it 'should allow options to be passed' do
             out = pry_eval(TestHost::M, 'show-source -b')
-            out.should =~ /\d:\s*class M/
-            out.should =~ /\d:\s*def alpha/
-            out.should =~ /\d:\s*def beta/
+            expect(out).to match(/\d:\s*class M/)
+            expect(out).to match(/\d:\s*def alpha/)
+            expect(out).to match(/\d:\s*def beta/)
           end
 
           describe "should skip over broken modules" do
@@ -597,8 +597,8 @@ describe "show-source" do
 
             it 'should return source for first valid module' do
               out = pry_eval('show-source BabyDuck::Muesli')
-              out.should =~ /def d; end/
-              out.should_not =~ /def a; end/
+              expect(out).to match(/def d; end/)
+              expect(out).not_to match(/def a; end/)
             end
           end
         end
@@ -621,25 +621,25 @@ describe "show-source" do
         it 'should show source for an ordinary command' do
           @set.command "foo", :body_of_foo do; end
 
-          pry_eval('show-source foo').should =~ /:body_of_foo/
+          expect(pry_eval('show-source foo')).to match(/:body_of_foo/)
         end
 
         it "should output source of commands using special characters" do
           @set.command "!%$", "I gots the yellow fever" do; end
 
-          pry_eval('show-source !%$').should =~ /yellow fever/
+          expect(pry_eval('show-source !%$')).to match(/yellow fever/)
         end
 
         it 'should show source for a command with spaces in its name' do
           @set.command "foo bar", :body_of_foo_bar do; end
 
-          pry_eval('show-source foo bar').should =~ /:body_of_foo_bar/
+          expect(pry_eval('show-source foo bar')).to match(/:body_of_foo_bar/)
         end
 
         it 'should show source for a command by listing name' do
           @set.command /foo(.*)/, :body_of_foo_bar_regex, :listing => "bar" do; end
 
-          pry_eval('show-source bar').should =~ /:body_of_foo_bar_regex/
+          expect(pry_eval('show-source bar')).to match(/:body_of_foo_bar_regex/)
         end
       end
 
@@ -648,7 +648,7 @@ describe "show-source" do
           @set.create_command "foo", "babble" do
             def process() :body_of_foo end
           end
-          pry_eval('show-source foo').should =~ /:body_of_foo/
+          expect(pry_eval('show-source foo')).to match(/:body_of_foo/)
         end
 
         it 'should show source for a command defined inside pry' do
@@ -657,7 +657,7 @@ describe "show-source" do
             def process() :body_of_foo end
           end
         }
-        pry_eval('show-source foo').should =~ /:body_of_foo/
+        expect(pry_eval('show-source foo')).to match(/:body_of_foo/)
       end
     end
 
@@ -676,7 +676,7 @@ describe "show-source" do
       end
 
       it 'should show source for a command' do
-        pry_eval('show-source temp-command').should =~ /:body_of_temp/
+        expect(pry_eval('show-source temp-command')).to match(/:body_of_temp/)
       end
 
       it 'should show source for a command defined inside pry' do
@@ -687,7 +687,7 @@ describe "show-source" do
           end
         }
         Pry.config.commands.add_command(::TemporaryCommandInPry)
-        pry_eval('show-source temp-command-in-pry').should =~ /:body_of_temp/
+        expect(pry_eval('show-source temp-command-in-pry')).to match(/:body_of_temp/)
         Object.remove_const(:TemporaryCommandInPry)
       end
     end
@@ -697,8 +697,8 @@ describe "show-source" do
     it 'should set _file_ and _dir_ to file containing method source' do
       t = pry_tester
       t.process_command "show-source TestClassForShowSource#alpha"
-      t.pry.last_file.should =~ /show_source_doc_examples/
-      t.pry.last_dir.should =~ /fixtures/
+      expect(t.pry.last_file).to match(/show_source_doc_examples/)
+      expect(t.pry.last_dir).to match(/fixtures/)
     end
   end
 
@@ -728,13 +728,13 @@ describe "show-source" do
         it 'shows superclass code' do
           t = pry_tester
           t.process_command "show-source Jesus::Jangle"
-          t.last_output.should =~ /doink/
+          expect(t.last_output).to match(/doink/)
         end
 
         it 'ignores included modules' do
           t = pry_tester
           t.process_command "show-source Jesus::Jangle"
-          t.last_output.should_not =~ /lillybing/
+          expect(t.last_output).not_to match(/lillybing/)
         end
 
         it 'errors when class has no superclass to show' do
@@ -745,19 +745,19 @@ describe "show-source" do
         it 'shows warning when reverting to superclass code' do
           t = pry_tester
           t.process_command "show-source Jesus::Jangle"
-          t.last_output.should =~ /Warning.*?Cannot find.*?Jesus::Jangle.*Showing.*Jesus::Jingle instead/
+          expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Jangle.*Showing.*Jesus::Jingle instead/)
         end
 
         it 'shows nth level superclass code (when no intermediary superclasses have code either)' do
           t = pry_tester
           t.process_command "show-source Jesus::Bangle"
-          t.last_output.should =~ /doink/
+          expect(t.last_output).to match(/doink/)
         end
 
         it 'shows correct warning when reverting to nth level superclass' do
           t = pry_tester
           t.process_command "show-source Jesus::Bangle"
-          t.last_output.should =~ /Warning.*?Cannot find.*?Jesus::Bangle.*Showing.*Jesus::Jingle instead/
+          expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Bangle.*Showing.*Jesus::Jingle instead/)
         end
       end
 
@@ -787,13 +787,13 @@ describe "show-source" do
         it 'shows included module code' do
           t = pry_tester
           t.process_command "show-source Jesus::Beta"
-          t.last_output.should =~ /alpha/
+          expect(t.last_output).to match(/alpha/)
         end
 
         it 'shows warning when reverting to included module code' do
           t = pry_tester
           t.process_command "show-source Jesus::Beta"
-          t.last_output.should =~ /Warning.*?Cannot find.*?Jesus::Beta.*Showing.*Jesus::Alpha instead/
+          expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Beta.*Showing.*Jesus::Alpha instead/)
         end
 
         it 'errors when module has no included module to show' do
@@ -804,13 +804,13 @@ describe "show-source" do
         it 'shows nth level included module code (when no intermediary modules have code either)' do
           t = pry_tester
           t.process_command "show-source Jesus::Gamma"
-          t.last_output.should =~ /alpha/
+          expect(t.last_output).to match(/alpha/)
         end
 
         it 'shows correct warning when reverting to nth level included module' do
           t = pry_tester
           t.process_command "show-source Jesus::Gamma"
-          t.last_output.should =~ /Warning.*?Cannot find.*?Jesus::Gamma.*Showing.*Jesus::Alpha instead/
+          expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Gamma.*Showing.*Jesus::Alpha instead/)
         end
       end
     end

--- a/spec/commands/watch_expression_spec.rb
+++ b/spec/commands/watch_expression_spec.rb
@@ -20,22 +20,22 @@ describe "watch expression" do
 
   it "registers the after_eval hook" do
     eval 'watch 1+1'
-    @tester.pry.hooks.hook_exists?(:after_eval, :watch_expression).should == true
+    expect(@tester.pry.hooks.hook_exists?(:after_eval, :watch_expression)).to eq(true)
   end
 
   it "prints no watched expressions" do
-    eval('watch').should =~ /No watched expressions/
+    expect(eval('watch')).to match(/No watched expressions/)
   end
 
   it "watches an expression" do
     eval "watch 1+1"
-    eval('watch').should =~ /=> 2/
+    expect(eval('watch')).to match(/=> 2/)
   end
 
   it "watches a local variable" do
     eval 'foo = :bar'
     eval 'watch foo'
-    eval('watch').should =~ /=> :bar/
+    expect(eval('watch')).to match(/=> :bar/)
   end
 
   it "prints when an expression changes" do
@@ -109,11 +109,11 @@ describe "watch expression" do
     end
 
     it "keeps keeper" do
-      eval('watch').should =~ /keeper/
+      expect(eval('watch')).to match(/keeper/)
     end
 
     it "deletes delete" do
-      eval('watch').should_not =~ /delete/
+      expect(eval('watch')).not_to match(/delete/)
     end
   end
 end

--- a/spec/commands/whereami_spec.rb
+++ b/spec/commands/whereami_spec.rb
@@ -12,7 +12,7 @@ describe "whereami" do
     Cor.new.blimey!
 
     # using [.] so the regex doesn't match itself
-    pry_eval(Pad.binding, 'whereami').should =~ /self[.]blimey!/
+    expect(pry_eval(Pad.binding, 'whereami')).to match(/self[.]blimey!/)
 
     Object.remove_const(:Cor)
   end
@@ -48,7 +48,7 @@ describe "whereami" do
       end
     end.new.blimey!
 
-    pry_eval(cor, 'whereami').should =~ /::Kernel.binding [#] omnom/
+    expect(pry_eval(cor, 'whereami')).to match(/::Kernel.binding [#] omnom/)
   end
 
   it 'should show description and correct code when __LINE__ and __FILE__ are outside @method.source_location' do
@@ -60,8 +60,8 @@ describe "whereami" do
       end
     end
 
-    Cor.instance_method(:blimey!).source.should =~ /pry_eval/
-    Cor.new.blimey!.should =~ /Cor#blimey!.*Look at me/m
+    expect(Cor.instance_method(:blimey!).source).to match(/pry_eval/)
+    expect(Cor.new.blimey!).to match(/Cor#blimey!.*Look at me/m)
     Object.remove_const(:Cor)
   end
 
@@ -76,7 +76,7 @@ describe "whereami" do
 
       expect { Cor.instance_method(:blimey!).source }.to raise_error MethodSource::SourceNotFoundError
 
-      Cor.new.blimey!.should =~ /Cor#blimey!.*Look at me/m
+      expect(Cor.new.blimey!).to match(/Cor#blimey!.*Look at me/m)
       Object.remove_const(:Cor)
     end
 
@@ -212,24 +212,25 @@ describe "whereami" do
     :punk
     :sanders
 
-    out.should_not =~ /:litella/
-    out.should =~ /:pig/
-    out.should =~ /:punk/
-    out.should_not =~ /:sanders/
+    expect(out).not_to match(/:litella/)
+    expect(out).to match(/:pig/)
+    expect(out).to match(/:punk/)
+    expect(out).not_to match(/:sanders/)
 
     Pry.config.default_window_size = old_size
   end
 
   it "should work at the top level" do
-    pry_eval(Pry.toplevel_binding, 'whereami').should =~
+    expect(pry_eval(Pry.toplevel_binding, 'whereami')).to match(
       /At the top level/
+    )
   end
 
   it "should work inside a class" do
-    pry_eval(Pry, 'whereami').should =~ /Inside Pry/
+    expect(pry_eval(Pry, 'whereami')).to match(/Inside Pry/)
   end
 
   it "should work inside an object" do
-    pry_eval(Object.new, 'whereami').should =~ /Inside #<Object/
+    expect(pry_eval(Object.new, 'whereami')).to match(/Inside #<Object/)
   end
 end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -4,7 +4,7 @@ require "pry/input_completer"
 
 def completer_test(bind, pry=nil, assert_flag=true)
   test = proc {|symbol|
-    Pry::InputCompleter.new(pry || Readline, pry).call(symbol[0..-2], :target => Pry.binding_for(bind)).include?(symbol).should  == assert_flag}
+    expect(Pry::InputCompleter.new(pry || Readline, pry).call(symbol[0..-2], :target => Pry.binding_for(bind)).include?(symbol)).to  eq(assert_flag)}
   return proc {|*symbols| symbols.each(&test) }
 end
 
@@ -30,7 +30,7 @@ describe Pry::InputCompleter do
   # another jruby hack :((
   if !Pry::Helpers::BaseHelpers.jruby?
     it "should not crash if there's a Module that has a symbolic name." do
-      expect { Pry::InputCompleter.new(Readline).call "a.to_s.", :target => Pry.binding_for(Object.new) }.not_to raise_error Exception
+      expect { Pry::InputCompleter.new(Readline).call "a.to_s.", :target => Pry.binding_for(Object.new) }.not_to raise_error
     end
   end
 
@@ -46,13 +46,13 @@ describe Pry::InputCompleter do
     object.class.send(:class_variable_set, :'@@number', 10)
 
     # check to see if variables are in scope
-    object.instance_variables.
+    expect(object.instance_variables.
       map { |v| v.to_sym }.
-      include?(:'@name').should == true
+      include?(:'@name')).to eq(true)
 
-    object.class.class_variables.
+    expect(object.class.class_variables.
       map { |v| v.to_sym }.
-      include?(:'@@number').should == true
+      include?(:'@@number')).to eq(true)
 
     # Complete instance variables.
     b = Pry.binding_for(object)
@@ -114,7 +114,7 @@ describe Pry::InputCompleter do
     completer_test(binding).call('o.foo')
 
     # trailing slash
-    Pry::InputCompleter.new(Readline).call('Mod2/', :target => Pry.binding_for(Mod)).include?('Mod2/').should   == true
+    expect(Pry::InputCompleter.new(Readline).call('Mod2/', :target => Pry.binding_for(Mod)).include?('Mod2/')).to   eq(true)
   end
 
   it 'should complete for arbitrary scopes' do
@@ -185,7 +185,7 @@ describe Pry::InputCompleter do
     completer_test(binding).call('o.foo')
 
     # trailing slash
-    Pry::InputCompleter.new(Readline).call('Mod2/', :target => Pry.binding_for(Mod)).include?('Mod2/').should   == true
+    expect(Pry::InputCompleter.new(Readline).call('Mod2/', :target => Pry.binding_for(Mod)).include?('Mod2/')).to   eq(true)
   end
 
   it 'should complete for arbitrary scopes' do
@@ -209,6 +209,6 @@ describe Pry::InputCompleter do
 
   it 'should not return nil in its output' do
     pry = Pry.new
-    Pry::InputCompleter.new(Readline, pry).call("pry.", :target => binding).should_not include nil
+    expect(Pry::InputCompleter.new(Readline, pry).call("pry.", :target => binding)).not_to include nil
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -12,13 +12,13 @@ describe Pry::Config do
   describe "traversal to parent" do
     it "traverses back to the parent when a local key is not found" do
       local = Pry::Config.new Pry::Config.from_hash(foo: 1)
-      local.foo.should == 1
+      expect(local.foo).to eq(1)
     end
 
     it "stores a local key and prevents traversal to the parent" do
       local = Pry::Config.new Pry::Config.from_hash(foo: 1)
       local.foo = 2
-      local.foo.should == 2
+      expect(local.foo).to eq(2)
     end
 
     it "traverses through a chain of parents" do
@@ -26,28 +26,28 @@ describe Pry::Config do
       local1 = Pry::Config.new(root)
       local2 = Pry::Config.new(local1)
       local3 = Pry::Config.new(local2)
-      local3.foo.should == 21
+      expect(local3.foo).to eq(21)
     end
 
     it "stores a local copy of the parent's hooks upon accessing them" do
       parent = Pry::Config.from_hash(hooks: "parent_hooks")
       local  = Pry::Config.new parent
       local.hooks.gsub! 'parent', 'local'
-      local.hooks.should == 'local_hooks'
-      parent.hooks.should == 'parent_hooks'
+      expect(local.hooks).to eq('local_hooks')
+      expect(parent.hooks).to eq('parent_hooks')
     end
   end
 
   describe ".from_hash" do
     it "returns an object without a default" do
       local = Pry::Config.from_hash({})
-      local.default.should == nil
+      expect(local.default).to eq(nil)
     end
 
     it "returns an object with a default" do
       default = Pry::Config.new(nil)
       local = Pry::Config.from_hash({}, default)
-      local.default.should == local
+      expect(local.default).to eq(local)
     end
   end
 
@@ -60,8 +60,8 @@ describe Pry::Config do
     it "returns a Method object for a dynamic key" do
       @config["key"] = 1
       method_obj = @config.method(:key)
-      method_obj.name.should == :key
-      method_obj.call.should == 1
+      expect(method_obj.name).to eq(:key)
+      expect(method_obj.call).to eq(1)
     end
   end
 
@@ -72,24 +72,24 @@ describe Pry::Config do
 
     it "returns true for a local key" do
       @config.zzfoo = 1
-      @config.respond_to?(:zzfoo).should == true
+      expect(@config.respond_to?(:zzfoo)).to eq(true)
     end
 
     it "returns false for an unknown key" do
-      @config.respond_to?(:blahblah).should == false
+      expect(@config.respond_to?(:blahblah)).to eq(false)
     end
   end
 
   describe "#default" do
     it "returns nil" do
       local = Pry::Config.new(nil)
-      local.default.should == nil
+      expect(local.default).to eq(nil)
     end
 
     it "returns the default" do
       default = Pry::Config.new(nil)
       local = Pry::Config.new(default)
-      local.default.should == default
+      expect(local.default).to eq(default)
     end
   end
 
@@ -97,7 +97,7 @@ describe Pry::Config do
     it "returns an array of local keys" do
       root = Pry::Config.from_hash({zoo: "boo"}, nil)
       local = Pry::Config.from_hash({foo: "bar"}, root)
-      local.keys.should == ["foo"]
+      expect(local.keys).to eq(["foo"])
     end
   end
 
@@ -107,12 +107,12 @@ describe Pry::Config do
       local2 = Pry::Config.new(nil)
       local1.foo = "hi"
       local2.foo = "hi"
-      local1.should == local2
+      expect(local1).to eq(local2)
     end
 
     it "compares equality against an object who does not implement #to_hash" do
       local1 = Pry::Config.new(nil)
-      local1.should_not == Object.new
+      expect(local1).not_to eq(Object.new)
     end
   end
 
@@ -120,9 +120,9 @@ describe Pry::Config do
     it "forgets a local key" do
       local = Pry::Config.new Pry::Config.from_hash(foo: 1)
       local.foo = 2
-      local.foo.should == 2
+      expect(local.foo).to eq(2)
       local.forget(:foo)
-      local.foo.should == 1
+      expect(local.foo).to eq(1)
     end
   end
 
@@ -130,13 +130,13 @@ describe Pry::Config do
     it "provides a copy of local key & value pairs as a Hash" do
       local = Pry::Config.new Pry::Config.from_hash(bar: true)
       local.foo = "21"
-      local.to_hash.should == { "foo" => "21" }
+      expect(local.to_hash).to eq({ "foo" => "21" })
     end
 
     it "returns a duplicate of the lookup table" do
       local = Pry::Config.new(nil)
       local.to_hash.merge!("foo" => 42)
-      local.foo.should_not == 42
+      expect(local.foo).not_to eq(42)
     end
   end
 
@@ -148,18 +148,18 @@ describe Pry::Config do
     it "merges an object who returns a Hash through #to_hash" do
       obj = Class.new { def to_hash() {epoch: 1} end }.new
       @config.merge!(obj)
-      @config.epoch.should == 1
+      expect(@config.epoch).to eq(1)
     end
 
     it "merges an object who returns a Hash through #to_h" do
       obj = Class.new { def to_h() {epoch: 2} end }.new
       @config.merge!(obj)
-      @config.epoch.should == 2
+      expect(@config.epoch).to eq(2)
     end
 
     it "merges a Hash" do
       @config.merge!(epoch: 420)
-      @config.epoch.should == 420
+      expect(@config.epoch).to eq(420)
     end
 
     it "raises a TypeError for objects who can't become a Hash" do
@@ -173,17 +173,17 @@ describe Pry::Config do
     end
 
     it "returns true" do
-      @local.clear.should == true
+      expect(@local.clear).to eq(true)
     end
 
     it "clears local assignments" do
       @local.foo = 1
       @local.clear
-      @local.to_hash.should == {}
+      expect(@local.to_hash).to eq({})
     end
 
     it "is aliased as #refresh" do
-      @local.method(:clear).should == @local.method(:refresh)
+      expect(@local.method(:clear)).to eq(@local.method(:refresh))
     end
   end
 
@@ -191,7 +191,7 @@ describe Pry::Config do
     it "stores keys as strings" do
       local = Pry::Config.from_hash({})
       local[:zoo] = "hello"
-      local.to_hash.should == { "zoo" => "hello" }
+      expect(local.to_hash).to eq({ "zoo" => "hello" })
     end
   end
 end

--- a/spec/control_d_handler_spec.rb
+++ b/spec/control_d_handler_spec.rb
@@ -13,16 +13,16 @@ describe Pry::DEFAULT_CONTROL_D_HANDLER do
       it "should clear out passed string" do
         str = 'hello world'
         Pry::DEFAULT_CONTROL_D_HANDLER.call(str, nil)
-        str.should == ''
+        expect(str).to eq('')
       end
     end
 
     describe 'at top-level session' do
       it 'should break out of a REPL loop' do
         instance = Pry.new
-        instance.binding_stack.should_not be_empty
-        instance.eval(nil).should equal false
-        instance.binding_stack.should be_empty
+        expect(instance.binding_stack).not_to be_empty
+        expect(instance.eval(nil)).to equal false
+        expect(instance.binding_stack).to be_empty
       end
     end
 
@@ -30,9 +30,9 @@ describe Pry::DEFAULT_CONTROL_D_HANDLER do
       it 'should pop last binding from the binding stack' do
         t = pry_tester
         t.eval "cd Object.new"
-        t.eval("_pry_.binding_stack.size").should == 2
-        t.eval("_pry_.eval(nil)").should equal true
-        t.eval("_pry_.binding_stack.size").should == 1
+        expect(t.eval("_pry_.binding_stack.size")).to eq(2)
+        expect(t.eval("_pry_.eval(nil)")).to equal true
+        expect(t.eval("_pry_.binding_stack.size")).to eq(1)
       end
 
       it "breaks out of the parent session" do

--- a/spec/documentation_helper_spec.rb
+++ b/spec/documentation_helper_spec.rb
@@ -7,19 +7,19 @@ describe Pry::Helpers::DocumentationHelpers do
 
   describe "get_comment_content" do
     it "should strip off the hash and unindent" do
-      @helper.get_comment_content(" # hello\n # world\n").should == "hello\nworld\n"
+      expect(@helper.get_comment_content(" # hello\n # world\n")).to eq("hello\nworld\n")
     end
 
     it "should strip out leading lines of hashes" do
-      @helper.get_comment_content("###############\n#hello\n#world\n").should == "hello\nworld\n"
+      expect(@helper.get_comment_content("###############\n#hello\n#world\n")).to eq("hello\nworld\n")
     end
 
     it "should remove shebangs" do
-      @helper.get_comment_content("#!/usr/bin/env ruby\n# This is a program\n").should == "This is a program\n"
+      expect(@helper.get_comment_content("#!/usr/bin/env ruby\n# This is a program\n")).to eq("This is a program\n")
     end
 
     it "should unindent past separators" do
-      @helper.get_comment_content(" # Copyright Me <me@cirw.in>\n #--\n # So there.\n").should == "Copyright Me <me@cirw.in>\n--\nSo there.\n"
+      expect(@helper.get_comment_content(" # Copyright Me <me@cirw.in>\n #--\n # So there.\n")).to eq("Copyright Me <me@cirw.in>\n--\nSo there.\n")
     end
   end
 
@@ -33,35 +33,35 @@ describe Pry::Helpers::DocumentationHelpers do
     end
 
     it "should syntax highlight indented code" do
-      @helper.process_rdoc("  4 + 4\n").should_not == "  4 + 4\n"
+      expect(@helper.process_rdoc("  4 + 4\n")).not_to eq("  4 + 4\n")
     end
 
     it "should highlight words surrounded by +s" do
-      @helper.process_rdoc("the +parameter+").should =~ /the \e.*parameter\e.*/
+      expect(@helper.process_rdoc("the +parameter+")).to match(/the \e.*parameter\e.*/)
     end
 
     it "should syntax highlight things in backticks" do
-      @helper.process_rdoc("for `Example`").should =~ /for `\e.*Example\e.*`/
+      expect(@helper.process_rdoc("for `Example`")).to match(/for `\e.*Example\e.*`/)
     end
 
     it "should emphasise em tags" do
-      @helper.process_rdoc("for <em>science</em>").should == "for \e[1mscience\e[0m"
+      expect(@helper.process_rdoc("for <em>science</em>")).to eq("for \e[1mscience\e[0m")
     end
 
     it "should emphasise italic tags" do
-      @helper.process_rdoc("for <i>science</i>").should == "for \e[1mscience\e[0m"
+      expect(@helper.process_rdoc("for <i>science</i>")).to eq("for \e[1mscience\e[0m")
     end
 
     it "should syntax highlight code in <code>" do
-      @helper.process_rdoc("for <code>Example</code>").should =~ /for \e.*Example\e.*/
+      expect(@helper.process_rdoc("for <code>Example</code>")).to match(/for \e.*Example\e.*/)
     end
 
     it "should not double-highlight backticks inside indented code" do
-      @helper.process_rdoc("  `echo 5`").should =~ /echo 5/
+      expect(@helper.process_rdoc("  `echo 5`")).to match(/echo 5/)
     end
 
     it "should not remove ++" do
-      @helper.process_rdoc("--\n  comment in a bubble\n++").should =~ /\+\+/
+      expect(@helper.process_rdoc("--\n  comment in a bubble\n++")).to match(/\+\+/)
     end
   end
 

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -25,7 +25,7 @@ describe Pry::Editor do
     describe "build_editor_invocation_string" do
       it 'should shell-escape files' do
         invocation_str = @editor.build_editor_invocation_string(@tf_path, 5, true)
-        invocation_str.should =~ /#@tf_dir.+hello\\ world\.rb/
+        expect(invocation_str).to match(/#@tf_dir.+hello\\ world\.rb/)
       end
     end
   end
@@ -45,12 +45,12 @@ describe Pry::Editor do
 
     it "should replace / by \\" do
       invocation_str = @editor.build_editor_invocation_string(@tf_path, 5, true)
-      invocation_str.should =~ %r(\\#{@tf_dir.basename}\\)
+      expect(invocation_str).to match(%r(\\#{@tf_dir.basename}\\))
     end
 
     it "should not shell-escape files" do
       invocation_str = @editor.build_editor_invocation_string(@tf_path, 5, true)
-      invocation_str.should =~ /hello world\.rb/
+      expect(invocation_str).to match(/hello world\.rb/)
     end
   end
 
@@ -62,7 +62,7 @@ describe Pry::Editor do
       }))
 
       editor.invoke_editor(@tf_path, 10, true)
-      @file.should == @tf_path
+      expect(@file).to eq(@tf_path)
     end
   end
 end

--- a/spec/exception_whitelist_spec.rb
+++ b/spec/exception_whitelist_spec.rb
@@ -6,7 +6,7 @@ describe "Pry.config.exception_whitelist" do
   end
 
   it 'should rescue all exceptions NOT specified on whitelist' do
-    Pry.config.exception_whitelist.include?(NameError).should == false
+    expect(Pry.config.exception_whitelist.include?(NameError)).to eq(false)
     expect { Pry.start(self, :input => StringIO.new("raise NameError\nexit"), :output => @str_output) }.not_to raise_error
   end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -36,6 +36,6 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = [:should, :expect]
   end
-  config.alias_example_to :should
+
   config.include PryTestHelpers
 end

--- a/spec/helpers/table_spec.rb
+++ b/spec/helpers/table_spec.rb
@@ -98,7 +98,7 @@ asfadsssaaad    fasfaafdssd     s
     end
   end
 
-  should 'decide between one-line or indented output' do
+  specify 'decide between one-line or indented output' do
     Pry::Helpers.tablify_or_one_line('head', %w(ing)).should == "head: ing\n"
   end
 end

--- a/spec/helpers/table_spec.rb
+++ b/spec/helpers/table_spec.rb
@@ -99,6 +99,6 @@ asfadsssaaad    fasfaafdssd     s
   end
 
   specify 'decide between one-line or indented output' do
-    Pry::Helpers.tablify_or_one_line('head', %w(ing)).should == "head: ing\n"
+    expect(Pry::Helpers.tablify_or_one_line('head', %w(ing))).to eq("head: ing\n")
   end
 end

--- a/spec/helpers/table_spec.rb
+++ b/spec/helpers/table_spec.rb
@@ -3,21 +3,21 @@ require_relative '../helper'
 describe 'Formatting Table' do
   it 'knows about colorized fitting' do
     t = Pry::Helpers::Table.new %w(hihi), :column_count => 1
-    t.fits_on_line?(4).should == true
+    expect(t.fits_on_line?(4)).to eq(true)
     t.items = []
-    t.fits_on_line?(4).should == true
+    expect(t.fits_on_line?(4)).to eq(true)
 
     t.items = %w(hi hi)
-    t.fits_on_line?(4).should == true
+    expect(t.fits_on_line?(4)).to eq(true)
     t.column_count = 2
-    t.fits_on_line?(4).should == false
+    expect(t.fits_on_line?(4)).to eq(false)
 
     t.items = %w(
       a   ccc
       bb  dddd
     ).sort
-    t.fits_on_line?(8).should == true
-    t.fits_on_line?(7).should == false
+    expect(t.fits_on_line?(8)).to eq(true)
+    expect(t.fits_on_line?(7)).to eq(false)
   end
 
   describe 'formatting - should order downward and wrap to columns' do
@@ -34,7 +34,7 @@ describe 'Formatting Table' do
           bar+'actual'+bar,
           actual
       end
-      actual.should == expected
+      expect(actual).to eq(expected)
     end
 
     it 'should handle a tiny case' do
@@ -94,7 +94,7 @@ asfadsssaaad    fasfaafdssd     s
 
     it 'should format output as one column' do
       table = Pry::Helpers.tablify(@out, @elem_len - 1).to_s
-      table.should == "swizzle\ncrime  \nfun    "
+      expect(table).to eq("swizzle\ncrime  \nfun    ")
     end
   end
 

--- a/spec/history_array_spec.rb
+++ b/spec/history_array_spec.rb
@@ -7,65 +7,65 @@ describe Pry::HistoryArray do
   end
 
   it 'should have a maximum size specifed at creation time' do
-    @array.max_size.should == 10
+    expect(@array.max_size).to eq(10)
   end
 
   it 'should be able to be added objects to' do
-    @populated.size.should == 4
-    @populated.to_a.should == [1, 2, 3, 4]
+    expect(@populated.size).to eq(4)
+    expect(@populated.to_a).to eq([1, 2, 3, 4])
   end
 
   it 'should be able to access single elements' do
-    @populated[2].should == 3
+    expect(@populated[2]).to eq(3)
   end
 
   it 'should be able to access negative indices' do
-    @populated[-1].should == 4
+    expect(@populated[-1]).to eq(4)
   end
 
   it 'should be able to access ranges' do
-    @populated[1..2].should == [2, 3]
+    expect(@populated[1..2]).to eq([2, 3])
   end
 
   it 'should be able to access ranges starting from a negative index' do
-    @populated[-2..3].should == [3, 4]
+    expect(@populated[-2..3]).to eq([3, 4])
   end
 
   it 'should be able to access ranges ending at a negative index' do
-    @populated[2..-1].should == [3, 4]
+    expect(@populated[2..-1]).to eq([3, 4])
   end
 
   it 'should be able to access ranges using only negative indices' do
-    @populated[-2..-1].should == [3, 4]
+    expect(@populated[-2..-1]).to eq([3, 4])
   end
 
   it 'should be able to use range where end is excluded' do
-    @populated[-2...-1].should == [3]
+    expect(@populated[-2...-1]).to eq([3])
   end
 
   it 'should be able to access slices using a size' do
-    @populated[-3, 2].should == [2, 3]
+    expect(@populated[-3, 2]).to eq([2, 3])
   end
 
   it 'should remove older entries' do
     11.times { |n| @array << n }
 
-    @array[0].should  == nil
-    @array[1].should  == 1
-    @array[10].should == 10
+    expect(@array[0]).to  eq(nil)
+    expect(@array[1]).to  eq(1)
+    expect(@array[10]).to eq(10)
   end
 
   it 'should not be larger than specified maximum size' do
     12.times { |n| @array << n }
-    @array.entries.compact.size.should == 10
+    expect(@array.entries.compact.size).to eq(10)
   end
 
   it 'should pop!' do
     @populated.pop!
-    @populated.to_a.should == [1, 2, 3]
+    expect(@populated.to_a).to eq([1, 2, 3])
   end
 
   it 'should return an indexed hash' do
-    @populated.to_h[0].should == @populated[0]
+    expect(@populated.to_h[0]).to eq(@populated[0])
   end
 end

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -25,13 +25,13 @@ describe Pry do
       Pry.history << '3'
       Pry.history << '_ += 1'
       Pry.history << '_ += 1'
-      Pry.history.to_a.grep('_ += 1').count.should == 1
+      expect(Pry.history.to_a.grep('_ += 1').count).to eq(1)
     end
 
     it "does not record empty lines" do
       c = Pry.history.to_a.count
       Pry.history << ''
-      Pry.history.to_a.count.should == c
+      expect(Pry.history.to_a.count).to eq(c)
     end
   end
 
@@ -50,20 +50,20 @@ describe Pry do
     end
 
     it "clears this session's history" do
-      Pry.history.to_a.size.should > 0
+      expect(Pry.history.to_a.size).to be > 0
       Pry.history.clear
-      Pry.history.to_a.size.should == 0
+      expect(Pry.history.to_a.size).to eq(0)
     end
 
     it "doesn't affect the contents of the history file" do
-      Pry.history.to_a.size.should == 3
+      expect(Pry.history.to_a.size).to eq(3)
       Pry.history.clear
 
       File.open(@hist_file_path, 'r') { |fh|
         file = fh.to_a
 
-        file.length.should == 3
-        file.any? { |a| a =~ /athos/ }.should == true
+        expect(file.length).to eq(3)
+        expect(file.any? { |a| a =~ /athos/ }).to eq(true)
       }
     end
   end
@@ -77,7 +77,7 @@ describe Pry do
       end
       Pry.load_history
 
-      Pry.history.history_line_count.should == 5
+      expect(Pry.history.history_line_count).to eq(5)
     end
   end
 
@@ -85,29 +85,29 @@ describe Pry do
     it "restores loader" do
       Pry.history.loader = proc {}
       Pry.history.restore_default_behavior
-      Pry.history.loader.class.should == Method
-      Pry.history.loader.name.to_sym.should == :read_from_file
+      expect(Pry.history.loader.class).to eq(Method)
+      expect(Pry.history.loader.name.to_sym).to eq(:read_from_file)
     end
 
     it "restores saver" do
       Pry.history.saver = proc {}
       Pry.history.restore_default_behavior
-      Pry.history.saver.class.should == Method
-      Pry.history.saver.name.to_sym.should == :save_to_file
+      expect(Pry.history.saver.class).to eq(Method)
+      expect(Pry.history.saver.name.to_sym).to eq(:save_to_file)
     end
 
     it "restores pusher" do
       Pry.history.pusher = proc {}
       Pry.history.restore_default_behavior
-      Pry.history.pusher.class.should == Method
-      Pry.history.pusher.name.to_sym.should == :push_to_readline
+      expect(Pry.history.pusher.class).to eq(Method)
+      expect(Pry.history.pusher.name.to_sym).to eq(:push_to_readline)
     end
 
     it "restores clearer" do
       Pry.history.clearer = proc {}
       Pry.history.restore_default_behavior
-      Pry.history.clearer.class.should == Method
-      Pry.history.clearer.name.to_sym.should == :clear_readline
+      expect(Pry.history.clearer.class).to eq(Method)
+      expect(Pry.history.clearer.name.to_sym).to eq(:clear_readline)
     end
   end
 
@@ -115,13 +115,13 @@ describe Pry do
     it "returns the number of lines in history from just this session" do
       Pry.history << 'you?'
       Pry.history << 'you are so precious'
-      Pry.history.session_line_count.should == 2
+      expect(Pry.history.session_line_count).to eq(2)
     end
   end
 
   describe ".load_history" do
     it "reads the contents of the file" do
-      Pry.history.to_a[-2..-1].should == %w(2 3)
+      expect(Pry.history.to_a[-2..-1]).to eq(%w(2 3))
     end
   end
 
@@ -140,7 +140,7 @@ describe Pry do
 
     it "saves lines to a file as they are written" do
       @history.push "5"
-      File.read(@histfile.path).should == "5\n"
+      expect(File.read(@histfile.path)).to eq("5\n")
     end
 
     it "interleaves lines from many places" do
@@ -148,7 +148,7 @@ describe Pry do
       File.open(@histfile.path, 'a'){ |f| f.puts "6" }
       @history.push "7"
 
-      File.read(@histfile.path).should == "5\n6\n7\n"
+      expect(File.read(@histfile.path)).to eq("5\n6\n7\n")
     end
   end
 

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -9,7 +9,7 @@ describe Pry::Hooks do
     it 'should not execute hook while adding it' do
       run = false
       @hooks.add_hook(:test_hook, :my_name) { run = true }
-      run.should == false
+      expect(run).to eq(false)
     end
 
     it 'should not allow adding of a hook with a duplicate name' do
@@ -20,22 +20,22 @@ describe Pry::Hooks do
 
     it 'should create a new hook with a block' do
       @hooks.add_hook(:test_hook, :my_name) { }
-      @hooks.hook_count(:test_hook).should == 1
+      expect(@hooks.hook_count(:test_hook)).to eq(1)
     end
 
     it 'should create a new hook with a callable' do
       @hooks.add_hook(:test_hook, :my_name, proc { })
-      @hooks.hook_count(:test_hook).should == 1
+      expect(@hooks.hook_count(:test_hook)).to eq(1)
     end
 
     it 'should use block if given both block and callable' do
       run = false
       foo = false
       @hooks.add_hook(:test_hook, :my_name, proc { foo = true }) { run = true }
-      @hooks.hook_count(:test_hook).should == 1
+      expect(@hooks.hook_count(:test_hook)).to eq(1)
       @hooks.exec_hook(:test_hook)
-      run.should == true
-      foo.should == false
+      expect(run).to eq(true)
+      expect(foo).to eq(false)
     end
 
     it 'should raise if not given a block or any other object' do
@@ -45,11 +45,11 @@ describe Pry::Hooks do
     it 'should create multiple hooks for an event' do
       @hooks.add_hook(:test_hook, :my_name) {}
       @hooks.add_hook(:test_hook, :my_name2) {}
-      @hooks.hook_count(:test_hook).should == 2
+      expect(@hooks.hook_count(:test_hook)).to eq(2)
     end
 
     it 'should return a count of 0 for an empty hook' do
-      @hooks.hook_count(:test_hook).should == 0
+      expect(@hooks.hook_count(:test_hook)).to eq(0)
     end
   end
 
@@ -60,7 +60,7 @@ describe Pry::Hooks do
         h2 = Pry::Hooks.new
 
         h2.merge!(h1)
-        h2.get_hook(:test_hook, :testing).should == h1.get_hook(:test_hook, :testing)
+        expect(h2.get_hook(:test_hook, :testing)).to eq(h1.get_hook(:test_hook, :testing))
       end
 
       it 'should not share merged elements with original' do
@@ -69,7 +69,7 @@ describe Pry::Hooks do
 
         h2.merge!(h1)
         h2.add_hook(:test_hook, :testing2) {}
-        h2.get_hook(:test_hook, :testing2).should_not == h1.get_hook(:test_hook, :testing2)
+        expect(h2.get_hook(:test_hook, :testing2)).not_to eq(h1.get_hook(:test_hook, :testing2))
       end
 
       it 'should NOT overwrite hooks belonging to shared event in receiver' do
@@ -78,7 +78,7 @@ describe Pry::Hooks do
         h2 = Pry::Hooks.new.add_hook(:test_hook, :testing2, callable)
 
         h2.merge!(h1)
-        h2.get_hook(:test_hook, :testing2).should == callable
+        expect(h2.get_hook(:test_hook, :testing2)).to eq(callable)
       end
 
       it 'should overwrite identical hook in receiver' do
@@ -88,8 +88,8 @@ describe Pry::Hooks do
         h2 = Pry::Hooks.new.add_hook(:test_hook, :testing, callable2)
 
         h2.merge!(h1)
-        h2.get_hook(:test_hook, :testing).should == callable1
-        h2.hook_count(:test_hook).should == 1
+        expect(h2.get_hook(:test_hook, :testing)).to eq(callable1)
+        expect(h2.hook_count(:test_hook)).to eq(1)
       end
 
       it 'should preserve hook order' do
@@ -105,7 +105,7 @@ describe Pry::Hooks do
         h2.merge!(h1)
         h2.exec_hook(:test_hook)
 
-        name.should == "john"
+        expect(name).to eq("john")
       end
 
       describe "merge" do
@@ -114,8 +114,8 @@ describe Pry::Hooks do
           h2 = Pry::Hooks.new
 
           h3 = h2.merge(h1)
-          h3.should_not == h1
-          h3.should_not == h2
+          expect(h3).not_to eq(h1)
+          expect(h3).not_to eq(h2)
         end
 
         it 'should contain hooks from original instance' do
@@ -123,8 +123,8 @@ describe Pry::Hooks do
           h2 = Pry::Hooks.new.add_hook(:test_hook2, :testing) {}
 
           h3 = h2.merge(h1)
-          h3.get_hook(:test_hook, :testing).should == h1.get_hook(:test_hook, :testing)
-          h3.get_hook(:test_hook2, :testing).should == h2.get_hook(:test_hook2, :testing)
+          expect(h3.get_hook(:test_hook, :testing)).to eq(h1.get_hook(:test_hook, :testing))
+          expect(h3.get_hook(:test_hook2, :testing)).to eq(h2.get_hook(:test_hook2, :testing))
         end
 
         it 'should not affect original instances when new hooks are added' do
@@ -134,8 +134,8 @@ describe Pry::Hooks do
           h3 = h2.merge(h1)
           h3.add_hook(:test_hook3, :testing) {}
 
-          h1.get_hook(:test_hook3, :testing).should == nil
-          h2.get_hook(:test_hook3, :testing).should == nil
+          expect(h1.get_hook(:test_hook3, :testing)).to eq(nil)
+          expect(h2.get_hook(:test_hook3, :testing)).to eq(nil)
         end
       end
 
@@ -149,7 +149,7 @@ describe Pry::Hooks do
       end
 
       hooks_dup = @hooks.dup
-      hooks_dup.get_hook(:test_hook, :testing).should == @hooks.get_hook(:test_hook, :testing)
+      expect(hooks_dup.get_hook(:test_hook, :testing)).to eq(@hooks.get_hook(:test_hook, :testing))
     end
 
     it 'adding a new event to dupped instance should not affect original' do
@@ -158,7 +158,7 @@ describe Pry::Hooks do
 
       hooks_dup.add_hook(:other_test_hook, :testing) { :okay_man }
 
-      hooks_dup.get_hook(:other_test_hook, :testing).should_not == @hooks.get_hook(:other_test_hook, :testing)
+      expect(hooks_dup.get_hook(:other_test_hook, :testing)).not_to eq(@hooks.get_hook(:other_test_hook, :testing))
     end
 
     it 'adding a new hook to dupped instance should not affect original' do
@@ -167,7 +167,7 @@ describe Pry::Hooks do
 
       hooks_dup.add_hook(:test_hook, :testing2) { :okay_man }
 
-      hooks_dup.get_hook(:test_hook, :testing2).should_not == @hooks.get_hook(:test_hook, :testing2)
+      expect(hooks_dup.get_hook(:test_hook, :testing2)).not_to eq(@hooks.get_hook(:test_hook, :testing2))
     end
 
   end
@@ -180,12 +180,12 @@ describe Pry::Hooks do
         @hooks.add_hook(:test_hook, :my_name) { run = true }
         @hooks.add_hook(:test_hook, :my_name2) { fun = true }
         @hooks.get_hook(:test_hook, :my_name).call
-        run.should == true
-        fun.should == false
+        expect(run).to eq(true)
+        expect(fun).to eq(false)
       end
 
       it 'should return nil if hook does not exist' do
-        @hooks.get_hook(:test_hook, :my_name).should == nil
+        expect(@hooks.get_hook(:test_hook, :my_name)).to eq(nil)
       end
     end
 
@@ -196,13 +196,13 @@ describe Pry::Hooks do
         @hooks.add_hook(:test_hook, :my_name1, hook1)
         @hooks.add_hook(:test_hook, :my_name2, hook2)
         hash = @hooks.get_hooks(:test_hook)
-        hash.size.should == 2
-        hash[:my_name1].should == hook1
-        hash[:my_name2].should == hook2
+        expect(hash.size).to eq(2)
+        expect(hash[:my_name1]).to eq(hook1)
+        expect(hash[:my_name2]).to eq(hook2)
       end
 
       it 'should return an empty hash if no hooks defined' do
-        @hooks.get_hooks(:test_hook).should == {}
+        expect(@hooks.get_hooks(:test_hook)).to eq({})
       end
     end
   end
@@ -213,7 +213,7 @@ describe Pry::Hooks do
       @hooks.add_hook(:test_hook, :my_name2) { }
       @hooks.add_hook(:test_hook, :my_name3) { }
       @hooks.clear(:test_hook)
-      @hooks.hook_count(:test_hook).should == 0
+      expect(@hooks.hook_count(:test_hook)).to eq(0)
     end
   end
 
@@ -221,18 +221,18 @@ describe Pry::Hooks do
     it 'should successfully delete a hook' do
       @hooks.add_hook(:test_hook, :my_name) {}
       @hooks.delete_hook(:test_hook, :my_name)
-      @hooks.hook_count(:test_hook).should == 0
+      expect(@hooks.hook_count(:test_hook)).to eq(0)
     end
 
     it 'should return the deleted hook' do
       run = false
       @hooks.add_hook(:test_hook, :my_name) { run = true }
       @hooks.delete_hook(:test_hook, :my_name).call
-      run.should == true
+      expect(run).to eq(true)
     end
 
     it 'should return nil if hook does not exist' do
-      @hooks.delete_hook(:test_hook, :my_name).should == nil
+      expect(@hooks.delete_hook(:test_hook, :my_name)).to eq(nil)
     end
   end
 
@@ -241,14 +241,14 @@ describe Pry::Hooks do
       run = false
       @hooks.add_hook(:test_hook, :my_name) { run = true }
       @hooks.exec_hook(:test_hook)
-      run.should == true
+      expect(run).to eq(true)
     end
 
     it 'should execute proc hook' do
       run = false
       @hooks.add_hook(:test_hook, :my_name, proc { run = true })
       @hooks.exec_hook(:test_hook)
-      run.should == true
+      expect(run).to eq(true)
     end
 
     it 'should execute a general callable hook' do
@@ -262,7 +262,7 @@ describe Pry::Hooks do
 
       @hooks.add_hook(:test_hook, :my_name, callable)
       @hooks.exec_hook(:test_hook)
-      callable.test_var.should == true
+      expect(callable.test_var).to eq(true)
     end
 
     it 'should execute all hooks for an event if more than one is defined' do
@@ -271,8 +271,8 @@ describe Pry::Hooks do
       @hooks.add_hook(:test_hook, :my_name1) { y = true }
       @hooks.add_hook(:test_hook, :my_name2) { x = true }
       @hooks.exec_hook(:test_hook)
-      x.should == true
-      y.should == true
+      expect(x).to eq(true)
+      expect(y).to eq(true)
     end
 
     it 'should execute hooks in order' do
@@ -281,14 +281,14 @@ describe Pry::Hooks do
       @hooks.add_hook(:test_hook, :my_name2) { array << 2 }
       @hooks.add_hook(:test_hook, :my_name3) { array << 3 }
       @hooks.exec_hook(:test_hook)
-      array.should == [1, 2, 3]
+      expect(array).to eq([1, 2, 3])
     end
 
     it 'return value of exec_hook should be that of last executed hook' do
       @hooks.add_hook(:test_hook, :my_name1) { 1 }
       @hooks.add_hook(:test_hook, :my_name2) { 2 }
       @hooks.add_hook(:test_hook, :my_name3) { 3 }
-      @hooks.exec_hook(:test_hook).should == 3
+      expect(@hooks.exec_hook(:test_hook)).to eq(3)
     end
 
     it 'should add exceptions to the errors array' do
@@ -296,14 +296,14 @@ describe Pry::Hooks do
       @hooks.add_hook(:test_hook, :foo2) { raise 'two' }
       @hooks.add_hook(:test_hook, :foo3) { raise 'three' }
       @hooks.exec_hook(:test_hook)
-      @hooks.errors.map(&:message).should == ['one', 'two', 'three']
+      expect(@hooks.errors.map(&:message)).to eq(['one', 'two', 'three'])
     end
 
     it 'should return the last exception raised as the return value' do
       @hooks.add_hook(:test_hook, :foo1) { raise 'one' }
       @hooks.add_hook(:test_hook, :foo2) { raise 'two' }
       @hooks.add_hook(:test_hook, :foo3) { raise 'three' }
-      @hooks.exec_hook(:test_hook).should == @hooks.errors.last
+      expect(@hooks.exec_hook(:test_hook)).to eq(@hooks.errors.last)
     end
   end
 
@@ -317,7 +317,7 @@ describe Pry::Hooks do
           Pry.start binding, :hello => :baby
         end
 
-        options[:hello].should == :baby
+        expect(options[:hello]).to eq(:baby)
 
         Pry.config.hooks.delete_hook(:when_started, :test_hook)
       end
@@ -332,7 +332,7 @@ describe Pry::Hooks do
             Pry.start 5, :hello => :baby
           end
 
-          b.is_a?(Binding).should == true
+          expect(b.is_a?(Binding)).to eq(true)
           Pry.config.hooks.delete_hook(:when_started, :test_hook)
         end
 
@@ -344,7 +344,7 @@ describe Pry::Hooks do
             Pry.start 5, :hello => :baby
           end
 
-          b.eval('self').should == 5
+          expect(b.eval('self')).to eq(5)
           Pry.config.hooks.delete_hook(:when_started, :test_hook)
         end
       end
@@ -360,7 +360,7 @@ describe Pry::Hooks do
           Pry.start binding, :hello => :baby
         end
 
-        o.value.should == true
+        expect(o.value).to eq(true)
         Pry.config.hooks.delete_hook(:when_started, :test_hook)
       end
 
@@ -386,10 +386,10 @@ describe Pry::Hooks do
 
         # ensure that an exception really was raised and it broke out
         # of the repl
-        exception.is_a?(o.great_escape).should == true
+        expect(exception.is_a?(o.great_escape)).to eq(true)
 
         # check that after_session hook ran
-        array.should == nil
+        expect(array).to eq(nil)
 
         # cleanup after test
         Pry.config.exception_whitelist = old_ew
@@ -402,8 +402,8 @@ describe Pry::Hooks do
             redirect_pry_io(InputTester.new(":jemima", "exit-all"), out = StringIO.new) do
               Pry.start(self, :hooks => hooks)
             end
-            out.string.should =~ /little_duck/
-            out.string.should_not =~ /jemima/
+            expect(out.string).to match(/little_duck/)
+            expect(out.string).not_to match(/jemima/)
           end
 
           it 'should not interfere with command processing when replacing input code' do
@@ -419,8 +419,8 @@ describe Pry::Hooks do
             redirect_pry_io(InputTester.new("how-do-you-like-your-blue-eyed-boy-now-mister-death", "exit-all"), out = StringIO.new) do
               Pry.start(self, :hooks => hooks, :commands => commands)
             end
-            out.string.should =~ /in hours of bitterness i imagine balls of sapphire, of metal/
-            out.string.should_not =~ /little_duck/
+            expect(out.string).to match(/in hours of bitterness i imagine balls of sapphire, of metal/)
+            expect(out.string).not_to match(/little_duck/)
           end
         end
 
@@ -441,7 +441,7 @@ describe Pry::Hooks do
         end
 
         it "should print out a notice for each exception raised" do
-          mock_pry("1").should =~ /after_eval hook failed: RuntimeError: Baddums\n.*after_eval hook failed: RuntimeError: Simbads/m
+          expect(mock_pry("1")).to match(/after_eval hook failed: RuntimeError: Baddums\n.*after_eval hook failed: RuntimeError: Simbads/m)
         end
       end
     end
@@ -450,13 +450,13 @@ describe Pry::Hooks do
   describe "anonymous hooks" do
     it 'should allow adding of hook without a name' do
       @hooks.add_hook(:test_hook, nil) {}
-      @hooks.hook_count(:test_hook).should == 1
+      expect(@hooks.hook_count(:test_hook)).to eq(1)
     end
 
     it 'should only allow one anonymous hook to exist' do
       @hooks.add_hook(:test_hook, nil) {  }
       @hooks.add_hook(:test_hook, nil) {  }
-      @hooks.hook_count(:test_hook).should == 1
+      expect(@hooks.hook_count(:test_hook)).to eq(1)
     end
 
     it 'should execute most recently added anonymous hook' do
@@ -465,8 +465,8 @@ describe Pry::Hooks do
       @hooks.add_hook(:test_hook, nil) { y = 1 }
       @hooks.add_hook(:test_hook, nil) { x = 2 }
       @hooks.exec_hook(:test_hook)
-      y.should == nil
-      x.should == 2
+      expect(y).to eq(nil)
+      expect(x).to eq(2)
     end
   end
 

--- a/spec/indent_spec.rb
+++ b/spec/indent_spec.rb
@@ -12,21 +12,21 @@ describe Pry::Indent do
     input  = "array = [\n10,\n15\n]"
     output = "array = [\n  10,\n  15\n]"
 
-    @indent.indent(input).should == output
+    expect(@indent.indent(input)).to eq(output)
   end
 
   it 'should indent a hash' do
     input  = "hash = {\n:name => 'Ruby'\n}"
     output = "hash = {\n  :name => 'Ruby'\n}"
 
-    @indent.indent(input).should == output
+    expect(@indent.indent(input)).to eq(output)
   end
 
   it 'should indent a function' do
     input  = "def\nreturn 10\nend"
     output = "def\n  return 10\nend"
 
-    @indent.indent(input).should == output
+    expect(@indent.indent(input)).to eq(output)
   end
 
   it 'should indent a module and class' do
@@ -35,14 +35,14 @@ describe Pry::Indent do
     input_class  = "class Foo\n# Hello world\nend"
     output_class = "class Foo\n  # Hello world\nend"
 
-    @indent.indent(input).should       == output
-    @indent.indent(input_class).should == output_class
+    expect(@indent.indent(input)).to       eq(output)
+    expect(@indent.indent(input_class)).to eq(output_class)
   end
 
   it 'should indent separate lines' do
-    @indent.indent('def foo').should   == 'def foo'
-    @indent.indent('return 10').should == '  return 10'
-    @indent.indent('end').should       == 'end'
+    expect(@indent.indent('def foo')).to   eq('def foo')
+    expect(@indent.indent('return 10')).to eq('  return 10')
+    expect(@indent.indent('end')).to       eq('end')
   end
 
   it 'should not indent single line statements' do
@@ -51,7 +51,7 @@ def hello; end
 puts "Hello"
 TXT
 
-    @indent.indent(input).should == input
+    expect(@indent.indent(input)).to eq(input)
   end
 
   it 'should handle multiple open and closing tokens on a line' do
@@ -67,7 +67,7 @@ TXT
 end
 TXT
 
-    @indent.indent(input).should == output
+    expect(@indent.indent(input)).to eq(output)
   end
 
   it 'should properly indent nested code' do
@@ -99,7 +99,7 @@ module A
 end
 TXT
 
-    @indent.indent(input).should == output
+    expect(@indent.indent(input)).to eq(output)
   end
 
   it 'should indent statements such as if, else, etc' do
@@ -147,12 +147,12 @@ for num in [10, 15, 20] do
 end
 TXT
 
-    @indent.indent(input).should == output
+    expect(@indent.indent(input)).to eq(output)
   end
 
   it "should correctly handle while <foo> do" do
     input = "while 5 do\n5\nend"
-    @indent.indent(input).should == "while 5 do\n  5\nend"
+    expect(@indent.indent(input)).to eq("while 5 do\n  5\nend")
   end
 
   it "should ident case statements" do
@@ -186,39 +186,39 @@ else
 end
 TXT
 
-    @indent.indent(input).should == output
+    expect(@indent.indent(input)).to eq(output)
   end
 
   it "should indent correctly with nesting" do
-    @indent.indent("[[\n[]]\n]").should == "[[\n  []]\n]"
-    @indent.reset.indent("[[\n[]]\n]").should == "[[\n  []]\n]"
-    @indent.reset.indent("[[{\n[] =>\n[]}]\n]").should == "[[{\n      [] =>\n  []}]\n]"
+    expect(@indent.indent("[[\n[]]\n]")).to eq("[[\n  []]\n]")
+    expect(@indent.reset.indent("[[\n[]]\n]")).to eq("[[\n  []]\n]")
+    expect(@indent.reset.indent("[[{\n[] =>\n[]}]\n]")).to eq("[[{\n      [] =>\n  []}]\n]")
   end
 
   it "should not indent single-line ifs" do
-    @indent.indent("foo if bar\n#").should == "foo if bar\n#"
-    @indent.reset.indent("foo() if bar\n#").should == "foo() if bar\n#"
-    @indent.reset.indent("foo 'hi' if bar\n#").should == "foo 'hi' if bar\n#"
-    @indent.reset.indent("foo 1 while bar\n#").should == "foo 1 while bar\n#"
-    @indent.reset.indent("super if true\n#").should == "super if true\n#"
-    @indent.reset.indent("true if false\n#").should == "true if false\n#"
-    @indent.reset.indent("String if false\n#").should == "String if false\n#"
+    expect(@indent.indent("foo if bar\n#")).to eq("foo if bar\n#")
+    expect(@indent.reset.indent("foo() if bar\n#")).to eq("foo() if bar\n#")
+    expect(@indent.reset.indent("foo 'hi' if bar\n#")).to eq("foo 'hi' if bar\n#")
+    expect(@indent.reset.indent("foo 1 while bar\n#")).to eq("foo 1 while bar\n#")
+    expect(@indent.reset.indent("super if true\n#")).to eq("super if true\n#")
+    expect(@indent.reset.indent("true if false\n#")).to eq("true if false\n#")
+    expect(@indent.reset.indent("String if false\n#")).to eq("String if false\n#")
   end
 
   it "should indent cunningly disguised ifs" do
-    @indent.indent("{1 => if bar\n#").should == "{1 => if bar\n    #"
-    @indent.reset.indent("foo(if bar\n#").should == "foo(if bar\n    #"
-    @indent.reset.indent("bar(baz, if bar\n#").should == "bar(baz, if bar\n    #"
-    @indent.reset.indent("[if bar\n#").should == "[if bar\n    #"
-    @indent.reset.indent("true; while bar\n#").should == "true; while bar\n  #"
+    expect(@indent.indent("{1 => if bar\n#")).to eq("{1 => if bar\n    #")
+    expect(@indent.reset.indent("foo(if bar\n#")).to eq("foo(if bar\n    #")
+    expect(@indent.reset.indent("bar(baz, if bar\n#")).to eq("bar(baz, if bar\n    #")
+    expect(@indent.reset.indent("[if bar\n#")).to eq("[if bar\n    #")
+    expect(@indent.reset.indent("true; while bar\n#")).to eq("true; while bar\n  #")
   end
 
   it "should differentiate single/multi-line unless" do
-    @indent.indent("foo unless bar\nunless foo\nbar\nend").should == "foo unless bar\nunless foo\n  bar\nend"
+    expect(@indent.indent("foo unless bar\nunless foo\nbar\nend")).to eq("foo unless bar\nunless foo\n  bar\nend")
   end
 
   it "should not indent single/multi-line until" do
-    @indent.indent("%w{baz} until bar\nuntil foo\nbar\nend").should == "%w{baz} until bar\nuntil foo\n  bar\nend"
+    expect(@indent.indent("%w{baz} until bar\nuntil foo\nbar\nend")).to eq("%w{baz} until bar\nuntil foo\n  bar\nend")
   end
 
   it "should indent begin rescue end" do
@@ -237,17 +237,17 @@ rescue => e
 end
 OUTPUT
 
-    @indent.indent(input).should == output
+    expect(@indent.indent(input)).to eq(output)
   end
 
   it "should not indent inside strings" do
-    @indent.indent(%(def a\n"foo\nbar"\n  end)).should == %(def a\n  "foo\nbar"\nend)
-    @indent.indent(%(def a\nputs %w(foo\nbar), 'foo\nbar'\n  end)).should == %(def a\n  puts %w(foo\nbar), 'foo\nbar'\nend)
+    expect(@indent.indent(%(def a\n"foo\nbar"\n  end))).to eq(%(def a\n  "foo\nbar"\nend))
+    expect(@indent.indent(%(def a\nputs %w(foo\nbar), 'foo\nbar'\n  end))).to eq(%(def a\n  puts %w(foo\nbar), 'foo\nbar'\nend))
   end
 
   it "should not indent inside HEREDOCs" do
-    @indent.indent(%(def a\nputs <<FOO\n bar\nFOO\nbaz\nend)).should == %(def a\n  puts <<FOO\n bar\nFOO\n  baz\nend)
-    @indent.indent(%(def a\nputs <<-'^^'\n bar\n\t^^\nbaz\nend)).should == %(def a\n  puts <<-'^^'\n bar\n\t^^\n  baz\nend)
+    expect(@indent.indent(%(def a\nputs <<FOO\n bar\nFOO\nbaz\nend))).to eq(%(def a\n  puts <<FOO\n bar\nFOO\n  baz\nend))
+    expect(@indent.indent(%(def a\nputs <<-'^^'\n bar\n\t^^\nbaz\nend))).to eq(%(def a\n  puts <<-'^^'\n bar\n\t^^\n  baz\nend))
   end
 
   it "should not indent nested HEREDOCs" do
@@ -277,7 +277,7 @@ tongue
 end
 OUTPUT
 
-    @indent.indent(input).should == output
+    expect(@indent.indent(input)).to eq(output)
   end
 
   describe "nesting" do
@@ -291,7 +291,7 @@ OUTPUT
           end
         else
           it "should parse nesting on line #{i + 1} of example_nesting.rb" do
-            Pry::Indent.nesting_at(test, i + 1).should == eval(result)
+            expect(Pry::Indent.nesting_at(test, i + 1)).to eq(eval(result))
           end
         end
       end

--- a/spec/method/patcher_spec.rb
+++ b/spec/method/patcher_spec.rb
@@ -9,26 +9,26 @@ describe Pry::Method::Patcher do
   end
 
   it "should change the behaviour of the method" do
-    @x.test.should == :before
+    expect(@x.test).to eq(:before)
     @method.redefine "def @x.test; :after; end\n"
-    @x.test.should == :after
+    expect(@x.test).to eq(:after)
   end
 
   it "should return a new method with new source" do
-    @method.source.strip.should == "def @x.test; :before; end"
-    @method.redefine("def @x.test; :after; end\n").
-      source.strip.should == "def @x.test; :after; end"
+    expect(@method.source.strip).to eq("def @x.test; :before; end")
+    expect(@method.redefine("def @x.test; :after; end\n").
+      source.strip).to eq("def @x.test; :after; end")
   end
 
   it "should change the source of new Pry::Method objects" do
     @method.redefine "def @x.test; :after; end\n"
-    Pry::Method(@x.method(:test)).source.strip.should == "def @x.test; :after; end"
+    expect(Pry::Method(@x.method(:test)).source.strip).to eq("def @x.test; :after; end")
   end
 
   it "should preserve visibility" do
     class << @x; private :test; end
-    @method.visibility.should == :private
+    expect(@method.visibility).to eq(:private)
     @method.redefine "def @x.test; :after; end\n"
-    Pry::Method(@x.method(:test)).visibility.should == :private
+    expect(Pry::Method(@x.method(:test)).visibility).to eq(:private)
   end
 end

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -4,92 +4,92 @@ require 'set'
 describe Pry::Method do
   it "should use String names for compatibility" do
     klass = Class.new { def hello; end }
-    Pry::Method.new(klass.instance_method(:hello)).name.should == "hello"
+    expect(Pry::Method.new(klass.instance_method(:hello)).name).to eq("hello")
   end
 
   describe ".from_str" do
     it 'should look up instance methods if no methods available and no options provided' do
       klass = Class.new { def hello; end }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass))
-      meth.should == klass.instance_method(:hello)
+      expect(meth).to eq(klass.instance_method(:hello))
     end
 
     it 'should look up methods if no instance methods available and no options provided' do
       klass = Class.new { def self.hello; end }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass))
-      meth.should == klass.method(:hello)
+      expect(meth).to eq(klass.method(:hello))
     end
 
     it 'should look up instance methods first even if methods available and no options provided' do
       klass = Class.new { def hello; end; def self.hello; end  }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass))
-      meth.should == klass.instance_method(:hello)
+      expect(meth).to eq(klass.instance_method(:hello))
     end
 
     it 'should look up instance methods if "instance-methods"  option provided' do
       klass = Class.new { def hello; end; def self.hello; end  }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass), {"instance-methods" => true})
-      meth.should == klass.instance_method(:hello)
+      expect(meth).to eq(klass.instance_method(:hello))
     end
 
     it 'should look up methods if :methods  option provided' do
       klass = Class.new { def hello; end; def self.hello; end  }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass), {:methods => true})
-      meth.should == klass.method(:hello)
+      expect(meth).to eq(klass.method(:hello))
     end
 
     it 'should look up instance methods using the Class#method syntax' do
       klass = Class.new { def hello; end; def self.hello; end  }
       meth = Pry::Method.from_str("klass#hello", Pry.binding_for(binding))
-      meth.should == klass.instance_method(:hello)
+      expect(meth).to eq(klass.instance_method(:hello))
     end
 
     it 'should look up methods using the object.method syntax' do
       klass = Class.new { def hello; end; def self.hello; end  }
       meth = Pry::Method.from_str("klass.hello", Pry.binding_for(binding))
-      meth.should == klass.method(:hello)
+      expect(meth).to eq(klass.method(:hello))
     end
 
     it 'should NOT look up instance methods using the Class#method syntax if no instance methods defined' do
       klass = Class.new { def self.hello; end  }
       meth = Pry::Method.from_str("klass#hello", Pry.binding_for(binding))
-      meth.should == nil
+      expect(meth).to eq(nil)
     end
 
     it 'should NOT look up methods using the object.method syntax if no methods defined' do
       klass = Class.new { def hello; end  }
       meth = Pry::Method.from_str("klass.hello", Pry.binding_for(binding))
-      meth.should == nil
+      expect(meth).to eq(nil)
     end
 
     it 'should look up methods using klass.new.method syntax' do
       klass = Class.new { def hello; :hello; end }
       meth = Pry::Method.from_str("klass.new.hello", Pry.binding_for(binding))
-      meth.name.should == "hello"
+      expect(meth.name).to eq("hello")
     end
 
     it 'should take care of corner cases like mongo[] e.g Foo::Bar.new[]- issue 998' do
       klass = Class.new { def []; :hello; end }
       meth = Pry::Method.from_str("klass.new[]", Pry.binding_for(binding))
-      meth.name.should == "[]"
+      expect(meth.name).to eq("[]")
     end
 
     it 'should take care of cases like $ mongo[] - issue 998' do
       f = Class.new { def []; :hello; end }.new
       meth = Pry::Method.from_str("f[]", Pry.binding_for(binding))
-      meth.name.should == "[]"
+      expect(meth.name).to eq("[]")
     end
 
     it 'should look up instance methods using klass.meth#method syntax' do
       klass = Class.new { def self.meth; Class.new; end }
       meth = Pry::Method.from_str("klass.meth#initialize", Pry.binding_for(binding))
-      meth.name.should == "initialize"
+      expect(meth.name).to eq("initialize")
     end
 
     it 'should look up methods using instance::bar syntax' do
       klass = Class.new{ def self.meth; Class.new; end }
       meth = Pry::Method.from_str("klass::meth", Pry.binding_for(binding))
-      meth.name.should == "meth"
+      expect(meth.name).to eq("meth")
     end
 
     it 'should not raise an exception if receiver does not exist' do
@@ -99,11 +99,11 @@ describe Pry::Method do
 
   describe '.from_binding' do
     it 'should be able to pick a method out of a binding' do
-      Pry::Method.from_binding(Class.new{ def self.foo; binding; end }.foo).name.should == "foo"
+      expect(Pry::Method.from_binding(Class.new{ def self.foo; binding; end }.foo).name).to eq("foo")
     end
 
     it 'should NOT find a method from the toplevel binding' do
-      Pry::Method.from_binding(TOPLEVEL_BINDING).should == nil
+      expect(Pry::Method.from_binding(TOPLEVEL_BINDING)).to eq(nil)
     end
 
     it "should find methods that have been undef'd" do
@@ -115,7 +115,7 @@ describe Pry::Method do
       end
 
       m = Pry::Method.from_binding(c.bar)
-      m.name.should == "bar"
+      expect(m.name).to eq("bar")
     end
 
     # Our source_location trick doesn't work, due to https://github.com/rubinius/rubinius/issues/953
@@ -127,9 +127,9 @@ describe Pry::Method do
         g = b.new.gag33
         m = Pry::Method.from_binding(g)
 
-        m.owner.should == a
-        m.source_line.should == a.line
-        m.name.should == "gag33"
+        expect(m.owner).to eq(a)
+        expect(m.source_line).to eq(a.line)
+        expect(m.name).to eq("gag33")
       end
     end
 
@@ -139,9 +139,9 @@ describe Pry::Method do
 
       m = Pry::Method.from_binding(b.new.gag)
 
-      m.owner.should == b
-      m.source_line.should == b.line
-      m.name.should == "gag"
+      expect(m.owner).to eq(b)
+      expect(m.source_line).to eq(b.line)
+      expect(m.name).to eq("gag")
     end
 
     # Temporarily disabled to work around rubinius/rubinius#2871.
@@ -150,9 +150,9 @@ describe Pry::Method do
         a = Class.new(BasicObject) { def gag; ::Kernel.binding; end; def self.line; __LINE__; end }
 
         m = Pry::Method.from_binding(a.new.gag)
-        m.owner.should == a
-        m.source_file.should == __FILE__
-        m.source_line.should == a.line
+        expect(m.owner).to eq(a)
+        expect(m.source_file).to eq(__FILE__)
+        expect(m.source_line).to eq(a.line)
       end
     end
 
@@ -168,7 +168,7 @@ describe Pry::Method do
       end
 
       m = Pry::Method.from_binding(o.borscht)
-      m.source.should == Pry::Method(o.method(:paella)).source
+      expect(m.source).to eq(Pry::Method(o.method(:paella)).source)
     end
   end
 
@@ -180,8 +180,8 @@ describe Pry::Method do
       obj = b.new
 
       zuper = Pry::Method(obj.method(:rar)).super
-      zuper.owner.should == a
-      zuper.receiver.should == obj
+      expect(zuper.owner).to eq(a)
+      expect(zuper.receiver).to eq(obj)
     end
 
     it 'should be able to find the super method of an unbound method' do
@@ -189,13 +189,13 @@ describe Pry::Method do
       b = Class.new(a){ def rar; super; end }
 
       zuper = Pry::Method(b.instance_method(:rar)).super
-      zuper.owner.should == a
+      expect(zuper.owner).to eq(a)
     end
 
     it 'should return nil if no super method exists' do
       a = Class.new{ def rar; super; end }
 
-      Pry::Method(a.instance_method(:rar)).super.should == nil
+      expect(Pry::Method(a.instance_method(:rar)).super).to eq(nil)
     end
 
     it 'should be able to find super methods defined on modules' do
@@ -203,7 +203,7 @@ describe Pry::Method do
       a = Class.new{ def rar; super; end; include m }
 
       zuper = Pry::Method(a.new.method(:rar)).super
-      zuper.owner.should == m
+      expect(zuper.owner).to eq(m)
     end
 
     it 'should be able to find super methods defined on super-classes when there are modules in the way' do
@@ -212,7 +212,7 @@ describe Pry::Method do
       b = Class.new(a){ def rar; super; end; include m }
 
       zuper = Pry::Method(b.new.method(:rar)).super
-      zuper.owner.should == a
+      expect(zuper.owner).to eq(a)
     end
 
     it 'should be able to jump up multiple levels of bound method, even through modules' do
@@ -221,14 +221,14 @@ describe Pry::Method do
       b = Class.new(a){ def rar; super; end; include m }
 
       zuper = Pry::Method(b.new.method(:rar)).super
-      zuper.owner.should == m
-      zuper.super.owner.should == a
+      expect(zuper.owner).to eq(m)
+      expect(zuper.super.owner).to eq(a)
     end
   end
 
   describe 'all_from_class' do
     def should_find_method(name)
-      Pry::Method.all_from_class(@class).map(&:name).should include name
+      expect(Pry::Method.all_from_class(@class).map(&:name)).to include name
     end
 
     it 'should be able to find public instance methods defined in a class' do
@@ -264,7 +264,7 @@ describe Pry::Method do
 
     it 'should attribute overridden methods to the sub-class' do
       @class = Class.new(Class.new{ include Module.new{ def meth; 1; end; } }) { def meth; 2; end }
-      Pry::Method.all_from_class(@class).detect{ |x| x.name == 'meth' }.owner.should == @class
+      expect(Pry::Method.all_from_class(@class).detect{ |x| x.name == 'meth' }.owner).to eq(@class)
     end
 
     it 'should be able to find methods defined on a singleton class' do
@@ -281,7 +281,7 @@ describe Pry::Method do
   describe 'all_from_obj' do
     describe 'on normal objects' do
       def should_find_method(name)
-        Pry::Method.all_from_obj(@obj).map(&:name).should include name
+        expect(Pry::Method.all_from_obj(@obj).map(&:name)).to include name
       end
 
       it "should find methods defined in the object's class" do
@@ -313,7 +313,7 @@ describe Pry::Method do
 
       it "should not find methods defined on the classes singleton class" do
         @obj = Class.new{ class << self; def meth; 1; end; end }.new
-        Pry::Method.all_from_obj(@obj).map(&:name).should_not include 'meth'
+        expect(Pry::Method.all_from_obj(@obj).map(&:name)).not_to include 'meth'
       end
 
       it "should work in the face of an overridden send" do
@@ -324,7 +324,7 @@ describe Pry::Method do
 
     describe 'on classes' do
       def should_find_method(name)
-        Pry::Method.all_from_obj(@class).map(&:name).should include name
+        expect(Pry::Method.all_from_obj(@class).map(&:name)).to include name
       end
 
       it "should find methods defined in the class' singleton class" do
@@ -344,7 +344,7 @@ describe Pry::Method do
 
       it "should not find methods defined within the class" do
         @class = Class.new{ def meth; 1; end }
-        Pry::Method.all_from_obj(@obj).map(&:name).should_not include 'meth'
+        expect(Pry::Method.all_from_obj(@obj).map(&:name)).not_to include 'meth'
       end
 
       it "should find methods defined on Class" do
@@ -359,17 +359,17 @@ describe Pry::Method do
 
       it "should attribute overridden methods to the sub-class' singleton class" do
         @class = Class.new(Class.new{ class << self; def meth; 1; end; end }) { class << self; def meth; 1; end; end }
-        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner.should == (class << @class; self; end)
+        expect(Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner).to eq(class << @class; self; end)
       end
 
       it "should attrbute overridden methods to the class not the module" do
         @class = Class.new { class << self; def meth; 1; end; end; extend Module.new{ def meth; 1; end; } }
-        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner.should == (class << @class; self; end)
+        expect(Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner).to eq(class << @class; self; end)
       end
 
       it "should attribute overridden methods to the relevant singleton class in preference to Class" do
         @class = Class.new { class << self; def allocate; 1; end; end }
-        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'allocate' }.owner.should == (class << @class; self; end)
+        expect(Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'allocate' }.owner).to eq(class << @class; self; end)
       end
     end
 
@@ -392,50 +392,51 @@ describe Pry::Method do
       def singleton_class(obj); class << obj; self; end; end
 
       it "should look at a class and then its superclass" do
-        Pry::Method.instance_resolution_order(LS::Next).should == [LS::Next] + Pry::Method.instance_resolution_order(LS::Top)
+        expect(Pry::Method.instance_resolution_order(LS::Next)).to eq([LS::Next] + Pry::Method.instance_resolution_order(LS::Top))
       end
 
       it "should include the included modules between a class and its superclass" do
-        Pry::Method.instance_resolution_order(LS::Low).should == [LS::Low, LS::P, LS::N, LS::M] + Pry::Method.instance_resolution_order(LS::Next)
+        expect(Pry::Method.instance_resolution_order(LS::Low)).to eq([LS::Low, LS::P, LS::N, LS::M] + Pry::Method.instance_resolution_order(LS::Next))
       end
 
       it "should not include modules extended into the class" do
-        Pry::Method.instance_resolution_order(LS::Bottom).should == [LS::Bottom] + Pry::Method.instance_resolution_order(LS::Lower)
+        expect(Pry::Method.instance_resolution_order(LS::Bottom)).to eq([LS::Bottom] + Pry::Method.instance_resolution_order(LS::Lower))
       end
 
       it "should include included modules for Modules" do
-        Pry::Method.instance_resolution_order(LS::O).should == [LS::O, LS::M]
+        expect(Pry::Method.instance_resolution_order(LS::O)).to eq([LS::O, LS::M])
       end
 
       it "should include the singleton class of objects" do
         obj = LS::Low.new
-        Pry::Method.resolution_order(obj).should == [singleton_class(obj)] + Pry::Method.instance_resolution_order(LS::Low)
+        expect(Pry::Method.resolution_order(obj)).to eq([singleton_class(obj)] + Pry::Method.instance_resolution_order(LS::Low))
       end
 
       it "should not include singleton classes of numbers" do
-        Pry::Method.resolution_order(4).should == Pry::Method.instance_resolution_order(Fixnum)
+        expect(Pry::Method.resolution_order(4)).to eq(Pry::Method.instance_resolution_order(Fixnum))
       end
 
       it "should include singleton classes for classes" do
-        Pry::Method.resolution_order(LS::Low).should == [singleton_class(LS::Low)] + Pry::Method.resolution_order(LS::Next)
+        expect(Pry::Method.resolution_order(LS::Low)).to eq([singleton_class(LS::Low)] + Pry::Method.resolution_order(LS::Next))
       end
 
       it "should include modules included into singleton classes" do
-        Pry::Method.resolution_order(LS::Lower).should == [singleton_class(LS::Lower), LS::N, LS::M] + Pry::Method.resolution_order(LS::Low)
+        expect(Pry::Method.resolution_order(LS::Lower)).to eq([singleton_class(LS::Lower), LS::N, LS::M] + Pry::Method.resolution_order(LS::Low))
       end
 
       it "should include modules at most once" do
-        Pry::Method.resolution_order(LS::Bottom).count(LS::M).should == 1
+        expect(Pry::Method.resolution_order(LS::Bottom).count(LS::M)).to eq(1)
       end
 
       it "should include modules at the point which they would be reached" do
-        Pry::Method.resolution_order(LS::Bottom).should == [singleton_class(LS::Bottom), LS::O] + (Pry::Method.resolution_order(LS::Lower))
+        expect(Pry::Method.resolution_order(LS::Bottom)).to eq([singleton_class(LS::Bottom), LS::O] + (Pry::Method.resolution_order(LS::Lower)))
       end
 
       it "should include the Pry::Method.instance_resolution_order of Class after the singleton classes" do
-        Pry::Method.resolution_order(LS::Top).should ==
+        expect(Pry::Method.resolution_order(LS::Top)).to eq(
           [singleton_class(LS::Top), singleton_class(Object), singleton_class(BasicObject),
            *Pry::Method.instance_resolution_order(Class)]
+        )
       end
     end
   end
@@ -443,10 +444,10 @@ describe Pry::Method do
   describe 'method_name_from_first_line' do
     it 'should work in all simple cases' do
       meth = Pry::Method.new(nil)
-      meth.send(:method_name_from_first_line, "def x").should == "x"
-      meth.send(:method_name_from_first_line, "def self.x").should == "x"
-      meth.send(:method_name_from_first_line, "def ClassName.x").should == "x"
-      meth.send(:method_name_from_first_line, "def obj_name.x").should == "x"
+      expect(meth.send(:method_name_from_first_line, "def x")).to eq("x")
+      expect(meth.send(:method_name_from_first_line, "def self.x")).to eq("x")
+      expect(meth.send(:method_name_from_first_line, "def ClassName.x")).to eq("x")
+      expect(meth.send(:method_name_from_first_line, "def obj_name.x")).to eq("x")
     end
   end
 
@@ -468,17 +469,17 @@ describe Pry::Method do
       meth = Pry::Method(@class.new.method(:eat))
       aliases = Set.new(meth.aliases)
 
-      aliases.should == Set.new(["fress", "omnomnom"])
+      expect(aliases).to eq(Set.new(["fress", "omnomnom"]))
     end
 
     it 'should return an empty Array if cannot find aliases' do
       meth = Pry::Method(@class.new.method(:eruct))
-      meth.aliases.should be_empty
+      expect(meth.aliases).to be_empty
     end
 
     it 'should not include the own name in the list of aliases' do
       meth = Pry::Method(@class.new.method(:eat))
-      meth.aliases.should_not include "eat"
+      expect(meth.aliases).not_to include "eat"
     end
 
     it 'should find aliases for top-level methods' do
@@ -490,7 +491,7 @@ describe Pry::Method do
       end
 
       meth = Pry::Method.new(method(:my_top_level_method))
-      meth.aliases.should include 'my_other_top_level_method'
+      expect(meth.aliases).to include 'my_other_top_level_method'
 
       class Object
         remove_method :my_top_level_method
@@ -501,7 +502,7 @@ describe Pry::Method do
       meth = Pry::Method(Hash.new.method(:key?))
       aliases = Set.new(meth.aliases)
 
-      aliases.should == Set.new(["include?", "member?", "has_key?"])
+      expect(aliases).to eq(Set.new(["include?", "member?", "has_key?"]))
     end
   end
 end

--- a/spec/pager_spec.rb
+++ b/spec/pager_spec.rb
@@ -27,40 +27,40 @@ describe "Pry::Pager" do
 
     it "records short lines that don't add up to a page" do
       9.times { record_short_line }
-      @pt.page?.should equal false
+      expect(@pt.page?).to equal false
     end
 
     it "records short lines that do add up to a page" do
       10.times { record_short_line }
-      @pt.page?.should equal true
+      expect(@pt.page?).to equal true
     end
 
     it "treats a long line as taking up more than one row" do
       4.times { record_long_line }
-      @pt.page?.should equal false
+      expect(@pt.page?).to equal false
       record_long_line
-      @pt.page?.should equal true
+      expect(@pt.page?).to equal true
     end
 
     it "records a string with an embedded newline" do
       3.times { record_multiline }
-      @pt.page?.should equal false
+      expect(@pt.page?).to equal false
       record_short_line
-      @pt.page?.should equal true
+      expect(@pt.page?).to equal true
     end
 
     it "doesn't count a line until it ends" do
       12.times { record_string_without_newline }
-      @pt.page?.should equal false
+      expect(@pt.page?).to equal false
       record_short_line
-      @pt.page?.should equal true
+      expect(@pt.page?).to equal true
     end
 
     it "doesn't count ansi color codes towards length" do
       9.times { record_string_with_color_codes }
-      @pt.page?.should equal false
+      expect(@pt.page?).to equal false
       record_string_with_color_codes
-      @pt.page?.should equal true
+      expect(@pt.page?).to equal true
     end
   end
 end

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -7,7 +7,7 @@ describe "Prompts" do
       redirect_pry_io(InputTester.new("exit-all")) do
         Pry.start(self, :prompt => proc { |v| config = v })
       end
-      config.is_a?(Pry::Config).should == true
+      expect(config.is_a?(Pry::Config)).to eq(true)
     end
 
     it 'should get full config object, when using a proc array' do
@@ -15,7 +15,7 @@ describe "Prompts" do
       redirect_pry_io(InputTester.new("exit-all")) do
         Pry.start(self, :prompt => [proc { |v| config1 = v }, proc { |v| config2 = v }])
       end
-      config1.is_a?(Pry::Config).should == true
+      expect(config1.is_a?(Pry::Config)).to eq(true)
     end
 
     it 'should receive correct data in the config object' do
@@ -24,11 +24,11 @@ describe "Prompts" do
         Pry.start(self, :prompt => proc { |v| config = v })
       end
 
-      config.eval_string.should =~ /def hello/
-      config.nesting_level.should == 0
-      config.expr_number.should == 1
-      config.cont.should == true
-      config._pry_.is_a?(Pry).should == true
+      expect(config.eval_string).to match(/def hello/)
+      expect(config.nesting_level).to eq(0)
+      expect(config.expr_number).to eq(1)
+      expect(config.cont).to eq(true)
+      expect(config._pry_.is_a?(Pry)).to eq(true)
       expect(config.object).to eq self
     end
   end
@@ -40,9 +40,9 @@ describe "Prompts" do
         Pry.start(:test, :prompt => proc { |obj, nesting, _pry_|
                     o, n, p = obj, nesting, _pry_ })
       end
-      o.should == :test
-      n.should == 0
-      p.is_a?(Pry).should == true
+      expect(o).to eq(:test)
+      expect(n).to eq(0)
+      expect(p.is_a?(Pry)).to eq(true)
     end
 
     it 'should get 3 parameters, when using proc array' do
@@ -53,9 +53,9 @@ describe "Prompts" do
                                      proc { |obj, nesting, _pry_|
                                        o2, n2, p2 = obj, nesting, _pry_ }])
       end
-      o1.should == :test
-      n1.should == 0
-      p1.is_a?(Pry).should == true
+      expect(o1).to eq(:test)
+      expect(n1).to eq(0)
+      expect(p1.is_a?(Pry)).to eq(true)
     end
   end
 end

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -22,11 +22,11 @@ describe "test Pry defaults" do
       Pry.config.input = InputTester.new("5")
       Pry.config.output = @str_output
       Object.new.pry
-      @str_output.string.should =~ /5/
+      expect(@str_output.string).to match(/5/)
 
       Pry.config.output = @str_output
       Object.new.pry :input => InputTester.new("6")
-      @str_output.string.should =~ /6/
+      expect(@str_output.string).to match(/6/)
     end
 
     it 'should pass in the prompt if readline arity is 1' do
@@ -41,7 +41,7 @@ describe "test Pry defaults" do
       end.new
 
       Pry.start(self, :input => arity_one_input, :output => StringIO.new)
-      arity_one_input.prompt.should == Pry.prompt.call
+      expect(arity_one_input.prompt).to eq(Pry.prompt.call)
     end
 
     it 'should not pass in the prompt if the arity is 0' do
@@ -69,7 +69,7 @@ describe "test Pry defaults" do
       end.new
 
       Pry.start(self, :input => arity_multi_input, :output => StringIO.new)
-      arity_multi_input.prompt.should == nil
+      expect(arity_multi_input.prompt).to eq(nil)
     end
 
   end
@@ -79,57 +79,57 @@ describe "test Pry defaults" do
 
     Pry.config.input  = InputTester.new("5")
     Object.new.pry
-    @str_output.string.should =~ /5/
+    expect(@str_output.string).to match(/5/)
 
     Pry.config.input  = InputTester.new("6")
     Object.new.pry
-    @str_output.string.should =~ /5\n.*6/
+    expect(@str_output.string).to match(/5\n.*6/)
 
     Pry.config.input  = InputTester.new("7")
     @str_output = StringIO.new
     Object.new.pry :output => @str_output
-    @str_output.string.should_not =~ /5\n.*6/
-    @str_output.string.should =~ /7/
+    expect(@str_output.string).not_to match(/5\n.*6/)
+    expect(@str_output.string).to match(/7/)
   end
 
   it "should set the print default, and the default should be overridable" do
     new_print = proc { |out, value| out.puts "=> LOL" }
     Pry.config.print =  new_print
 
-    Pry.new.print.should == Pry.config.print
+    expect(Pry.new.print).to eq(Pry.config.print)
     Object.new.pry :input => InputTester.new("\"test\""), :output => @str_output
-    @str_output.string.should == "=> LOL\n"
+    expect(@str_output.string).to eq("=> LOL\n")
 
     @str_output = StringIO.new
     Object.new.pry :input => InputTester.new("\"test\""), :output => @str_output,
                    :print => proc { |out, value| out.puts value.reverse }
-    @str_output.string.should == "tset\n"
+    expect(@str_output.string).to eq("tset\n")
 
-    Pry.new.print.should == Pry.config.print
+    expect(Pry.new.print).to eq(Pry.config.print)
     @str_output = StringIO.new
     Object.new.pry :input => InputTester.new("\"test\""), :output => @str_output
-    @str_output.string.should == "=> LOL\n"
+    expect(@str_output.string).to eq("=> LOL\n")
   end
 
   describe "pry return values" do
     it 'should return nil' do
-      Pry.start(self, :input => StringIO.new("exit-all"), :output => StringIO.new).should == nil
+      expect(Pry.start(self, :input => StringIO.new("exit-all"), :output => StringIO.new)).to eq(nil)
     end
 
     it 'should return the parameter given to exit-all' do
-      Pry.start(self, :input => StringIO.new("exit-all 10"), :output => StringIO.new).should == 10
+      expect(Pry.start(self, :input => StringIO.new("exit-all 10"), :output => StringIO.new)).to eq(10)
     end
 
     it 'should return the parameter (multi word string) given to exit-all' do
-      Pry.start(self, :input => StringIO.new("exit-all \"john mair\""), :output => StringIO.new).should == "john mair"
+      expect(Pry.start(self, :input => StringIO.new("exit-all \"john mair\""), :output => StringIO.new)).to eq("john mair")
     end
 
     it 'should return the parameter (function call) given to exit-all' do
-      Pry.start(self, :input => StringIO.new("exit-all 'abc'.reverse"), :output => StringIO.new).should == 'cba'
+      expect(Pry.start(self, :input => StringIO.new("exit-all 'abc'.reverse"), :output => StringIO.new)).to eq('cba')
     end
 
     it 'should return the parameter (self) given to exit-all' do
-      Pry.start("carl", :input => StringIO.new("exit-all self"), :output => StringIO.new).should == "carl"
+      expect(Pry.start("carl", :input => StringIO.new("exit-all self"), :output => StringIO.new)).to eq("carl")
     end
   end
 
@@ -151,17 +151,17 @@ describe "test Pry defaults" do
       new_prompt = proc { "A" }
 
       pry = Pry.new
-      pry.prompt.should == Pry.prompt
-      get_prompts(pry).should == ["test prompt> ",  "test prompt> "]
+      expect(pry.prompt).to eq(Pry.prompt)
+      expect(get_prompts(pry)).to eq(["test prompt> ",  "test prompt> "])
 
 
       pry = Pry.new(:prompt => new_prompt)
-      pry.prompt.should == new_prompt
-      get_prompts(pry).should == ["A",  "A"]
+      expect(pry.prompt).to eq(new_prompt)
+      expect(get_prompts(pry)).to eq(["A",  "A"])
 
       pry = Pry.new
-      pry.prompt.should == Pry.prompt
-      get_prompts(pry).should == ["test prompt> ",  "test prompt> "]
+      expect(pry.prompt).to eq(Pry.prompt)
+      expect(get_prompts(pry)).to eq(["test prompt> ",  "test prompt> "])
     end
 
     it 'should set the prompt default, and the default should be overridable (multi prompt)' do
@@ -169,17 +169,17 @@ describe "test Pry defaults" do
       new_prompt = [proc { "A" }, proc { "B" }]
 
       pry = Pry.new
-      pry.prompt.should == Pry.prompt
-      get_prompts(pry).should == ["test prompt> ",  "test prompt* "]
+      expect(pry.prompt).to eq(Pry.prompt)
+      expect(get_prompts(pry)).to eq(["test prompt> ",  "test prompt* "])
 
 
       pry = Pry.new(:prompt => new_prompt)
-      pry.prompt.should == new_prompt
-      get_prompts(pry).should == ["A",  "B"]
+      expect(pry.prompt).to eq(new_prompt)
+      expect(get_prompts(pry)).to eq(["A",  "B"])
 
       pry = Pry.new
-      pry.prompt.should == Pry.prompt
-      get_prompts(pry).should == ["test prompt> ",  "test prompt* "]
+      expect(pry.prompt).to eq(Pry.prompt)
+      expect(get_prompts(pry)).to eq(["test prompt> ",  "test prompt* "])
     end
 
     describe 'storing and restoring the prompt' do
@@ -195,49 +195,49 @@ describe "test Pry defaults" do
       it 'should have a prompt stack' do
         @pry.push_prompt @b
         @pry.push_prompt @c
-        @pry.prompt.should == @c
+        expect(@pry.prompt).to eq(@c)
         @pry.pop_prompt
-        @pry.prompt.should == @b
+        expect(@pry.prompt).to eq(@b)
         @pry.pop_prompt
-        @pry.prompt.should == @a
+        expect(@pry.prompt).to eq(@a)
       end
 
       it 'should restore overridden prompts when returning from file-mode' do
         pry = Pry.new(:prompt => [ proc { 'P>' } ] * 2)
-        pry.select_prompt.should == "P>"
+        expect(pry.select_prompt).to eq("P>")
         pry.process_command('shell-mode')
-        pry.select_prompt.should =~ /\Apry .* \$ \z/
+        expect(pry.select_prompt).to match(/\Apry .* \$ \z/)
         pry.process_command('shell-mode')
-        pry.select_prompt.should == "P>"
+        expect(pry.select_prompt).to eq("P>")
       end
 
       it '#pop_prompt should return the popped prompt' do
         @pry.push_prompt @b
         @pry.push_prompt @c
-        @pry.pop_prompt.should == @c
-        @pry.pop_prompt.should == @b
+        expect(@pry.pop_prompt).to eq(@c)
+        expect(@pry.pop_prompt).to eq(@b)
       end
 
       it 'should not pop the last prompt' do
         @pry.push_prompt @b
-        @pry.pop_prompt.should == @b
-        @pry.pop_prompt.should == @a
-        @pry.pop_prompt.should == @a
-        @pry.prompt.should == @a
+        expect(@pry.pop_prompt).to eq(@b)
+        expect(@pry.pop_prompt).to eq(@a)
+        expect(@pry.pop_prompt).to eq(@a)
+        expect(@pry.prompt).to eq(@a)
       end
 
       describe '#prompt= should replace the current prompt with the new prompt' do
         it 'when only one prompt on the stack' do
           @pry.prompt = @b
-          @pry.prompt.should == @b
-          @pry.pop_prompt.should == @b
-          @pry.pop_prompt.should == @b
+          expect(@pry.prompt).to eq(@b)
+          expect(@pry.pop_prompt).to eq(@b)
+          expect(@pry.pop_prompt).to eq(@b)
         end
         it 'when several prompts on the stack' do
           @pry.push_prompt @b
           @pry.prompt = @c
-          @pry.pop_prompt.should == @c
-          @pry.pop_prompt.should == @a
+          expect(@pry.pop_prompt).to eq(@c)
+          expect(@pry.pop_prompt).to eq(@a)
         end
       end
     end
@@ -254,34 +254,34 @@ describe "test Pry defaults" do
         o = Object.new
         def o.inspect; "a" * MAX_LENGTH; end
 
-        Pry.view_clip(o, DEFAULT_OPTIONS).should =~ /#<Object/
+        expect(Pry.view_clip(o, DEFAULT_OPTIONS)).to match(/#<Object/)
       end
     end
 
     describe "given the 'main' object" do
       it "returns the #to_s of main (special case)" do
         o = TOPLEVEL_BINDING.eval('self')
-        Pry.view_clip(o, DEFAULT_OPTIONS).should == o.to_s
+        expect(Pry.view_clip(o, DEFAULT_OPTIONS)).to eq(o.to_s)
       end
     end
 
     describe "the list of prompt safe objects" do
       [1, 2.0, -5, "hello", :test].each do |o|
         it "returns the #inspect of the special-cased immediate object: #{o}" do
-          Pry.view_clip(o, DEFAULT_OPTIONS).should == o.inspect
+          expect(Pry.view_clip(o, DEFAULT_OPTIONS)).to eq(o.inspect)
         end
       end
 
       it "returns #<> format of the special-cased immediate object if #inspect is longer than maximum" do
         o = "o" * (MAX_LENGTH + 1)
-        Pry.view_clip(o, DEFAULT_OPTIONS).should =~ /#<String/
+        expect(Pry.view_clip(o, DEFAULT_OPTIONS)).to match(/#<String/)
       end
 
       it "returns the #inspect of the custom prompt safe objects" do
         Barbie = Class.new { def inspect; "life is plastic, it's fantastic" end }
         Pry.config.prompt_safe_objects << Barbie
         output = Pry.view_clip(Barbie.new, DEFAULT_OPTIONS)
-        output.should == "life is plastic, it's fantastic"
+        expect(output).to eq("life is plastic, it's fantastic")
       end
     end
 
@@ -290,7 +290,7 @@ describe "test Pry defaults" do
         o = Object.new
         def o.inspect; "a" * DEFAULT_OPTIONS; end
 
-        Pry.view_clip(o, DEFAULT_OPTIONS).should =~ /#<Object/
+        expect(Pry.view_clip(o, DEFAULT_OPTIONS)).to match(/#<Object/)
       end
     end
 
@@ -301,7 +301,7 @@ describe "test Pry defaults" do
           o = Object.new
           def o.inspect; "a" * (DEFAULT_OPTIONS + 1); end
 
-          Pry.view_clip(o, DEFAULT_OPTIONS).should =~ /#<Object/
+          expect(Pry.view_clip(o, DEFAULT_OPTIONS)).to match(/#<Object/)
         end
       end
 
@@ -310,8 +310,8 @@ describe "test Pry defaults" do
           it "returns a string of the #<class name:object idish> format" do
             c, m = Class.new, Module.new
 
-            Pry.view_clip(c, DEFAULT_OPTIONS).should =~ /#<Class/
-            Pry.view_clip(m, DEFAULT_OPTIONS).should =~ /#<Module/
+            expect(Pry.view_clip(c, DEFAULT_OPTIONS)).to match(/#<Class/)
+            expect(Pry.view_clip(m, DEFAULT_OPTIONS)).to match(/#<Module/)
           end
         end
 
@@ -323,8 +323,8 @@ describe "test Pry defaults" do
             def c.name; "a" * (MAX_LENGTH + 1); end
             def m.name; "a" * (MAX_LENGTH + 1); end
 
-            Pry.view_clip(c, DEFAULT_OPTIONS).should =~ /#<Class/
-            Pry.view_clip(m, DEFAULT_OPTIONS).should =~ /#<Module/
+            expect(Pry.view_clip(c, DEFAULT_OPTIONS)).to match(/#<Class/)
+            expect(Pry.view_clip(m, DEFAULT_OPTIONS)).to match(/#<Module/)
           end
         end
 
@@ -335,8 +335,8 @@ describe "test Pry defaults" do
             def c.name; "a" * MAX_LENGTH; end
             def m.name; "a" * MAX_LENGTH; end
 
-            Pry.view_clip(c, DEFAULT_OPTIONS).should == c.name
-            Pry.view_clip(m, DEFAULT_OPTIONS).should == m.name
+            expect(Pry.view_clip(c, DEFAULT_OPTIONS)).to eq(c.name)
+            expect(Pry.view_clip(m, DEFAULT_OPTIONS)).to eq(m.name)
           end
         end
 
@@ -352,7 +352,7 @@ describe "test Pry defaults" do
               :output => @str_output,
               :hooks => Pry::DEFAULT_HOOKS)
 
-      @str_output.string.should =~ /[w]hereami by default/
+      expect(@str_output.string).to match(/[w]hereami by default/)
     end
 
     it 'should hide whereami if quiet is set' do
@@ -361,25 +361,25 @@ describe "test Pry defaults" do
               :quiet => true,
               :hooks => Pry::DEFAULT_HOOKS)
 
-      @str_output.string.should == ""
+      expect(@str_output.string).to eq("")
     end
   end
 
   describe 'toplevel_binding' do
     it 'should be devoid of local variables' do
-      pry_eval(Pry.toplevel_binding, "ls -l").should_not =~ /version/
+      expect(pry_eval(Pry.toplevel_binding, "ls -l")).not_to match(/version/)
     end
 
     it 'should have self the same as TOPLEVEL_BINDING' do
-      Pry.toplevel_binding.eval('self').should.equal? TOPLEVEL_BINDING.eval('self')
+      expect(Pry.toplevel_binding.eval('self')).to.equal? TOPLEVEL_BINDING.eval('self')
     end
 
     # https://github.com/rubinius/rubinius/issues/1779
     unless Pry::Helpers::BaseHelpers.rbx?
       it 'should define private methods on Object' do
         TOPLEVEL_BINDING.eval 'def gooey_fooey; end'
-        method(:gooey_fooey).owner.should == Object
-        Pry::Method(method(:gooey_fooey)).visibility.should == :private
+        expect(method(:gooey_fooey).owner).to eq(Object)
+        expect(Pry::Method(method(:gooey_fooey)).visibility).to eq(:private)
       end
     end
   end
@@ -391,8 +391,8 @@ describe "test Pry defaults" do
       add_hook(:after_session, :my_name) { |out,_,_| out.puts "BYE" }
 
     Object.new.pry :output => @str_output
-    @str_output.string.should =~ /HELLO/
-    @str_output.string.should =~ /BYE/
+    expect(@str_output.string).to match(/HELLO/)
+    expect(@str_output.string).to match(/BYE/)
 
     Pry.config.input.rewind
 
@@ -402,8 +402,8 @@ describe "test Pry defaults" do
                    add_hook( :before_session, :my_name) { |out,_,_| out.puts "MORNING" }.
                    add_hook(:after_session, :my_name) { |out,_,_| out.puts "EVENING" }
 
-    @str_output.string.should =~ /MORNING/
-    @str_output.string.should =~ /EVENING/
+    expect(@str_output.string).to match(/MORNING/)
+    expect(@str_output.string).to match(/EVENING/)
 
     # try below with just defining one hook
     Pry.config.input.rewind
@@ -412,7 +412,7 @@ describe "test Pry defaults" do
                    :hooks => Pry::Hooks.new.
                    add_hook(:before_session, :my_name) { |out,_,_| out.puts "OPEN" }
 
-    @str_output.string.should =~ /OPEN/
+    expect(@str_output.string).to match(/OPEN/)
 
     Pry.config.input.rewind
     @str_output = StringIO.new
@@ -420,7 +420,7 @@ describe "test Pry defaults" do
                    :hooks => Pry::Hooks.new.
                    add_hook(:after_session, :my_name) { |out,_,_| out.puts "CLOSE" }
 
-    @str_output.string.should =~ /CLOSE/
+    expect(@str_output.string).to match(/CLOSE/)
 
     Pry.reset_defaults
     Pry.config.color = false

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -371,7 +371,7 @@ describe "test Pry defaults" do
     end
 
     it 'should have self the same as TOPLEVEL_BINDING' do
-      expect(Pry.toplevel_binding.eval('self')).to.equal? TOPLEVEL_BINDING.eval('self')
+      expect(Pry.toplevel_binding.eval('self')).to eq(TOPLEVEL_BINDING.eval('self'))
     end
 
     # https://github.com/rubinius/rubinius/issues/1779

--- a/spec/pry_output_spec.rb
+++ b/spec/pry_output_spec.rb
@@ -15,7 +15,7 @@ describe Pry do
     it "should display serialization exceptions" do
       Pry.config.print = lambda { |*a| raise "catch-22" }
 
-      mock_pry("1").should =~ /\(pry\) output error: #<RuntimeError: catch-22>/
+      expect(mock_pry("1")).to match(/\(pry\) output error: #<RuntimeError: catch-22>/)
     end
 
     it "should catch errors serializing exceptions" do
@@ -23,13 +23,13 @@ describe Pry do
         raise Exception.new("catch-22").tap{ |e| class << e; def inspect; raise e; end; end }
       end
 
-      mock_pry("1").should =~ /\(pry\) output error: failed to show result/
+      expect(mock_pry("1")).to match(/\(pry\) output error: failed to show result/)
     end
   end
 
   describe "DEFAULT_PRINT" do
     it "should output the right thing" do
-      mock_pry("[1]").should =~ /^=> \[1\]/
+      expect(mock_pry("[1]")).to match(/^=> \[1\]/)
     end
 
     it "should include the =>" do
@@ -37,15 +37,15 @@ describe Pry do
       accumulator = StringIO.new
       pry.config.output = accumulator
       pry.config.print.call(accumulator, [1], pry)
-      accumulator.string.should == "=> \[1\]\n"
+      expect(accumulator.string).to eq("=> \[1\]\n")
     end
 
     it "should not be phased by un-inspectable things" do
-      mock_pry("class NastyClass; undef pretty_inspect; end", "NastyClass.new").should =~ /#<.*NastyClass:0x.*?>/
+      expect(mock_pry("class NastyClass; undef pretty_inspect; end", "NastyClass.new")).to match(/#<.*NastyClass:0x.*?>/)
     end
 
     it "doesn't leak colour for object literals" do
-      mock_pry("Object.new").should =~ /=> #<Object:0x[a-z0-9]+>\n/
+      expect(mock_pry("Object.new")).to match(/=> #<Object:0x[a-z0-9]+>\n/)
     end
   end
 
@@ -56,7 +56,7 @@ describe Pry do
       pry.config.output = accumulator
       pry.config.output_prefix = "-> "
       pry.config.print.call(accumulator, [1], pry)
-      accumulator.string.should == "-> \[1\]\n"
+      expect(accumulator.string).to eq("-> \[1\]\n")
     end
   end
 
@@ -75,7 +75,7 @@ describe Pry do
       colorized   = CodeRay.scan("[1]", :ruby).term
       pry.config.output = accumulator
       pry.config.print.call(accumulator, [1], pry)
-      accumulator.string.should == "=> #{colorized}\n"
+      expect(accumulator.string).to eq("=> #{colorized}\n")
     end
 
     it "should not colorize strings that already include color" do
@@ -88,7 +88,7 @@ describe Pry do
       pry.config.output = accumulator
       pry.config.print.call(accumulator, f, pry)
       # We add an extra \e[0m to prevent color leak
-      accumulator.string.should == "=> \e[1;31mFoo\e[0m\e[0m\n"
+      expect(accumulator.string).to eq("=> \e[1;31mFoo\e[0m\e[0m\n")
     end
   end
 
@@ -97,19 +97,19 @@ describe Pry do
       @t = pry_tester
     end
     it "should normally output the result" do
-      mock_pry("1 + 2").should == "=> 3\n"
+      expect(mock_pry("1 + 2")).to eq("=> 3\n")
     end
 
     it "should not output anything if the input ends with a semicolon" do
-      mock_pry("1 + 2;").should == ""
+      expect(mock_pry("1 + 2;")).to eq("")
     end
 
     it "should output something if the input ends with a comment" do
-      mock_pry("1 + 2 # basic addition").should == "=> 3\n"
+      expect(mock_pry("1 + 2 # basic addition")).to eq("=> 3\n")
     end
 
     it "should not output something if the input is only a comment" do
-      mock_pry("# basic addition").should == ""
+      expect(mock_pry("# basic addition")).to eq("")
     end
   end
 end

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -24,11 +24,11 @@ describe Pry do
     end
 
     it 'should not binding.pry' do
-      binding.pry.should == nil
+      expect(binding.pry).to eq(nil)
     end
 
     it 'should not Pry.start' do
-      Pry.start.should == nil
+      expect(Pry.start).to eq(nil)
     end
   end
 
@@ -39,7 +39,7 @@ describe Pry do
       Pry.critical_section do
         Pry.start
       end
-      output.string.should =~ /Pry started inside Pry/
+      expect(output.string).to match(/Pry started inside Pry/)
     end
   end
 
@@ -57,13 +57,13 @@ describe Pry do
 
     it "should not leak local variables" do
       [Object.new, Array, 3].each do |obj|
-        Pry.binding_for(obj).eval("local_variables").should be_empty
+        expect(Pry.binding_for(obj).eval("local_variables")).to be_empty
       end
     end
 
     it "should work on frozen objects" do
       a = "hello".freeze
-      Pry.binding_for(a).eval("self").should.equal? a
+      expect(Pry.binding_for(a).eval("self")).to.equal? a
     end
   end
 
@@ -75,7 +75,7 @@ describe Pry do
 
     it "returns an instance of Pry::LastException" do
       @pry.last_exception = @e
-      @pry.last_exception.wrapped_exception.should == @e
+      expect(@pry.last_exception.wrapped_exception).to eq(@e)
     end
 
     it "returns a frozen exception" do
@@ -107,50 +107,50 @@ describe Pry do
 
       it 'should be able to operate inside the BasicObject class' do
         pry_eval(BasicObject, ":foo", "Pad.obj = _")
-        Pad.obj.should == :foo
+        expect(Pad.obj).to eq(:foo)
       end
 
       it 'should set an ivar on an object' do
         o = Object.new
         pry_eval(o, "@x = 10")
-        o.instance_variable_get(:@x).should == 10
+        expect(o.instance_variable_get(:@x)).to eq(10)
       end
 
       it 'should display error if Pry instance runs out of input' do
         redirect_pry_io(StringIO.new, @str_output) do
           Pry.start
         end
-        @str_output.string.should =~ /Error: Pry ran out of things to read/
+        expect(@str_output.string).to match(/Error: Pry ran out of things to read/)
       end
 
       it 'should make self evaluate to the receiver of the rep session' do
         o = :john
-        pry_eval(o, "self").should == o
+        expect(pry_eval(o, "self")).to eq(o)
       end
 
       it 'should define a nested class under Hello and not on top-level or Pry' do
         mock_pry(Pry.binding_for(Hello), "class Nested", "end")
-        Hello.const_defined?(:Nested).should == true
+        expect(Hello.const_defined?(:Nested)).to eq(true)
       end
 
       it 'should suppress output if input ends in a ";" and is an Exception object (single line)' do
-        mock_pry("Exception.new;").should == ""
+        expect(mock_pry("Exception.new;")).to eq("")
       end
 
       it 'should suppress output if input ends in a ";" (single line)' do
-        mock_pry("x = 5;").should == ""
+        expect(mock_pry("x = 5;")).to eq("")
       end
 
       it 'should be able to evaluate exceptions normally' do
         was_called = false
         mock_pry("RuntimeError.new", :exception_handler => proc{ was_called = true })
-        was_called.should == false
+        expect(was_called).to eq(false)
       end
 
       it 'should notice when exceptions are raised' do
         was_called = false
         mock_pry("raise RuntimeError", :exception_handler => proc{ was_called = true })
-        was_called.should == true
+        expect(was_called).to eq(true)
       end
 
       it 'should not try to catch intended exceptions' do
@@ -161,47 +161,47 @@ describe Pry do
 
       describe "multi-line input" do
         it "works" do
-          mock_pry('x = ', '1 + 4').should =~ /5/
+          expect(mock_pry('x = ', '1 + 4')).to match(/5/)
         end
 
         it 'should suppress output if input ends in a ";" (multi-line)' do
-          mock_pry('def self.blah', ':test', 'end;').should == ''
+          expect(mock_pry('def self.blah', ':test', 'end;')).to eq('')
         end
 
         describe "newline stripping from an empty string" do
           it "with double quotes" do
-            mock_pry('"', '"').should =~ %r|"\\n"|
-            mock_pry('"', "\n", "\n", "\n", '"').should =~ %r|"\\n\\n\\n\\n"|
+            expect(mock_pry('"', '"')).to match(%r|"\\n"|)
+            expect(mock_pry('"', "\n", "\n", "\n", '"')).to match(%r|"\\n\\n\\n\\n"|)
           end
 
           it "with single quotes" do
-            mock_pry("'", "'").should =~ %r|"\\n"|
-            mock_pry("'", "\n", "\n", "\n", "'").should =~ %r|"\\n\\n\\n\\n"|
+            expect(mock_pry("'", "'")).to match(%r|"\\n"|)
+            expect(mock_pry("'", "\n", "\n", "\n", "'")).to match(%r|"\\n\\n\\n\\n"|)
           end
 
           it "with fancy delimiters" do
-            mock_pry('%(', ')').should =~ %r|"\\n"|
-            mock_pry('%|', "\n", "\n", '|').should =~ %r|"\\n\\n\\n"|
-            mock_pry('%q[', "\n", "\n", ']').should =~ %r|"\\n\\n\\n"|
+            expect(mock_pry('%(', ')')).to match(%r|"\\n"|)
+            expect(mock_pry('%|', "\n", "\n", '|')).to match(%r|"\\n\\n\\n"|)
+            expect(mock_pry('%q[', "\n", "\n", ']')).to match(%r|"\\n\\n\\n"|)
           end
         end
 
         describe "newline stripping from an empty regexp" do
           it "with regular regexp delimiters" do
-            mock_pry('/', '/').should =~ %r{/\n/}
+            expect(mock_pry('/', '/')).to match(%r{/\n/})
           end
 
           it "with fancy delimiters" do
-            mock_pry('%r{', "\n", "\n", '}').should =~ %r{/\n\n\n/}
-            mock_pry('%r<', "\n", '>').should =~ %r{/\n\n/}
+            expect(mock_pry('%r{', "\n", "\n", '}')).to match(%r{/\n\n\n/})
+            expect(mock_pry('%r<', "\n", '>')).to match(%r{/\n\n/})
           end
         end
 
         describe "newline from an empty heredoc" do
           it "works" do
-            mock_pry('<<HERE', 'HERE').should =~ %r|""|
-            mock_pry("<<'HERE'", "\n", 'HERE').should =~ %r|"\\n"|
-            mock_pry("<<-'HERE'", "\n", "\n", 'HERE').should =~ %r|"\\n\\n"|
+            expect(mock_pry('<<HERE', 'HERE')).to match(%r|""|)
+            expect(mock_pry("<<'HERE'", "\n", 'HERE')).to match(%r|"\\n"|)
+            expect(mock_pry("<<-'HERE'", "\n", "\n", 'HERE')).to match(%r|"\\n\\n"|)
           end
         end
       end
@@ -217,7 +217,7 @@ describe Pry do
 
           pry_tester = Pry.start(o, :input => input, :output => StringIO.new)
 
-          o.instance_variable_get(:@x).should == 10
+          expect(o.instance_variable_get(:@x)).to eq(10)
         end
       end
 
@@ -226,7 +226,7 @@ describe Pry do
           clean = "puts <<-FOO\nhi\nFOO\n"
           a = clean.dup
           Pry::Code.complete_expression?(a)
-          a.should == clean
+          expect(a).to eq(clean)
         end
       end
 
@@ -234,9 +234,9 @@ describe Pry do
         it 'sets _ to the last result' do
           t = pry_tester
           t.eval ":foo"
-          t.eval("_").should == :foo
+          expect(t.eval("_")).to eq(:foo)
           t.eval "42"
-          t.eval("_").should == 42
+          expect(t.eval("_")).to eq(42)
         end
 
         it 'sets out to an array with the result' do
@@ -245,8 +245,8 @@ describe Pry do
           t.eval "42"
           res = t.eval "_out_"
 
-          res.should be_a_kind_of Pry::HistoryArray
-          res[1..2].should == [:foo, 42]
+          expect(res).to be_a_kind_of Pry::HistoryArray
+          expect(res[1..2]).to eq([:foo, 42])
         end
 
         it 'sets _in_ to an array with the entered lines' do
@@ -255,29 +255,29 @@ describe Pry do
           t.eval "42"
           res = t.eval "_in_"
 
-          res.should be_a_kind_of Pry::HistoryArray
-          res[1..2].should == [":foo\n", "42\n"]
+          expect(res).to be_a_kind_of Pry::HistoryArray
+          expect(res[1..2]).to eq([":foo\n", "42\n"])
         end
 
         it 'uses 100 as the size of _in_ and _out_' do
-          pry_tester.eval("[_in_.max_size, _out_.max_size]").should == [100, 100]
+          expect(pry_tester.eval("[_in_.max_size, _out_.max_size]")).to eq([100, 100])
         end
 
         it 'can change the size of the history arrays' do
-          pry_tester(:memory_size => 1000).eval("[_out_, _in_].map(&:max_size)").should == [1000, 1000]
+          expect(pry_tester(:memory_size => 1000).eval("[_out_, _in_].map(&:max_size)")).to eq([1000, 1000])
         end
 
         it 'store exceptions' do
           mock_pry("foo!", "Pad.in = _in_[-1]; Pad.out = _out_[-1]")
 
-          Pad.in.should == "foo!\n"
+          expect(Pad.in).to eq("foo!\n")
           expect(Pad.out).to be_a_kind_of NoMethodError
         end
       end
 
       describe "last_result" do
         it "should be set to the most recent value" do
-          pry_eval("2", "_ + 82").should == 84
+          expect(pry_eval("2", "_ + 82")).to eq(84)
         end
 
         # This test needs mock_pry because the command retvals work by
@@ -288,15 +288,15 @@ describe Pry do
             a.to_i + 1
           end
 
-          mock_pry('++ 86', '++ #{_}').should =~ /88/
+          expect(mock_pry('++ 86', '++ #{_}')).to match(/88/)
         end
 
         it "should be preserved over an empty line" do
-          pry_eval("2 + 2", " ", "\t",  " ", "_ + 92").should == 96
+          expect(pry_eval("2 + 2", " ", "\t",  " ", "_ + 92")).to eq(96)
         end
 
         it "should be preserved when evalling a  command without :keep_retval" do
-          pry_eval("2 + 2", "ls -l", "_ + 96").should == 100
+          expect(pry_eval("2 + 2", "ls -l", "_ + 96")).to eq(100)
         end
       end
 
@@ -314,7 +314,7 @@ describe Pry do
           o = Object.new
 
           pry_tester = o.pry
-          @str_output.string.should =~ /nest:3/
+          expect(@str_output.string).to match(/nest:3/)
         end
       end
 
@@ -322,27 +322,27 @@ describe Pry do
         it 'should define a method on the singleton class of an object when performing "def meth;end" inside the object' do
           [Object.new, {}, []].each do |val|
             pry_eval(val, 'def hello; end')
-            val.methods(false).map(&:to_sym).include?(:hello).should == true
+            expect(val.methods(false).map(&:to_sym).include?(:hello)).to eq(true)
           end
         end
 
         it 'should define an instance method on the module when performing "def meth;end" inside the module' do
           hello = Module.new
           pry_eval(hello, "def hello; end")
-          hello.instance_methods(false).map(&:to_sym).include?(:hello).should == true
+          expect(hello.instance_methods(false).map(&:to_sym).include?(:hello)).to eq(true)
         end
 
         it 'should define an instance method on the class when performing "def meth;end" inside the class' do
           hello = Class.new
           pry_eval(hello, "def hello; end")
-          hello.instance_methods(false).map(&:to_sym).include?(:hello).should == true
+          expect(hello.instance_methods(false).map(&:to_sym).include?(:hello)).to eq(true)
         end
 
         it 'should define a method on the class of an object when performing "def meth;end" inside an immediate value or Numeric' do
           [:test, 0, true, false, nil,
               (0.0 unless Pry::Helpers::BaseHelpers.jruby?)].each do |val|
             pry_eval(val, "def hello; end");
-            val.class.instance_methods(false).map(&:to_sym).include?(:hello).should == true
+            expect(val.class.instance_methods(false).map(&:to_sym).include?(:hello)).to eq(true)
           end
         end
       end
@@ -362,7 +362,7 @@ describe Pry do
 
           20.pry
 
-          str_output.string.should =~ /20/
+          expect(str_output.string).to match(/20/)
         end
 
         it "should start a pry session on the receiver (second form)" do
@@ -373,7 +373,7 @@ describe Pry do
 
           pry 20
 
-          str_output.string.should =~ /20/
+          expect(str_output.string).to match(/20/)
         end
 
         it "should raise if more than two arguments are passed to Object#pry" do
@@ -384,9 +384,9 @@ describe Pry do
       describe "Pry.binding_for" do
         it 'should return TOPLEVEL_BINDING if parameter self is main' do
           _main_ = lambda { TOPLEVEL_BINDING.eval('self') }
-          Pry.binding_for(_main_.call).is_a?(Binding).should == true
-          Pry.binding_for(_main_.call).should == TOPLEVEL_BINDING
-          Pry.binding_for(_main_.call).should == Pry.binding_for(_main_.call)
+          expect(Pry.binding_for(_main_.call).is_a?(Binding)).to eq(true)
+          expect(Pry.binding_for(_main_.call)).to eq(TOPLEVEL_BINDING)
+          expect(Pry.binding_for(_main_.call)).to eq(Pry.binding_for(_main_.call))
         end
       end
     end
@@ -399,7 +399,7 @@ describe Pry do
 
     it 'correctly handles the :quiet option (#1261)' do
       instance = Pry.new(:quiet => true)
-      instance.quiet?.should == true
+      expect(instance.quiet?).to eq(true)
     end
   end
 
@@ -408,8 +408,8 @@ describe Pry do
       location  = "#{__FILE__}:#{__LINE__ + 1}"[1..-1] # omit leading .
       backtrace = Pry.new.backtrace
 
-      backtrace.should_not equal nil
-      backtrace.any? { |l| l.include?(location) }.should equal true
+      expect(backtrace).not_to equal nil
+      expect(backtrace.any? { |l| l.include?(location) }).to equal true
     end
   end
 end

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -63,7 +63,7 @@ describe Pry do
 
     it "should work on frozen objects" do
       a = "hello".freeze
-      expect(Pry.binding_for(a).eval("self")).to.equal? a
+      expect(Pry.binding_for(a).eval("self")).to eq(a)
     end
   end
 

--- a/spec/pryrc_spec.rb
+++ b/spec/pryrc_spec.rb
@@ -19,10 +19,10 @@ describe Pry do
 
     it "should never run the rc file twice" do
       Pry.start(self, :input => StringIO.new("exit-all\n"), :output => StringIO.new)
-      TEST_RC.should == [0]
+      expect(TEST_RC).to eq([0])
 
       Pry.start(self, :input => StringIO.new("exit-all\n"), :output => StringIO.new)
-      TEST_RC.should == [0]
+      expect(TEST_RC).to eq([0])
     end
 
     # Resolving symlinks doesn't work on jruby 1.9 [jruby issue #538]
@@ -33,7 +33,7 @@ describe Pry do
 
         Pry.start(self, :input => StringIO.new("exit-all\n"), :output => StringIO.new)
 
-        TEST_RC.should == [0]
+        expect(TEST_RC).to eq([0])
       end
     end
 
@@ -50,7 +50,7 @@ describe Pry do
       Pry.config.should_load_rc = false
       Pry.config.should_load_local_rc = false
       Pry.start(self, :input => StringIO.new("exit-all\n"), :output => StringIO.new)
-      Object.const_defined?(:TEST_RC).should == false
+      expect(Object.const_defined?(:TEST_RC)).to eq(false)
     end
 
     describe "that raise exceptions" do
@@ -84,13 +84,14 @@ describe Pry do
 
       it "should continue to run pry" do
         @doing_it[]
-        Object.const_defined?(:TEST_BEFORE_RAISE).should == true
-        Object.const_defined?(:TEST_AFTER_RAISE).should == true
+        expect(Object.const_defined?(:TEST_BEFORE_RAISE)).to eq(true)
+        expect(Object.const_defined?(:TEST_AFTER_RAISE)).to eq(true)
       end
 
       it "should output an error" do
-        @doing_it.call.split("\n").first.should =~
+        expect(@doing_it.call.split("\n").first).to match(
           %r{Error loading .*spec/fixtures/testrcbad: messin with ya}
+        )
       end
     end
   end

--- a/spec/regression/readline_spec.rb
+++ b/spec/regression/readline_spec.rb
@@ -15,7 +15,7 @@ describe "Readline" do
       require "pry"
       p defined?(Readline)
     RUBY
-    `#@ruby -I #@pry_dir -e '#{code}'`.should == "nil\n"
+    expect(`#@ruby -I #@pry_dir -e '#{code}'`).to eq("nil\n")
   end
 
   it "is loaded on invoking 'pry'" do
@@ -24,7 +24,7 @@ describe "Readline" do
       Pry.start self, input: StringIO.new("exit-all"), output: StringIO.new
       puts defined?(Readline)
     RUBY
-    `#@ruby -I #@pry_dir -e '#{code}'`.end_with?("constant\n").should == true
+    expect(`#@ruby -I #@pry_dir -e '#{code}'`.end_with?("constant\n")).to eq(true)
   end
 
   it "is not loaded on invoking 'pry' if Pry.input is set" do
@@ -34,6 +34,6 @@ describe "Readline" do
       Pry.start self, output: StringIO.new
       p defined?(Readline)
     RUBY
-    `#@ruby -I #@pry_dir -e '#{code}'`.end_with?("nil\n").should == true
+    expect(`#@ruby -I #@pry_dir -e '#{code}'`.end_with?("nil\n")).to eq(true)
   end
 end

--- a/spec/run_command_spec.rb
+++ b/spec/run_command_spec.rb
@@ -12,12 +12,12 @@ describe "Pry.run_command" do
   it 'performs a simple ls' do
     @context.eval("hokey_pokey = 10")
     Pry.run_command "ls", :context => @context, :output => out = StringIO.new
-    out.string.should =~ /hokey_pokey/
+    expect(out.string).to match(/hokey_pokey/)
   end
 
   # This is a regression test as 0.9.11 broke this behaviour
   it 'can perform a show-source' do
     Pry.run_command "show-source drum", :context => @context, :output => out = StringIO.new
-    out.string.should =~ /roken is dodelijk/
+    expect(out.string).to match(/roken is dodelijk/)
   end
 end

--- a/spec/sticky_locals_spec.rb
+++ b/spec/sticky_locals_spec.rb
@@ -13,7 +13,7 @@ describe "Sticky locals (_file_ and friends)" do
     pry_tester.tap do |t|
       pry = t.eval '_pry_'
       t.eval 'cd 0'
-      t.eval('_pry_').should == pry
+      expect(t.eval('_pry_')).to eq(pry)
     end
   end
 
@@ -47,11 +47,11 @@ describe "Sticky locals (_file_ and friends)" do
       set_file_and_dir_locals("/blah/ostrich.rb")
     end
 
-    pry_eval('file-and-dir-test', 'cd 0', '_file_').
-      should =~ /\/blah\/ostrich\.rb/
+    expect(pry_eval('file-and-dir-test', 'cd 0', '_file_')).
+      to match(/\/blah\/ostrich\.rb/)
 
-    pry_eval('file-and-dir-test', 'cd 0', '_dir_').
-      should =~ /\/blah/
+    expect(pry_eval('file-and-dir-test', 'cd 0', '_dir_')).
+      to match(/\/blah/)
 
     Pry.config.commands.delete "file-and-dir-test"
   end
@@ -59,7 +59,7 @@ describe "Sticky locals (_file_ and friends)" do
   it 'locals should return last result (_)' do
     pry_tester.tap do |t|
       lam = t.eval 'lambda { |foo| }'
-      t.eval('_').should == lam
+      expect(t.eval('_')).to eq(lam)
     end
   end
 
@@ -67,7 +67,7 @@ describe "Sticky locals (_file_ and friends)" do
     pry_tester.tap do |t|
       lam = t.eval 'lambda { |foo| }'
       t.eval 'num = 1'
-      t.eval('__').should == lam
+      expect(t.eval('__')).to eq(lam)
     end
   end
 
@@ -80,7 +80,7 @@ describe "Sticky locals (_file_ and friends)" do
                                         "exit-all")) do
           Pry.start(o)
         end
-        o.instance_variable_get(:@value).should == :john
+        expect(o.instance_variable_get(:@value)).to eq(:john)
         Pry.config.extra_sticky_locals = {}
       end
 
@@ -93,7 +93,7 @@ describe "Sticky locals (_file_ and friends)" do
           Pry.start(o)
         end
 
-        o.instance_variable_get(:@value).should == :john
+        expect(o.instance_variable_get(:@value)).to eq(:john)
         Pry.config.extra_sticky_locals = {}
       end
 
@@ -107,7 +107,7 @@ describe "Sticky locals (_file_ and friends)" do
           Pry.start(o, :extra_sticky_locals => { :test_local => :john } )
         end
 
-        o.instance_variable_get(:@value).should == :john
+        expect(o.instance_variable_get(:@value)).to eq(:john)
       end
 
       it 'should define multiple sticky locals' do
@@ -119,8 +119,8 @@ describe "Sticky locals (_file_ and friends)" do
                       :test_local2 => :carl} )
         end
 
-        o.instance_variable_get(:@value1).should == :john
-        o.instance_variable_get(:@value2).should == :carl
+        expect(o.instance_variable_get(:@value1)).to eq(:john)
+        expect(o.instance_variable_get(:@value2)).to eq(:carl)
       end
 
 
@@ -131,7 +131,7 @@ describe "Sticky locals (_file_ and friends)" do
           Pry.start(o, :extra_sticky_locals => { :test_local => proc { :john }} )
         end
 
-        o.instance_variable_get(:@value).should == :john
+        expect(o.instance_variable_get(:@value)).to eq(:john)
       end
     end
 
@@ -145,7 +145,7 @@ describe "Sticky locals (_file_ and friends)" do
           Pry.start(o, :extra_sticky_locals => { :test_local => :carl })
         end
 
-        o.instance_variable_get(:@value).should == :carl
+        expect(o.instance_variable_get(:@value)).to eq(:carl)
         Pry.config.extra_sticky_locals = {}
       end
     end
@@ -153,14 +153,14 @@ describe "Sticky locals (_file_ and friends)" do
     it 'should create a new sticky local' do
       t = pry_tester
       t.eval "_pry_.add_sticky_local(:test_local){ :test_value }"
-      t.eval("test_local").should == :test_value
+      expect(t.eval("test_local")).to eq(:test_value)
     end
 
     it 'should still exist after cd-ing into new binding' do
       t = pry_tester
       t.eval "_pry_.add_sticky_local(:test_local){ :test_value }"
       t.eval "cd Object.new"
-      t.eval("test_local").should == :test_value
+      expect(t.eval("test_local")).to eq(:test_value)
     end
 
     it 'should provide different values for successive block invocations' do
@@ -169,7 +169,7 @@ describe "Sticky locals (_file_ and friends)" do
       pry.add_sticky_local(:test_local) { rand }
       value1 = pry.evaluate_ruby 'test_local'
       value2 = pry.evaluate_ruby 'test_local'
-      value1.should_not == value2
+      expect(value1).not_to eq(value2)
     end
   end
 

--- a/spec/syntax_checking_spec.rb
+++ b/spec/syntax_checking_spec.rb
@@ -19,7 +19,7 @@ describe Pry do
         Pry.start
       end
 
-      @str_output.string.should_not =~ /SyntaxError/
+      expect(@str_output.string).not_to match(/SyntaxError/)
     end
   end
 
@@ -37,7 +37,7 @@ describe Pry do
         Pry.start
       end
 
-      @str_output.string.should =~ /SyntaxError/
+      expect(@str_output.string).to match(/SyntaxError/)
     end
   end
 
@@ -46,36 +46,36 @@ describe Pry do
       Pry.start
     end
 
-    @str_output.string.should =~ /SyntaxError/
+    expect(@str_output.string).to match(/SyntaxError/)
   end
 
   it "should allow trailing , to continue the line" do
     pry = Pry.new
-    Pry::Code.complete_expression?("puts 1, 2,").should == false
+    expect(Pry::Code.complete_expression?("puts 1, 2,")).to eq(false)
   end
 
   it "should complete an expression that contains a line ending with a ," do
     pry = Pry.new
-    Pry::Code.complete_expression?("puts 1, 2,\n3").should == true
+    expect(Pry::Code.complete_expression?("puts 1, 2,\n3")).to eq(true)
   end
 
   it "should not suppress the error output if the line ends in ;" do
-    mock_pry("raise RuntimeError, 'foo';").should =~ /RuntimeError/
+    expect(mock_pry("raise RuntimeError, 'foo';")).to match(/RuntimeError/)
   end
 
   it "should not clobber _ex_ on a SyntaxError in the repl" do
-    mock_pry("raise RuntimeError, 'foo'", "puts foo)", "_ex_.is_a?(RuntimeError)").should =~ /^RuntimeError.*\nSyntaxError.*\n=> true/m
+    expect(mock_pry("raise RuntimeError, 'foo'", "puts foo)", "_ex_.is_a?(RuntimeError)")).to match(/^RuntimeError.*\nSyntaxError.*\n=> true/m)
   end
 
   it "should allow whitespace delimeted strings" do
-    mock_pry('"%s" %% foo ').should =~ /"foo"/
+    expect(mock_pry('"%s" %% foo ')).to match(/"foo"/)
   end
 
   it "should allow newline delimeted strings" do
-    mock_pry('"%s" %%','foo').should =~ /"foo"/
+    expect(mock_pry('"%s" %%','foo')).to match(/"foo"/)
   end
 
   it "should allow whitespace delimeted strings ending on the first char of a line" do
-    mock_pry('"%s" %% ', ' #done!').should =~ /"\\n"/
+    expect(mock_pry('"%s" %% ', ' #done!')).to match(/"\\n"/)
   end
 end

--- a/spec/wrapped_module_spec.rb
+++ b/spec/wrapped_module_spec.rb
@@ -39,29 +39,29 @@ describe Pry::WrappedModule do
 
     describe "number_of_candidates" do
       it 'should return the correct number of candidates' do
-        Pry::WrappedModule(Host::CandidateTest).number_of_candidates.should == 3
+        expect(Pry::WrappedModule(Host::CandidateTest).number_of_candidates).to eq(3)
       end
 
       it 'should return 0 candidates for a class with no nested modules or methods' do
-        Pry::WrappedModule(Host::PitifullyBlank).number_of_candidates.should == 0
+        expect(Pry::WrappedModule(Host::PitifullyBlank).number_of_candidates).to eq(0)
       end
 
       it 'should return 1 candidate for a class with a nested module with methods' do
-        Pry::WrappedModule(Host::ForeverAlone).number_of_candidates.should == 1
+        expect(Pry::WrappedModule(Host::ForeverAlone).number_of_candidates).to eq(1)
       end
     end
 
     describe "ordering of candidates" do
       it 'should return class with largest number of methods as primary candidate' do
-        Pry::WrappedModule(Host::CandidateTest).candidate(0).file.should =~ /helper1/
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(0).file).to match(/helper1/)
       end
 
       it 'should return class with second largest number of methods as second ranked candidate' do
-        Pry::WrappedModule(Host::CandidateTest).candidate(1).file.should =~ /helper2/
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(1).file).to match(/helper2/)
       end
 
       it 'should return class with third largest number of methods as third ranked candidate' do
-        Pry::WrappedModule(Host::CandidateTest).candidate(2).file.should =~ /#{__FILE__}/
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(2).file).to match(/#{__FILE__}/)
       end
 
       it 'should raise when trying to access non-existent candidate' do
@@ -72,64 +72,64 @@ describe Pry::WrappedModule do
     describe "source_location" do
       it 'should return primary candidates source_location by default' do
         wm = Pry::WrappedModule(Host::CandidateTest)
-        wm.source_location.should == wm.candidate(0).source_location
+        expect(wm.source_location).to eq(wm.candidate(0).source_location)
       end
 
       it 'should return the location of the outer module if an inner module has methods' do
         wm = Pry::WrappedModule(Host::ForeverAlone)
-        File.expand_path(wm.source_location.first).should == File.expand_path(__FILE__)
-        wm.source_location.last.should == Host::FOREVER_ALONE_LINE
+        expect(File.expand_path(wm.source_location.first)).to eq(File.expand_path(__FILE__))
+        expect(wm.source_location.last).to eq(Host::FOREVER_ALONE_LINE)
       end
 
       it 'should return nil if no source_location can be found' do
-        Pry::WrappedModule(Host::PitifullyBlank).source_location.should == nil
+        expect(Pry::WrappedModule(Host::PitifullyBlank).source_location).to eq(nil)
       end
     end
 
     describe "source" do
       it 'should return primary candidates source by default' do
         wm = Pry::WrappedModule(Host::CandidateTest)
-        wm.source.should == wm.candidate(0).source
+        expect(wm.source).to eq(wm.candidate(0).source)
       end
 
       it 'should return source for highest ranked candidate' do
-        Pry::WrappedModule(Host::CandidateTest).candidate(0).source.should =~ /test1/
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(0).source).to match(/test1/)
       end
 
       it 'should return source for second ranked candidate' do
-        Pry::WrappedModule(Host::CandidateTest).candidate(1).source.should =~ /test4/
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(1).source).to match(/test4/)
       end
 
       it 'should return source for third ranked candidate' do
-        Pry::WrappedModule(Host::CandidateTest).candidate(2).source.should =~ /test6/
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(2).source).to match(/test6/)
       end
 
       it 'should return source for deeply nested class' do
-        Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).source.should =~ /nested_method/
-        Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).source.lines.count.should == 4
+        expect(Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).source).to match(/nested_method/)
+        expect(Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).source.lines.count).to eq(4)
       end
     end
 
     describe "doc" do
       it 'should return primary candidates doc by default' do
         wm = Pry::WrappedModule(Host::CandidateTest)
-        wm.doc.should == wm.candidate(0).doc
+        expect(wm.doc).to eq(wm.candidate(0).doc)
       end
 
       it 'should return doc for highest ranked candidate' do
-        Pry::WrappedModule(Host::CandidateTest).candidate(0).doc.should =~ /rank 0/
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(0).doc).to match(/rank 0/)
       end
 
       it 'should return doc for second ranked candidate' do
-        Pry::WrappedModule(Host::CandidateTest).candidate(1).doc.should =~ /rank 1/
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(1).doc).to match(/rank 1/)
       end
 
       it 'should return doc for third ranked candidate' do
-        Pry::WrappedModule(Host::CandidateTest).candidate(2).doc.should =~ /rank 2/
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(2).doc).to match(/rank 2/)
       end
 
       it 'should return docs for deeply nested class' do
-        Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).doc.should =~ /nested docs/
+        expect(Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).doc).to match(/nested docs/)
       end
     end
   end
@@ -145,41 +145,41 @@ describe Pry::WrappedModule do
     end
 
     it "should return Foo# for normal classes" do
-      Pry::WrappedModule.new(Foo).method_prefix.should == "Foo#"
+      expect(Pry::WrappedModule.new(Foo).method_prefix).to eq("Foo#")
     end
 
     it "should return Bar# for modules" do
-      Pry::WrappedModule.new(Kernel).method_prefix.should == "Kernel#"
+      expect(Pry::WrappedModule.new(Kernel).method_prefix).to eq("Kernel#")
     end
 
     it "should return Foo. for singleton classes of classes" do
-      Pry::WrappedModule.new(class << Foo; self; end).method_prefix.should == "Foo."
+      expect(Pry::WrappedModule.new(class << Foo; self; end).method_prefix).to eq("Foo.")
     end
 
     example "of singleton classes of objects" do
-      Pry::WrappedModule.new(class << @foo; self; end).method_prefix.should == "self."
+      expect(Pry::WrappedModule.new(class << @foo; self; end).method_prefix).to eq("self.")
     end
 
     example "of anonymous classes should not be empty" do
-      Pry::WrappedModule.new(Class.new).method_prefix.should =~ /#<Class:.*>#/
+      expect(Pry::WrappedModule.new(Class.new).method_prefix).to match(/#<Class:.*>#/)
     end
 
     example "of singleton classes of anonymous classes should not be empty" do
-      Pry::WrappedModule.new(class << Class.new; self; end).method_prefix.should =~ /#<Class:.*>./
+      expect(Pry::WrappedModule.new(class << Class.new; self; end).method_prefix).to match(/#<Class:.*>./)
     end
   end
 
   describe ".singleton_class?" do
     it "should be true for singleton classes" do
-      Pry::WrappedModule.new(class << ""; self; end).singleton_class?.should == true
+      expect(Pry::WrappedModule.new(class << ""; self; end).singleton_class?).to eq(true)
     end
 
     it "should be false for normal classes" do
-      Pry::WrappedModule.new(Class.new).singleton_class?.should == false
+      expect(Pry::WrappedModule.new(Class.new).singleton_class?).to eq(false)
     end
 
     it "should be false for modules" do
-      Pry::WrappedModule.new(Module.new).singleton_class?.should == false
+      expect(Pry::WrappedModule.new(Module.new).singleton_class?).to eq(false)
     end
   end
 
@@ -189,8 +189,8 @@ describe Pry::WrappedModule do
     end
 
     it "should return the attached object" do
-      Pry::WrappedModule.new(class << "hi"; self; end).singleton_instance.should == "hi"
-      Pry::WrappedModule.new(class << Object; self; end).singleton_instance.should.equal?(Object)
+      expect(Pry::WrappedModule.new(class << "hi"; self; end).singleton_instance).to eq("hi")
+      expect(Pry::WrappedModule.new(class << Object; self; end).singleton_instance).to.equal?(Object)
     end
   end
 
@@ -205,25 +205,25 @@ describe Pry::WrappedModule do
       end
 
       it 'should return superclass for a wrapped class'  do
-        Pry::WrappedModule(@c).super.wrapped.should == @b
+        expect(Pry::WrappedModule(@c).super.wrapped).to eq(@b)
       end
 
       it 'should return nth superclass for a wrapped class'  do
         d = Class.new(@c)
-        Pry::WrappedModule(d).super(2).wrapped.should == @b
+        expect(Pry::WrappedModule(d).super(2).wrapped).to eq(@b)
       end
 
       it 'should ignore modules when retrieving nth superclass'  do
-        Pry::WrappedModule(@c).super(2).wrapped.should == @a
+        expect(Pry::WrappedModule(@c).super(2).wrapped).to eq(@a)
       end
 
       it 'should return nil when no nth superclass exists' do
-        Pry::WrappedModule(@c).super(10).should == nil
+        expect(Pry::WrappedModule(@c).super(10)).to eq(nil)
       end
 
       it 'should return self when .super(0) is used' do
         c = Pry::WrappedModule(@c)
-        c.super(0).should == c
+        expect(c.super(0)).to eq(c)
       end
     end
 
@@ -235,16 +235,16 @@ describe Pry::WrappedModule do
       end
 
       it 'should not ignore modules when retrieving supers' do
-        Pry::WrappedModule(@m3).super.wrapped.should == @m2
+        expect(Pry::WrappedModule(@m3).super.wrapped).to eq(@m2)
       end
 
       it 'should retrieve nth super' do
-        Pry::WrappedModule(@m3).super(2).wrapped.should == @m1
+        expect(Pry::WrappedModule(@m3).super(2).wrapped).to eq(@m1)
       end
 
       it 'should return self when .super(0) is used' do
         m = Pry::WrappedModule(@m1)
-        m.super(0).should == m
+        expect(m.super(0)).to eq(m)
       end
     end
   end
@@ -258,19 +258,19 @@ describe Pry::WrappedModule do
 
     it 'should lookup a constant' do
       m = Pry::WrappedModule.from_str("Namespace::Value", binding)
-      m.wrapped.should == Namespace::Value
+      expect(m.wrapped).to eq(Namespace::Value)
     end
 
     it 'should lookup a local' do
       local = Namespace::Value
       m = Pry::WrappedModule.from_str("local", binding)
-      m.wrapped.should == Namespace::Value
+      expect(m.wrapped).to eq(Namespace::Value)
     end
 
     it 'should lookup an ivar' do
       @ivar = Namespace::Value
       m = Pry::WrappedModule.from_str("@ivar", binding)
-      m.wrapped.should == Namespace::Value
+      expect(m.wrapped).to eq(Namespace::Value)
     end
   end
 end

--- a/spec/wrapped_module_spec.rb
+++ b/spec/wrapped_module_spec.rb
@@ -190,7 +190,7 @@ describe Pry::WrappedModule do
 
     it "should return the attached object" do
       expect(Pry::WrappedModule.new(class << "hi"; self; end).singleton_instance).to eq("hi")
-      expect(Pry::WrappedModule.new(class << Object; self; end).singleton_instance).to.equal?(Object)
+      expect(Pry::WrappedModule.new(class << Object; self; end).singleton_instance).to eq(Object)
     end
   end
 


### PR DESCRIPTION
I used transpec to do a bulk upgrade the specs which are (semi-) automatically updateable. I tried to put only similar changes into one commit that is easy to see them in a split diff. Except from b8382ec every commit should be "green".

I read the "taking it slow" part from #1294 perfectly timed after I finished this, so feel free to cherry-pick the non-transtec commits if that fits better into the upgrade plan ;)

This is way not enough to disable the should syntax (many files are untouched at all), but I think it is good have them converted to get a better overview of the 'real' work:

    Converting spec/command_spec.rb
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/command_spec.rb:235:          args.should == ['four']
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/command_spec.rb:236:          opts[:f].should == 4
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/command_spec.rb:260:          opts.fetch_command(:blahblah).should == nil
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/command_spec.rb:261:          opts.fetch_command(:yell).present?.should == true
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/command_spec.rb:277:          args.should == ['papa']
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/command_spec.rb:278:          opts.fetch_command(:yell).present?.should == true
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/command_spec.rb:279:          opts.fetch_command(:yell).person?.should == true
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/command_spec.rb:293:          args.should == ['yell', 'papa', 'sonny', 'daughter']
    Converting spec/commands/cd_spec.rb
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/cd_spec.rb:12:        binding_stack.map { |b| b.eval('self') }.should == other
    Converting spec/commands/edit_spec.rb
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/edit_spec.rb:563:            X.method(:x).owner.should == self
    Converting spec/commands/show_doc_spec.rb
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/show_doc_spec.rb:36:      pry_eval(binding, 'show-doc').should =~ /sample comment/
    Converting spec/commands/show_source_spec.rb
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/show_source_spec.rb:36:      pry_eval(binding, 'show-source').should =~ /def @o.sample/
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/show_source_spec.rb:43:      pry_eval(binding, 'show-source -l').should =~ /def @o.sample/
    Converting spec/commands/whereami_spec.rb
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:23:        pry_eval(binding, 'whereami').should =~ /Cor[#]blimey!/
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:36:          should == File.expand_path(__FILE__)
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:110:          pry_eval(binding, 'whereami 3').should =~ /class Cor/
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:124:          pry_eval(binding, 'whereami -m').should =~ /def blimey/
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:137:          pry_eval(binding, 'whereami -f').should =~ /show entire file when -f option used/
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:152:            out.should =~ /class Cor/
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:153:            out.should =~ /blimey/
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:166:            out.should =~ /class Cor/
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:167:            out.should =~ /blimey/
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:187:            out.should =~ /class Cor/
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:188:            out.should =~ /blimey/
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:199:        out.should =~ /^\s*def/
    Cannot convert #should_not into #expect since #expect is not available in the context.
    spec/commands/whereami_spec.rb:200:        out.should_not =~ /\=\>/
    Converting spec/pry_spec.rb
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/pry_spec.rb:12:        input('BasicObject.new').should =~ /^=> #<BasicObject:/
    Converting spec/spec_helpers/repl_tester.rb
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/spec_helpers/repl_tester.rb:75:    match.should === last_prompt
    Cannot convert #should into #expect since #expect is not available in the context.
    spec/spec_helpers/repl_tester.rb:81:    match.should === @pry.output.string.chomp
