### PR TITLE
Fix history clear bug(No re-init @original_lines)

### DIFF
--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -57,6 +57,7 @@ class Pry
     # history file.
     def clear
       @clearer.call
+      @original_lines = 0
       @history = []
     end
 

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -53,6 +53,7 @@ describe Pry do
       Pry.history.to_a.size.should > 0
       Pry.history.clear
       Pry.history.to_a.size.should == 0
+      Pry.history.original_lines.should == 0
     end
 
     it "doesn't affect the contents of the history file" do


### PR DESCRIPTION
## :bug: Bug Reproduction
I confirm this bug in ...  

* Ubuntu 12.04 LTS  + ruby 2.0.0p0 + pry 0.10.1 env
* Windows7 + Cygwin + ruby 2.0.0p451 + pry 0.10.1 env

~~~bash
$ pry
[1] pry(main)> "hoge"
=> "hoge"
[2] pry(main)> hist --clear
History cleared.
[3] pry(main)> hist
ArgumentError: negative array size
from /home/user/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/pry-0.10.1/lib/pry/commands/hist.rb:171:in `last'
~~~

## :question:  Cause

Not re-initialize @original_lines at `hist --clear`

~~~bash
$ pry
[1] pry(main)> "hoge"
=> "hoge"
[2] pry(main)> hist
1: "hoge"
[3] pry(main)> hist --clear
History cleared.
[4] pry(main)> hist
ArgumentError: negative array size
from /home/user/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/pry-0.10.1/lib/pry/commands/hist.rb:171:in `last'
[4] pry(main)> Pry.history.original_lines
=> 693
[5] pry(main)> Pry.history.session_line_count
=> -690
~~~

* Pry.history.session_line_count

~~~ruby
    def session_line_count
      # In this case, 3 - 693 = -690
      @history.count - @original_lines
    end
~~~

## :bug::boom::hammer: After Fix

~~~bash
$ pry
[1] pry(main)> "hoge"
=> "hoge"
[2] pry(main)> hist
1: "hoge"
[3] pry(main)> hist --clear
History cleared.
[4] pry(main)> hist

[5] pry(main)> Pry.history.original_lines
=> 0
[6] pry(main)> Pry.history.session_line_count
=> 3
~~~