### PR TITLE
Cleanup warnings

### DIFF
--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -91,6 +91,8 @@ class Pry
       @lines = lines.each_with_index.map { |line, lineno|
         LOC.new(line, lineno + start_line.to_i) }
       @code_type = code_type
+
+      @with_marker = @with_indentation = nil
     end
 
     # Append the given line. +lineno+ is one more than the last existing

--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -4,6 +4,12 @@ class Pry
 
     command_options :shellwords => false, :interpolate => false
 
+    def initialize(*)
+      super
+
+      @used_super = nil
+    end
+
     def options(opt)
       opt.on :s, :super, "Select the 'super' method. Can be repeated to traverse the ancestors", :as => :count
       opt.on :l, "line-numbers", "Show line numbers"

--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -1,6 +1,12 @@
 class Pry
   class Command::Whereami < Pry::ClassCommand
 
+    def initialize(*)
+      super
+
+      @method_code = nil
+    end
+
     class << self
       attr_accessor :method_size_cutoff
     end

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -83,7 +83,7 @@ class Pry
     def read_from_file
       path = history_file_path
 
-      if File.exists?(path)
+      if File.exist?(path)
         File.foreach(path) { |line| yield(line) }
       end
     rescue => error

--- a/lib/pry/module_candidate.rb
+++ b/lib/pry/module_candidate.rb
@@ -49,6 +49,7 @@ class Pry
           raise CommandError, "No such module candidate. Allowed candidates range is from 0 to #{number_of_candidates - 1}"
         end
 
+        @source = @source_location = nil
         @rank = rank
         @file, @line = source_location
       end

--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -133,6 +133,8 @@ class Pry::Pager
       pager
     end
 
+    @system_pager = nil
+
     def self.available?
       if @system_pager.nil?
         @system_pager = begin
@@ -151,6 +153,7 @@ class Pry::Pager
       super
       @tracker = PageTracker.new(height, width)
       @buffer  = ""
+      @pager   = nil
     end
 
     def write(str)

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -63,6 +63,7 @@ class Pry
       @source = nil
       @source_location = nil
       @doc = nil
+      @all_source_locations_by_popularity = nil
     end
 
     # Returns an array of the names of the constants accessible in the wrapped


### PR DESCRIPTION
When Ruby's `-w` is given (e.g. debugging Rails), pry will output these warnings and they are too annoying:
- `lib/pry/code.rb:271: warning: instance variable @with_marker not initialized`
- `lib/pry/commands/show_info.rb:93: warning: instance variable @used_super not initialized`
- `lib/pry/commands/whereami.rb:140: warning: instance variable @method_code not initialized`
- `lib/pry/history.rb:86: warning: File.exists? is a deprecated name, use File.exist? instead`
- `lib/pry/module_candidate.rb:61: warning: instance variable @source not initialized`
- `lib/pry/module_candidate.rb:79: warning: instance variable @source_location not initialized`
- `lib/pry/pager.rb:137: warning: instance variable @system_pager not initialized`
- `lib/pry/pager.rb:186: warning: instance variable @pager not initialized`
- `lib/pry/wrapped_module.rb:311: warning: instance variable @all_source_locations_by_popularity not initialized`
