### PR TITLE
gem install fails when config doesn't have --user-install set

### DIFF
--- a/lib/pry/rubygem.rb
+++ b/lib/pry/rubygem.rb
@@ -57,7 +57,8 @@ class Pry
       # @param [String] name
       # @return [void]
       def install(name)
-        gemrc_opts = Gem.configuration['gem'].split(' ')
+        gem_config = Gem.configuration['gem']
+        gemrc_opts = (gem_config.nil? ? "" : gem_config.split(' '))
         destination = if gemrc_opts.include?('--user-install')
                         Gem.user_dir
                       elsif File.writable?(Gem.dir)


### PR DESCRIPTION
as gem should install in global directory if user install option is  not defined , it fails on split as that is nil, so this should allow the gem installation without failing as default behaviour , unless user sets his config.
