### PR TITLE
spec: rm stray reference to OpenStruct

### DIFF
--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -368,7 +368,7 @@ describe Pry::Hooks do
 
     describe "after_session hook" do
       it 'should always run, even if uncaught exception bubbles out of repl' do
-        o = OpenStruct.new
+        o = Pry::Config.new
         o.great_escape = Class.new(StandardError)
 
         old_ew = Pry.config.exception_whitelist


### PR DESCRIPTION
OpenStruct was removed in 91d412c044f174a2c50d1583a3f34c1f0f795e7d, but a stray reference remained in the test suite. Remove it here.
