### PR TITLE
Enable syntax highlighting for Rakefile and other similarly named files

### DIFF
--- a/lib/pry/code/code_file.rb
+++ b/lib/pry/code/code_file.rb
@@ -18,7 +18,11 @@ class Pry
       %w(.rhtml)     => :rhtml,
       %w(.yaml .yml) => :yaml,
       %w(.cpp .hpp .cc .h cxx) => :cpp,
-      %w(.rb .ru .irbrc .gemspec .pryrc) => :ruby,
+      %w(.rb .ru .irbrc .gemspec .pryrc .rake) => :ruby,
+    }
+
+    FILES = {
+      %w(Gemfile Rakefile Guardfile Capfile) => :ruby
     }
 
     # @return [Symbol] The type of code stored in this wrapper.
@@ -79,6 +83,8 @@ class Pry
     def type_from_filename(filename, default = :unknown)
       _, @code_type = EXTENSIONS.find do |k, _|
         k.any? { |ext| ext == File.extname(filename) }
+      end || FILES.find do |k, _|
+        k.any? { |file_name| file_name == File.basename(filename) }
       end
 
       code_type || default


### PR DESCRIPTION
Hi,

When I noticed I wasn't getting any highlighting in my Rakefile it was slightly confusing, I spent a lot of time trying to enable colors, eventually discovering that it was the Rakefile that was not supported.

So this is a small commit to enable syntax highlighting in Rakefiles and a few others.

There are no specs, as I couldn't find any existing ones around the ```CodeFile``` class. However, I can add a few if required.

Cheers,