### PR TITLE
Replace map.flatten(1) with flat_map

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -603,9 +603,9 @@ class Pry
     # @param [String] search  The line typed so far
     # @return [Array<String>]  the words to complete
     def complete(search)
-      slop.map do |opt|
+      slop.flat_map do |opt|
         [opt.long && "--#{opt.long} " || opt.short && "-#{opt.short}"]
-      end.flatten(1).compact + super
+      end.compact + super
     end
 
     # A method called just before `options(opt)` as part of `call`.

--- a/lib/pry/commands/ls/jruby_hacks.rb
+++ b/lib/pry/commands/ls/jruby_hacks.rb
@@ -19,7 +19,7 @@ module Pry::Command::Ls::JRubyHacks
       m.name.sub(/\A(is|get|set)(?=[A-Z_])/, '').gsub(/[_?=]/, '').downcase
     end
 
-    grouped.map do |key, values|
+    grouped.flat_map do |key, values|
       values = values.sort_by do |m|
         rubbishness(m.name)
       end
@@ -28,7 +28,7 @@ module Pry::Command::Ls::JRubyHacks
       values.select do |x|
         (!found.any? { |y| x == y }) && found << x
       end
-    end.flatten(1)
+    end
   end
 
   # When removing jruby aliases, we want to keep the alias that is

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -140,11 +140,11 @@ class Pry
       # @param [Boolean] include_super Whether to include methods from ancestors.
       # @return [Array[Pry::Method]]
       def all_from_class(klass, include_super=true)
-        %w(public protected private).map do |visibility|
+        %w(public protected private).flat_map do |visibility|
           safe_send(klass, :"#{visibility}_instance_methods", include_super).map do |method_name|
             new(safe_send(klass, :instance_method, method_name), :visibility => visibility.to_sym)
           end
-        end.flatten(1)
+        end
       end
 
       #
@@ -212,9 +212,9 @@ class Pry
       # the lowest copy will be returned.
       def singleton_class_resolution_order(klass)
         ancestors = Pry::Method.safe_send(klass, :ancestors)
-        resolution_order = ancestors.grep(Class).map do |anc|
+        resolution_order = ancestors.grep(Class).flat_map do |anc|
           [singleton_class_of(anc), *singleton_class_of(anc).included_modules]
-        end.flatten(1)
+        end
 
         resolution_order.reverse.uniq.reverse - Class.included_modules
       end

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -330,13 +330,13 @@ class Pry
 
       return methods unless methods.empty?
 
-      safe_send(mod, :constants).map do |const_name|
+      safe_send(mod, :constants).flat_map do |const_name|
         if const = nested_module?(mod, const_name)
           all_relevant_methods_for(const)
         else
           []
         end
-      end.flatten
+      end
     end
 
     # Return all methods (instance methods and class methods) for a


### PR DESCRIPTION
Using `flat_map` is equivalent `map.flatten(1)` but simpler and more than 4X faster.
###### Benchmark

``` ruby
require 'benchmark/ips'

ARRAY = 100.times.map { (0..9).to_a }

def slow
  ARRAY.map { |x| x }.flatten(1)
end

def fast
  ARRAY.flat_map { |x| x }
end

Benchmark.ips do |x|
  x.report('slow') { slow }
  x.report('fast') { fast }
  x.compare!
end
```
###### Ruby 2.1.2

```
slow 12268.9 (±7.3%) i/s -  61182 in 5.013846s
fast 53921.4 (±7.1%) i/s - 269412 in 5.023821s

Comparison:
fast: 53921.4 i/s
slow: 12268.9 i/s - 4.39x slower
```

This is one instance of `map.flatten` (without the `1` argument) that I replaced with `flat_map` (in `lib/pry/wrapped_module.rb`), since it appears to always return one-dimensional arrays.
