### PR TITLE
Fix "not_a_real_file?" regex

### DIFF
--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -32,7 +32,7 @@ class Pry
       end
 
       def not_a_real_file?(file)
-        file =~ /(\(.*\))|<.*>/ || file =~ /__unknown__/ || file == "" || file == "-e"
+        file =~ /^(\(.*\))$|^<.*>$/ || file =~ /__unknown__/ || file == "" || file == "-e"
       end
 
       def command_dependencies_met?(options)


### PR DESCRIPTION
At the moment `not_a_real_file?` is returning true if the file path contains parentheses that surround text.
I believe the intention of the regex that I modified in this pr is to look for file paths that are entirely surrounded in parentheses or by carats like `(no_path)` or `<not_a_path>`. I fixed it to do that rather than returning true for something like `~/Dropbox (Personal)/Programming_Stuff/MyProject` where the parentheses are part of a valid path.

