### PR TITLE
Fix err msg

### DIFF
--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -484,7 +484,7 @@ class Pry
       else
         fail_msg = "Cannot locate this method: #{name}."
         if mri?
-          fail_msg += ' Try `gem install pry-doc` to get access to Ruby Core documentation.'
+          fail_msg += " Try 'gem install pry-doc' to get access to Ruby Core documentation.""
         end
         raise CommandError, fail_msg
       end

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -484,7 +484,7 @@ class Pry
       else
         fail_msg = "Cannot locate this method: #{name}."
         if mri?
-          fail_msg += ' Try `gem-install pry-doc` to get access to Ruby Core documentation.'
+          fail_msg += ' Try `gem install pry-doc` to get access to Ruby Core documentation.'
         end
         raise CommandError, fail_msg
       end

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -484,7 +484,7 @@ class Pry
       else
         fail_msg = "Cannot locate this method: #{name}."
         if mri?
-          fail_msg += " Try 'gem install pry-doc' to get access to Ruby Core documentation.""
+          fail_msg += " Try 'gem install pry-doc' to get access to Ruby Core documentation."
         end
         raise CommandError, fail_msg
       end


### PR DESCRIPTION
I may be mislead but shouldn't gem install exclude hyphen for shell execution w backticks?

grepping the project, found a couple more references to 'gem-install' 

```
CHANGELOG.md
71:* The `gem-install` command can require gems like `net-ssh` thanks to better
84:* Fix `gem-install` on JRuby (#870)
245:* `gem-install` immediately requires gems

lib/pry/commands/gem_install.rb
3:    match 'gem-install'
9:      Usage: gem-install GEM_NAME
14:      gem-install pry-stack_explorer
```