### PR TITLE
Remove '/' -> '\' replacement

### DIFF
--- a/lib/pry/editor.rb
+++ b/lib/pry/editor.rb
@@ -44,7 +44,8 @@ class Pry
         _pry_.config.editor.call(*args)
       else
         sanitized_file = if windows?
-                            file.gsub(/\//, '\\')
+                            # Windows tolerates the forward slash separator.
+                            # file.gsub(/\//, '\\')
                           else
                             Shellwords.escape(file)
                           end


### PR DESCRIPTION
The edit command breaks on windows if '/' is replaced with '\'. Windows tolerates '/' just fine.