### PR TITLE
support custom implementation of BasicObject#inspect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 
+* Add support for BasicObject subclasses who implement their own #inspect (#1341)
 * Fix 'include RSpec::Matchers' at the top-level (#1277)
 * Add 'gem-readme' command, prints the README file bundled with a rubygem
 * Add 'gem-search' command, searches for a gem with the rubygems.org HTTP API

--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -34,14 +34,17 @@ class Pry
       super
     rescue => e
       raise if e.is_a? Pry::Pager::StopPaging
-
-      # Read the class name off of the singleton class to provide a default
-      # inspect.
-      singleton = class << obj; self; end
-      ancestors = Pry::Method.safe_send(singleton, :ancestors)
-      klass  = ancestors.reject { |k| k == singleton }.first
-      obj_id = obj.__id__.to_s(16) rescue 0
-      str    = "#<#{klass}:0x#{obj_id}>"
+      begin
+        str = obj.inspect
+      rescue Exception 
+        # Read the class name off of the singleton class to provide a default
+        # inspect.
+        singleton = class << obj; self; end
+        ancestors = Pry::Method.safe_send(singleton, :ancestors)
+        klass  = ancestors.reject { |k| k == singleton }.first
+        obj_id = obj.__id__.to_s(16) rescue 0
+        str    = "#<#{klass}:0x#{obj_id}>"
+      end
 
       text highlight_object_literal(str)
     end

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -1,9 +1,8 @@
 class Pry
   module Helpers
-
     # The methods defined on {Text} are available to custom commands via {Pry::Command#text}.
     module Text
-
+      extend self
       COLORS =
       {
         "black"   => 0,
@@ -17,91 +16,86 @@ class Pry
         "white"   => 7
       }
 
-      class << self
-
-        COLORS.each_pair do |color, value|
-          define_method color do |text|
-            "\033[0;#{30+value}m#{text}\033[0m"
-          end
-
-          define_method "bright_#{color}" do |text|
-            "\033[1;#{30+value}m#{text}\033[0m"
-          end
+      COLORS.each_pair do |color, value|
+        define_method color do |text|
+          "\033[0;#{30+value}m#{text}\033[0m"
         end
 
-        # Remove any color codes from _text_.
-        #
-        # @param  [String, #to_s] text
-        # @return [String] _text_ stripped of any color codes.
-        def strip_color(text)
-          text.to_s.gsub(/\e\[.*?(\d)+m/ , '')
-        end
-
-        # Returns _text_ as bold text for use on a terminal.
-        #
-        # @param [String, #to_s] text
-        # @return [String] _text_
-        def bold(text)
-          "\e[1m#{text}\e[0m"
-        end
-
-        # Returns `text` in the default foreground colour.
-        # Use this instead of "black" or "white" when you mean absence of colour.
-        #
-        # @param [String, #to_s] text
-        # @return [String]
-        def default(text)
-          text.to_s
-        end
-        alias_method :bright_default, :bold
-
-        # Executes the block with `Pry.config.color` set to false.
-        # @yield
-        # @return [void]
-        def no_color(&block)
-          boolean = Pry.config.color
-          Pry.config.color = false
-          yield
-        ensure
-          Pry.config.color = boolean
-        end
-
-        # Executes the block with `Pry.config.pager` set to false.
-        # @yield
-        # @return [void]
-        def no_pager(&block)
-          boolean = Pry.config.pager
-          Pry.config.pager = false
-          yield
-        ensure
-          Pry.config.pager = boolean
-        end
-
-        # Returns _text_ in a numbered list, beginning at _offset_.
-        #
-        # @param  [#each_line] text
-        # @param  [Fixnum] offset
-        # @return [String]
-        def with_line_numbers(text, offset, color=:blue)
-          lines = text.each_line.to_a
-          max_width = (offset + lines.count).to_s.length
-          lines.each_with_index.map do |line, index|
-            adjusted_index = (index + offset).to_s.rjust(max_width)
-            "#{self.send(color, adjusted_index)}: #{line}"
-          end.join
-        end
-
-        # Returns _text_ indented by _chars_ spaces.
-        #
-        # @param [String] text
-        # @param [Fixnum] chars
-        def indent(text, chars)
-          text.lines.map { |l| "#{' ' * chars}#{l}" }.join
+        define_method "bright_#{color}" do |text|
+          "\033[1;#{30+value}m#{text}\033[0m"
         end
       end
 
-    end
+      # Remove any color codes from _text_.
+      #
+      # @param  [String, #to_s] text
+      # @return [String] _text_ stripped of any color codes.
+      def strip_color(text)
+        text.to_s.gsub(/\e\[.*?(\d)+m/ , '')
+      end
 
+      # Returns _text_ as bold text for use on a terminal.
+      #
+      # @param [String, #to_s] text
+      # @return [String] _text_
+      def bold(text)
+        "\e[1m#{text}\e[0m"
+      end
+
+      # Returns `text` in the default foreground colour.
+      # Use this instead of "black" or "white" when you mean absence of colour.
+      #
+      # @param [String, #to_s] text
+      # @return [String]
+      def default(text)
+        text.to_s
+      end
+      alias_method :bright_default, :bold
+
+      # Executes the block with `Pry.config.color` set to false.
+      # @yield
+      # @return [void]
+      def no_color(&block)
+        boolean = Pry.config.color
+        Pry.config.color = false
+        yield
+      ensure
+        Pry.config.color = boolean
+      end
+
+      # Executes the block with `Pry.config.pager` set to false.
+      # @yield
+      # @return [void]
+      def no_pager(&block)
+        boolean = Pry.config.pager
+        Pry.config.pager = false
+        yield
+      ensure
+        Pry.config.pager = boolean
+      end
+
+      # Returns _text_ in a numbered list, beginning at _offset_.
+      #
+      # @param  [#each_line] text
+      # @param  [Fixnum] offset
+      # @return [String]
+      def with_line_numbers(text, offset, color=:blue)
+        lines = text.each_line.to_a
+        max_width = (offset + lines.count).to_s.length
+        lines.each_with_index.map do |line, index|
+          adjusted_index = (index + offset).to_s.rjust(max_width)
+          "#{self.send(color, adjusted_index)}: #{line}"
+        end.join
+      end
+
+      # Returns _text_ indented by _chars_ spaces.
+      #
+      # @param [String] text
+      # @param [Fixnum] chars
+      def indent(text, chars)
+        text.lines.map { |l| "#{' ' * chars}#{l}" }.join
+      end
+    end
   end
 end
 

--- a/spec/color_printer_spec.rb
+++ b/spec/color_printer_spec.rb
@@ -12,6 +12,37 @@ describe Pry::ColorPrinter do
       end
     end
 
+    describe 'Object subclass' do 
+      before do
+        class ObjectF < Object 
+          def inspect
+            'foo'
+          end
+        end
+
+        class ObjectG < Object
+          def inspect 
+            raise 
+          end
+        end
+      end
+
+      after do 
+        Object.send :remove_const, :ObjectF
+        Object.send :remove_const, :ObjectG
+      end 
+
+      it 'prints a string' do
+        Pry::ColorPrinter.pp(ObjectF.new, io)
+        expect(str).to eq('foo')
+      end 
+
+      it 'prints a string, even when an exception is raised' do 
+        Pry::ColorPrinter.pp(ObjectG.new, io)
+        expect(str).to match(/\A#<ObjectG:0x\w+>\z/)
+      end
+    end
+
     describe 'BasicObject' do
       it 'prints a string' do
         Pry::ColorPrinter.pp(BasicObject.new, io)

--- a/spec/color_printer_spec.rb
+++ b/spec/color_printer_spec.rb
@@ -20,15 +20,33 @@ describe Pry::ColorPrinter do
     end
 
     describe 'BasicObject subclass' do
-      class F < BasicObject
-        def inspect
-          'foo'
+      before do
+        class BasicF < BasicObject
+          def inspect
+            'foo'
+          end
+        end
+
+        class BasicG < BasicObject
+          def inspect
+            raise
+          end
         end
       end
 
+      after do
+        Object.__send__ :remove_const, :BasicF
+        Object.__send__ :remove_const, :BasicG
+      end
+
       it 'prints a string' do
-        Pry::ColorPrinter.pp(F.new, io)
+        Pry::ColorPrinter.pp(BasicF.new, io)
         expect(str).to eq("foo")
+      end
+
+      it 'prints a string, even when an exception is raised' do
+        Pry::ColorPrinter.pp(BasicG.new, io)
+        expect(str).to match(/\A#<BasicG:0x\w+>\z/)
       end
     end
   end

--- a/spec/color_printer_spec.rb
+++ b/spec/color_printer_spec.rb
@@ -1,0 +1,35 @@
+require 'helper'
+describe Pry::ColorPrinter do    
+  include Pry::Helpers::Text
+  let(:io) { StringIO.new }
+  let(:str) { strip_color(io.string.chomp) }
+  
+  describe '.pp' do
+    describe 'Object' do
+      it 'prints a string' do
+        Pry::ColorPrinter.pp(Object.new, io)
+        expect(str).to match(/\A#<Object:0x\w+>\z/)
+      end
+    end
+
+    describe 'BasicObject' do
+      it 'prints a string' do
+        Pry::ColorPrinter.pp(BasicObject.new, io)
+        expect(str).to match(/\A#<BasicObject:0x\w+>\z/)
+      end
+    end
+
+    describe 'BasicObject subclass' do
+      class F < BasicObject
+        def inspect
+          'foo'
+        end
+      end
+
+      it 'prints a string' do
+        Pry::ColorPrinter.pp(F.new, io)
+        expect(str).to eq("foo")
+      end
+    end
+  end
+end


### PR DESCRIPTION
If BasicObject or a subclass of BasicObject implements #inspect,
we will try to use its return value as output but if that fails,
we'll fallback on \__id\__.

fixes #1341