### PR TITLE
Fix Warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ task :default => [:test]
 
 def run_specs paths
   format = ENV['VERBOSE'] ? '--format documentation ' : ''
-  sh "rspec #{format}#{paths.join ' '}"
+  sh "rspec -w #{format}#{paths.join ' '}"
 end
 
 desc "Run tests"

--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -92,7 +92,7 @@ class Pry
         LOC.new(line, lineno + start_line.to_i) }
       @code_type = code_type
 
-      @with_marker = @with_indentation = nil
+      @with_marker = @with_indentation = @with_line_numbers = nil
     end
 
     # Append the given line. +lineno+ is one more than the last existing

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -147,6 +147,7 @@ class Pry
     # @return [Boolean]
     def safe_to_evaluate?(str)
       return true if str.strip == "self"
+      return false if str =~ /%/
       kind = target.eval("defined?(#{str})")
       kind =~ /variable|constant/
     end

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -52,7 +52,7 @@ class Pry
       # Define or get the command's banner
       def banner(arg=nil)
         @banner = arg if arg
-        @banner || description
+        @banner ||= description
       end
 
       def block

--- a/lib/pry/commands/cat/exception_formatter.rb
+++ b/lib/pry/commands/cat/exception_formatter.rb
@@ -27,16 +27,17 @@ class Pry
       end
 
       def backtrace_level
-        return @backtrace_level if @backtrace_level
+        @backtrace_level ||=
+          begin
+            bl =  if opts[:ex].nil?
+                    ex.bt_index
+                  else
+                    ex.bt_index = absolute_index_number(opts[:ex], ex.backtrace.size)
+                  end
 
-        bl =  if opts[:ex].nil?
-                ex.bt_index
-              else
-                ex.bt_index = absolute_index_number(opts[:ex], ex.backtrace.size)
-              end
-
-        increment_backtrace_level
-        @backtrace_level = bl
+            increment_backtrace_level
+            bl
+          end
       end
 
       def increment_backtrace_level

--- a/lib/pry/commands/code_collector.rb
+++ b/lib/pry/commands/code_collector.rb
@@ -51,21 +51,23 @@ class Pry
     #
     # @return [String]
     def content
-      return @content if @content
-      raise CommandError, "Only one of --out, --in, --doc and CODE_OBJECT may be specified." if bad_option_combination?
+      @content ||=
+        begin
+          raise CommandError, "Only one of --out, --in, --doc and CODE_OBJECT may be specified." if bad_option_combination?
 
-      content = case
-                when opts.present?(:o)
-                  pry_output_content
-                when opts.present?(:i)
-                  pry_input_content
-                when opts.present?(:d)
-                  code_object_doc
-                else
-                  code_object_source_or_file
-                end
+          content = case
+                    when opts.present?(:o)
+                      pry_output_content
+                    when opts.present?(:i)
+                      pry_input_content
+                    when opts.present?(:d)
+                      code_object_doc
+                    else
+                      code_object_source_or_file
+                    end
 
-      @content ||= restrict_to_lines(content, line_range)
+          restrict_to_lines(content, line_range)
+        end
     end
 
     # The code object
@@ -141,7 +143,7 @@ class Pry
     end
 
     def file_content
-      if File.exists?(obj_name)
+      if File.exist?(obj_name)
         # Set the file accessor.
         self.file = obj_name
         File.read(obj_name)

--- a/lib/pry/commands/easter_eggs.rb
+++ b/lib/pry/commands/easter_eggs.rb
@@ -10,17 +10,17 @@ class Pry
     end
 
     command "get-naked", "" do
-      text = %{
+      txt = %{
   --
   We dont have to take our clothes off to have a good time.
   We could dance & party all night And drink some cherry wine.
   -- Jermaine Stewart }
-      output.puts text
-      text
+      output.puts txt
+      txt
     end
 
     command "east-coker", "" do
-      text = %{
+      txt = %{
   --
   Now the light falls
   Across the open field, leaving the deep lane
@@ -34,12 +34,12 @@ class Pry
   Wait for the early owl.
                 -- T.S Eliot
           }
-      output.puts text
-      text
+      output.puts txt
+      txt
     end
 
     command "cohen-poem", "" do
-      text = %{
+      txt = %{
   --
   When this American woman,
   whose thighs are bound in casual red cloth,
@@ -57,8 +57,8 @@ class Pry
   they are lost for hours.
                 -- Leonard Cohen
               }
-      output.puts text
-      text
+      output.puts txt
+      txt
     end
 
     command "pessoa-poem", "" do

--- a/lib/pry/commands/edit/file_and_line_locator.rb
+++ b/lib/pry/commands/edit/file_and_line_locator.rb
@@ -7,7 +7,7 @@ class Pry
         end
 
         def from_code_object(code_object, filename_argument)
-          if File.exists?(code_object.source_file.to_s)
+          if File.exist?(code_object.source_file.to_s)
             [code_object.source_file, code_object.source_line]
           else
             raise CommandError, "Cannot find a file for #{filename_argument}!"

--- a/lib/pry/commands/ls/formatter.rb
+++ b/lib/pry/commands/ls/formatter.rb
@@ -7,6 +7,7 @@ class Pry
       def initialize(_pry_)
         @_pry_ = _pry_
         @target = _pry_.current_context
+        @default_switch = nil
       end
 
       def write_out

--- a/lib/pry/commands/ls/self_methods.rb
+++ b/lib/pry/commands/ls/self_methods.rb
@@ -11,6 +11,7 @@ class Pry
         super(_pry_)
         @interrogatee = interrogatee
         @no_user_opts = no_user_opts
+        @ppp_switch = nil
       end
 
       def output_self

--- a/lib/pry/commands/ls/self_methods.rb
+++ b/lib/pry/commands/ls/self_methods.rb
@@ -11,7 +11,8 @@ class Pry
         super(_pry_)
         @interrogatee = interrogatee
         @no_user_opts = no_user_opts
-        @ppp_switch = nil
+        @ppp_switch = opts[:ppp]
+        @jruby_switch = opts['all-java']
       end
 
       def output_self

--- a/lib/pry/commands/reload_code.rb
+++ b/lib/pry/commands/reload_code.rb
@@ -31,7 +31,7 @@ class Pry
     end
 
     def reload_current_file
-      if !File.exists?(current_file)
+      if !File.exist?(current_file)
         raise CommandError, "Current file: #{current_file} cannot be found on disk!"
       end
 
@@ -49,7 +49,7 @@ class Pry
     def check_for_reloadability(code_object, identifier)
       if !code_object || !code_object.source_file
         raise CommandError, "Cannot locate #{identifier}!"
-      elsif !File.exists?(code_object.source_file)
+      elsif !File.exist?(code_object.source_file)
         raise CommandError,
           "Cannot reload #{identifier} as it has no associated file on disk. " \
           "File found was: #{code_object.source_file}"

--- a/lib/pry/commands/watch_expression/expression.rb
+++ b/lib/pry/commands/watch_expression/expression.rb
@@ -10,7 +10,7 @@ class Pry
       end
 
       def eval!
-        @previous_value = @value
+        @previous_value = value
         @value = Pry::ColorPrinter.pp(target_eval(target, source), "")
       end
 

--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -159,12 +159,12 @@ class Pry
     end
 
     def class_code
-      return @class_code if @class_code
-
-      mod = @method ? Pry::WrappedModule(@method.owner) : target_class
-
-      idx = mod.candidates.find_index { |v| expand_path(v.source_file) == @file }
-      @class_code = idx && Pry::Code.from_module(mod, idx)
+      @class_code ||=
+        begin
+          mod = @method ? Pry::WrappedModule(@method.owner) : target_class
+          idx = mod.candidates.find_index { |v| expand_path(v.source_file) == @file }
+          idx && Pry::Code.from_module(mod, idx)
+        end
     end
 
     def valid_method?

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -137,8 +137,10 @@ private
   end
 
   def __push(key,value)
-    define_singleton_method(key) { self[key] }
-    define_singleton_method("#{key}=") { |val| @lookup[key] = val }
+    unless singleton_class.method_defined? key
+      define_singleton_method(key) { self[key] }
+      define_singleton_method("#{key}=") { |val| @lookup[key] = val }
+    end
     @lookup[key] = value
   end
 

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -138,7 +138,7 @@ private
 
   def __push(key,value)
     define_singleton_method(key) { self[key] }
-    define_singleton_method("#{key}=") { |value| @lookup[key] = value }
+    define_singleton_method("#{key}=") { |val| @lookup[key] = val }
     @lookup[key] = value
   end
 

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -359,13 +359,13 @@ class Pry
     #   Paraphrased from `awesome_print` gem.
     def signature
       if respond_to?(:parameters)
-        args = parameters.inject([]) do |arr, (type, name)|
-          name ||= (type == :block ? 'block' : "arg#{arr.size + 1}")
-          arr << case type
-                 when :req   then name.to_s
-                 when :opt   then "#{name}=?"
-                 when :rest  then "*#{name}"
-                 when :block then "&#{name}"
+        args = parameters.inject([]) do |arr, (typ, nam)|
+          nam ||= (typ == :block ? 'block' : "arg#{arr.size + 1}")
+          arr << case typ
+                 when :req   then nam.to_s
+                 when :opt   then "#{nam}=?"
+                 when :rest  then "*#{nam}"
+                 when :block then "&#{nam}"
                  else '?'
                  end
         end

--- a/lib/pry/method/disowned.rb
+++ b/lib/pry/method/disowned.rb
@@ -22,6 +22,7 @@ class Pry
       # @param [String] method_name
       def initialize(receiver, method_name, binding=nil)
         @receiver, @name = receiver, method_name
+        @method = nil
       end
 
       # Is the method undefined? (aka `Disowned`)

--- a/lib/pry/module_candidate.rb
+++ b/lib/pry/module_candidate.rb
@@ -61,16 +61,14 @@ class Pry
         return nil if file.nil?
         return @source if @source
 
-        @source = strip_leading_whitespace(Pry::Code.from_file(file).expression_at(line, number_of_lines_in_first_chunk))
+        @source ||= strip_leading_whitespace(Pry::Code.from_file(file).expression_at(line, number_of_lines_in_first_chunk))
       end
 
       # @raise [Pry::CommandError] If documentation cannot be found.
       # @return [String] The documentation for the candidate.
       def doc
         return nil if file.nil?
-        return @doc if @doc
-
-        @doc = get_comment_content(Pry::Code.from_file(file).comment_describing(line))
+        @doc ||= get_comment_content(Pry::Code.from_file(file).comment_describing(line))
       end
 
       # @return [Array, nil] A `[String, Fixnum]` pair representing the

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -174,8 +174,8 @@ class Pry
             completions.compact
           end
         elsif input.respond_to? :completion_proc=
-          input.completion_proc = proc do |input|
-            @pry.complete input
+          input.completion_proc = proc do |inp|
+            @pry.complete inp
           end
         end
 

--- a/lib/pry/test/helper.rb
+++ b/lib/pry/test/helper.rb
@@ -54,7 +54,7 @@ module PryTestHelpers
     yield file
   ensure
     file.close(true) if file
-    File.unlink("#{file.path}c") if File.exists?("#{file.path}c") # rbx
+    File.unlink("#{file.path}c") if File.exist?("#{file.path}c") # rbx
   end
 
   def unindent(*args)

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -48,6 +48,7 @@ class Pry
       # @return [Boolean]
       def safe_to_evaluate?(str, target)
         return true if str.strip == "self"
+        return false if str =~ /%/
         kind = target.eval("defined?(#{str})")
         kind =~ /variable|constant/
       end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -17,7 +17,7 @@ describe Pry::Hooks do
           # irrelevant
         end
       end.parse_options(argv)
-      argv.include?('-v').should == false
+      argv.include?('-v').should eq false
     end
   end
 
@@ -31,7 +31,7 @@ describe Pry::Hooks do
         end
       end.parse_options(["--optiontest"])
 
-      run.should == true
+      run.should eq true
     end
 
     it "should be able to add multiple options" do
@@ -64,7 +64,7 @@ describe Pry::Hooks do
         run = true if opts.present?(:optiontest)
       end.parse_options(["--optiontest"])
 
-      run.should == true
+      run.should eq true
     end
 
     it "should be able to  process multiple options" do
@@ -80,8 +80,8 @@ describe Pry::Hooks do
         run2 = true if opts.present?(:optiontest2)
       end.parse_options(["--optiontest", "--optiontest2"])
 
-      run.should == true
-      run2.should == true
+      run.should eq true
+      run2.should eq true
     end
 
   end

--- a/spec/code_object_spec.rb
+++ b/spec/code_object_spec.rb
@@ -24,13 +24,13 @@ describe Pry::CodeObject do
 
     it 'should lookup methods' do
       m = Pry::CodeObject.lookup("@obj.ziggy", @p)
-      m.is_a?(Pry::Method).should == true
-      m.name.to_sym.should == :ziggy
+      m.is_a?(Pry::Method).should eq true
+      m.name.to_sym.should eq :ziggy
     end
 
     it 'should lookup modules' do
       m = Pry::CodeObject.lookup("ClassyWassy", @p)
-      m.is_a?(Pry::WrappedModule).should == true
+      m.is_a?(Pry::WrappedModule).should eq true
       m.source.should =~ /piggy/
     end
 
@@ -38,8 +38,9 @@ describe Pry::CodeObject do
       my_proc = proc { :hello }
       @p.binding_stack = [binding]
       m = Pry::CodeObject.lookup("my_proc", @p)
-      m.is_a?(Pry::Method).should == true
+      m.is_a?(Pry::Method).should eq true
       m.source.should =~ /hello/
+      m.wrapped.should eq my_proc
     end
 
     describe 'commands lookup' do
@@ -53,7 +54,7 @@ describe Pry::CodeObject do
           "lobster"
         end
         m = Pry::CodeObject.lookup("jeremy-jones", @p)
-        (m <= Pry::Command).should == true
+        (m <= Pry::Command).should eq true
         m.source.should =~ /lobster/
       end
 
@@ -75,7 +76,7 @@ describe Pry::CodeObject do
         it 'should return Pry::ClassCommand class when looking up class command' do
           Pry.config.commands.add_command(LobsterLady)
           m = Pry::CodeObject.lookup("lobster-lady", @p)
-          (m <= Pry::ClassCommand).should == true
+          (m <= Pry::ClassCommand).should eq true
           m.source.should =~ /class LobsterLady/
           Pry.config.commands.delete("lobster-lady")
         end
@@ -83,23 +84,23 @@ describe Pry::CodeObject do
         it 'should return Pry::WrappedModule when looking up command class directly (as a class, not as a command)' do
           Pry.config.commands.add_command(LobsterLady)
           m = Pry::CodeObject.lookup("LobsterLady", @p)
-          m.is_a?(Pry::WrappedModule).should == true
+          m.is_a?(Pry::WrappedModule).should eq true
           m.source.should =~ /class LobsterLady/
           Pry.config.commands.delete("lobster-lady")
         end
       end
 
       it 'looks up commands by :listing name as well' do
-        @p.commands.command /jeremy-.*/, "", :listing => "jeremy-baby" do
+        @p.commands.command(/jeremy-.*/, "", :listing => "jeremy-baby") do
           "lobster"
         end
         m = Pry::CodeObject.lookup("jeremy-baby", @p)
-        (m <= Pry::Command).should == true
+        (m <= Pry::Command).should eq true
         m.source.should =~ /lobster/
       end
 
       it 'finds nothing when passing nil as the first argument' do
-        Pry::CodeObject.lookup(nil, @p).should == nil
+        Pry::CodeObject.lookup(nil, @p).should eq nil
       end
 
     end
@@ -113,8 +114,9 @@ describe Pry::CodeObject do
 
       @p.binding_stack = [binding]
       m = Pry::CodeObject.lookup("o#princess_bubblegum", @p)
-      m.is_a?(Pry::Method).should == true
+      m.is_a?(Pry::Method).should eq true
       m.source.should =~ /mathematic!/
+      m.wrapped.should eq o.instance_method(:princess_bubblegum)
     end
 
     it 'should lookup class methods defined on classes accessed via local variable' do
@@ -125,16 +127,18 @@ describe Pry::CodeObject do
       end
       @p.binding_stack = [binding]
       m = Pry::CodeObject.lookup("o.finn", @p)
-      m.is_a?(Pry::Method).should == true
+      m.is_a?(Pry::Method).should eq true
       m.source.should =~ /4 realzies/
+      m.wrapped.should eq o.method(:finn)
     end
 
     it 'should lookup the class of an object (when given a variable)' do
       moddy = ClassyWassy.new
       @p.binding_stack = [binding]
       m = Pry::CodeObject.lookup("moddy", @p)
-      m.is_a?(Pry::WrappedModule).should == true
+      m.is_a?(Pry::WrappedModule).should eq true
       m.source.should =~ /piggy/
+      m.wrapped.should eq moddy.class
     end
 
     describe "inferring object from binding when lookup str is empty/nil" do
@@ -148,7 +152,7 @@ describe Pry::CodeObject do
           ["", nil].each do |v|
             @p.binding_stack = [@b1]
             m = Pry::CodeObject.lookup(v, @p)
-            m.is_a?(Pry::WrappedModule).should == true
+            m.is_a?(Pry::WrappedModule).should eq true
             m.name.should =~ /ClassyWassy/
           end
         end
@@ -157,7 +161,7 @@ describe Pry::CodeObject do
           ["", nil].each do |v|
             @p.binding_stack = [@b2]
             m = Pry::CodeObject.lookup(v, @p)
-            m.is_a?(Pry::WrappedModule).should == true
+            m.is_a?(Pry::WrappedModule).should eq true
             m.name.should =~ /ClassyWassy/
           end
         end
@@ -170,7 +174,7 @@ describe Pry::CodeObject do
           ["", nil].each do |v|
             @p.binding_stack = [b]
             m = Pry::CodeObject.lookup(v, @p)
-            m.is_a?(Pry::Method).should == true
+            m.is_a?(Pry::Method).should eq true
             m.name.should =~ /piggy/
           end
         end
@@ -193,14 +197,14 @@ describe Pry::CodeObject do
 
     it 'should lookup original class with :super => 0' do
       m = Pry::CodeObject.lookup("CuteSubclass", @p, :super => 0)
-      m.is_a?(Pry::WrappedModule).should == true
-      m.wrapped.should == CuteSubclass
+      m.is_a?(Pry::WrappedModule).should eq true
+      m.wrapped.should eq CuteSubclass
     end
 
     it 'should lookup immediate super class with :super => 1' do
       m = Pry::CodeObject.lookup("CuteSubclass", @p, :super => 1)
-      m.is_a?(Pry::WrappedModule).should == true
-      m.wrapped.should == MyClassyWassy
+      m.is_a?(Pry::WrappedModule).should eq true
+      m.wrapped.should eq MyClassyWassy
     end
 
     it 'should ignore :super parameter for commands' do
@@ -246,19 +250,19 @@ describe Pry::CodeObject do
 
     it 'should look up classes before methods (at top-level)' do
       m = Pry::CodeObject.lookup("ClassyWassy", @p)
-      m.is_a?(Pry::WrappedModule).should == true
+      m.is_a?(Pry::WrappedModule).should eq true
       m.source.should =~ /piggy/
     end
 
     it 'should look up methods before classes when ending in () (at top-level)' do
       m = Pry::CodeObject.lookup("ClassyWassy()", @p)
-      m.is_a?(Pry::Method).should == true
+      m.is_a?(Pry::Method).should eq true
       m.source.should =~ /ducky/
     end
 
     it 'should look up classes before methods when namespaced' do
       m = Pry::CodeObject.lookup("ClassyWassy::Puff", @p)
-      m.is_a?(Pry::WrappedModule).should == true
+      m.is_a?(Pry::WrappedModule).should eq true
       m.source.should =~ /tiggy/
     end
 
@@ -267,17 +271,17 @@ describe Pry::CodeObject do
       b.eval("piggy = Puff.new")
       @p.binding_stack = [b]
       o = Pry::CodeObject.lookup("piggy", @p)
-      o.is_a?(Pry::WrappedModule).should == true
+      o.is_a?(Pry::WrappedModule).should eq true
     end
 
     # actually locals are never looked up (via co.default_lookup)  when they're classes, it
     # just falls through to co.method_or_class
     it 'should look up classes before locals' do
-      c = ClassyWassy
+      _c = ClassyWassy
       @p.binding_stack = [binding]
-      o = Pry::CodeObject.lookup("c", @p)
-      o.is_a?(Pry::WrappedModule).should == true
-      o.wrapped.should == ClassyWassy
+      o = Pry::CodeObject.lookup("_c", @p)
+      o.is_a?(Pry::WrappedModule).should eq true
+      o.wrapped.should eq ClassyWassy
     end
   end
 end

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -8,18 +8,18 @@ describe Pry::Code do
 
     specify 'read lines from Pry\'s line buffer' do
       pry_eval ':hay_guys'
-      Pry::Code.from_file('(pry)').grep(/:hay_guys/).length.should == 1
+      Pry::Code.from_file('(pry)').grep(/:hay_guys/).length.should eq 1
     end
 
     specify 'default to unknown' do
       temp_file('') do |f|
-        Pry::Code.from_file(f.path).code_type.should == :unknown
+        Pry::Code.from_file(f.path).code_type.should eq :unknown
       end
     end
 
     specify 'check the extension' do
       temp_file('.c') do |f|
-        Pry::Code.from_file(f.path).code_type.should == :c
+        Pry::Code.from_file(f.path).code_type.should eq :c
       end
     end
 
@@ -31,19 +31,19 @@ describe Pry::Code do
 
     specify 'check for files relative to origin pwd' do
       Dir.chdir('spec') do |f|
-        Pry::Code.from_file('spec/' + File.basename(__FILE__)).code_type.should == :ruby
+        Pry::Code.from_file('spec/' + File.basename(__FILE__)).code_type.should eq :ruby
       end
     end
 
     specify 'check for Ruby files relative to origin pwd with `.rb` omitted' do
       Dir.chdir('spec') do |f|
-        Pry::Code.from_file('spec/' + File.basename(__FILE__, '.*')).code_type.should == :ruby
+        Pry::Code.from_file('spec/' + File.basename(__FILE__, '.*')).code_type.should eq :ruby
       end
     end
 
     specify 'find files that are relative to the current working directory' do
       Dir.chdir('spec') do |f|
-        Pry::Code.from_file(File.basename(__FILE__)).code_type.should == :ruby
+        Pry::Code.from_file(File.basename(__FILE__)).code_type.should eq :ruby
       end
     end
 
@@ -57,31 +57,31 @@ describe Pry::Code do
       end
 
       it 'finds files with `.rb` extension' do
-        Pry::Code.from_file('slinky.rb').code_type.should == :ruby
+        Pry::Code.from_file('slinky.rb').code_type.should eq :ruby
       end
 
       it 'finds files with `.rb` omitted' do
-        Pry::Code.from_file('slinky').code_type.should == :ruby
+        Pry::Code.from_file('slinky').code_type.should eq :ruby
       end
 
       it 'finds files in a relative directory with `.rb` extension' do
-        Pry::Code.from_file('../helper.rb').code_type.should == :ruby
+        Pry::Code.from_file('../helper.rb').code_type.should eq :ruby
       end
 
       it 'finds files in a relative directory with `.rb` omitted' do
-        Pry::Code.from_file('../helper').code_type.should == :ruby
+        Pry::Code.from_file('../helper').code_type.should eq :ruby
       end
 
       it "doesn't confuse files with the same name, but without an extension" do
-        Pry::Code.from_file('cat_load_path').code_type.should == :unknown
+        Pry::Code.from_file('cat_load_path').code_type.should eq :unknown
       end
 
       it "doesn't confuse files with the same name, but with an extension" do
-        Pry::Code.from_file('cat_load_path.rb').code_type.should == :ruby
+        Pry::Code.from_file('cat_load_path.rb').code_type.should eq :ruby
       end
 
       it "recognizes special Ruby files without extensions" do
-        Pry::Code.from_file('Gemfile').code_type.should == :ruby
+        Pry::Code.from_file('Gemfile').code_type.should eq :ruby
       end
     end
   end
@@ -105,15 +105,15 @@ describe Pry::Code do
     end
 
     specify 'break a string into lines' do
-      Pry::Code.new(@str).length.should == 3
+      Pry::Code.new(@str).length.should eq 3
     end
 
     specify 'accept an array' do
-      Pry::Code.new(@array).length.should == 3
+      Pry::Code.new(@array).length.should eq 3
     end
 
     it 'an array or string specify produce an equivalent object' do
-      Pry::Code.new(@str).should == Pry::Code.new(@array)
+      Pry::Code.new(@str).should eq Pry::Code.new(@array)
     end
   end
 
@@ -132,19 +132,19 @@ describe Pry::Code do
       describe '#between' do
         specify 'work with an inclusive range' do
           @code = @code.between(1..3)
-          @code.length.should == 3
+          @code.length.should eq 3
           @code.should =~ /\Aclass MyProgram/
           @code.should =~ /world!'\Z/
         end
 
         specify 'default to an inclusive range' do
           @code = @code.between(3, 5)
-          @code.length.should == 3
+          @code.length.should eq 3
         end
 
         specify 'work with an exclusive range' do
           @code = @code.between(2...4)
-          @code.length.should == 2
+          @code.length.should eq 2
           @code.should =~ /\A  def self/
           @code.should =~ /world!'\Z/
         end
@@ -152,7 +152,7 @@ describe Pry::Code do
         specify 'use real line numbers for positive indices' do
           @code = @code.after(3, 3)
           @code = @code.between(4, 4)
-          @code.length.should == 1
+          @code.length.should eq 1
           @code.should =~ /\A  end\Z/
         end
       end
@@ -167,7 +167,7 @@ describe Pry::Code do
       describe '#around' do
         specify 'work' do
           @code = @code.around(3, 1)
-          @code.length.should == 3
+          @code.length.should eq 3
           @code.should =~ /\A  def self/
           @code.should =~ /  end\Z/
         end
@@ -183,7 +183,7 @@ describe Pry::Code do
       describe '#grep' do
         specify 'work' do
           @code = @code.grep(/end/)
-          @code.length.should == 2
+          @code.length.should eq 2
         end
       end
     end
@@ -249,7 +249,7 @@ describe Pry::Code do
       describe 'before and after' do
         specify 'work' do
           @code = @code.before(4, 2).after(2)
-          @code.should == "    puts 'Hello, world!'"
+          @code.should eq "    puts 'Hello, world!'"
         end
       end
     end

--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -41,7 +41,7 @@ describe "commands" do
       end
 
       pry_tester(:commands => set).tap do |t|
-        t.eval('test-command').should == t.eval('test-alias')
+        t.eval('test-command').should eq t.eval('test-alias')
       end
     end
 
@@ -86,7 +86,7 @@ describe "commands" do
 
     it 'should be able to alias a regex command' do
       set = Pry::CommandSet.new do
-        command /du.k/ do
+        command(/du.k/) do
           output.puts "ducky"
         end
         alias_command "test-alias", "duck"
@@ -99,10 +99,10 @@ describe "commands" do
 
     it 'should be able to make the alias a regex' do
       set = Pry::CommandSet.new do
-        command /du.k/ do
+        command(/du.k/) do
           output.puts "ducky"
         end
-        alias_command /test-ali.s/, "duck"
+        alias_command(/test-ali.s/, "duck")
       end
 
       redirect_pry_io(InputTester.new("test-alias"), out1 = StringIO.new) do
@@ -127,9 +127,9 @@ describe "commands" do
         Pry.start(@o, :commands => set)
       end
 
-      Pad.bs1.size.should == 7
-      Pad.self.should == @o
-      Pad.bs2.size.should == 1
+      Pad.bs1.size.should eq 7
+      Pad.self.should eq @o
+      Pad.bs2.size.should eq 1
     end
 
     it 'should allow running of cd command when contained in a single string' do
@@ -144,9 +144,9 @@ describe "commands" do
         Pry.start(@o, :commands => set)
       end
 
-      Pad.bs1.size.should == 7
-      Pad.self.should == @o
-      Pad.bs2.size.should == 1
+      Pad.bs1.size.should eq 7
+      Pad.self.should eq @o
+      Pad.bs2.size.should eq 1
     end
 
     it 'should allow running of cd command when split into array' do
@@ -161,9 +161,9 @@ describe "commands" do
         Pry.start(@o, :commands => set)
       end
 
-      Pad.bs1.size.should == 7
-      Pad.self.should == @o
-      Pad.bs2.size.should == 1
+      Pad.bs1.size.should eq 7
+      Pad.self.should eq @o
+      Pad.bs2.size.should eq 1
     end
 
     it 'should run a command from within a command' do
@@ -182,7 +182,7 @@ describe "commands" do
 
     it 'should run a regex command from within a command' do
       klass = Pry::CommandSet.new do
-        command /v(.*)?/ do |arg|
+        command(/v(.*)?/) do |arg|
           output.puts "v #{arg}"
         end
 
@@ -196,7 +196,7 @@ describe "commands" do
 
     it 'should run a command from within a command with arguments' do
       klass = Pry::CommandSet.new do
-        command /v(\w+)/ do |arg1, arg2|
+        command(/v(\w+)/) do |arg1, arg2|
           output.puts "v #{arg1} #{arg2}"
         end
 
@@ -267,7 +267,7 @@ describe "commands" do
     expect { pry_eval 'raise \'#{aggy}\'' }.to raise_error RuntimeError
     expect { pry_eval 'raise #{aggy}'     }.to raise_error RuntimeError
 
-    pry_eval('format \'#{my_var}\'').should == "\#{my_var}"
+    pry_eval('format \'#{my_var}\'').should eq "\#{my_var}"
   end
 
   it 'should create a command with a space in its name zzz' do
@@ -294,7 +294,7 @@ describe "commands" do
 
   it 'should create a regex command and be able to invoke it' do
     set = Pry::CommandSet.new do
-      command /hello(.)/, "" do
+      command(/hello(.)/, "") do
         c = captures.first
         output.puts "hello#{c}"
       end
@@ -305,7 +305,7 @@ describe "commands" do
 
   it 'should create a regex command and pass captures into the args list before regular arguments' do
     set = Pry::CommandSet.new do
-      command /hello(.)/, "" do |c1, a1|
+      command(/hello(.)/, "") do |c1, a1|
         output.puts "hello #{c1} #{a1}"
       end
     end
@@ -315,19 +315,19 @@ describe "commands" do
 
   it 'should create a regex command and interpolate the captures' do
     set = Pry::CommandSet.new do
-      command /hello (.*)/, "" do |c1|
+      command(/hello (.*)/, "") do |c1|
         output.puts "hello #{c1}"
       end
     end
 
     bong = "bong"
     pry_tester(binding, :commands => set).eval('hello #{bong}').
-      should =~ /hello bong/
+      should =~ /hello #{bong}/
   end
 
   it 'should create a regex command and arg_string should be interpolated' do
     set = Pry::CommandSet.new do
-      command /hello(\w+)/, "" do |c1, a1, a2, a3|
+      command(/hello(\w+)/, "") do |c1, a1, a2, a3|
         output.puts "hello #{c1} #{a1} #{a2} #{a3}"
       end
     end
@@ -338,12 +338,12 @@ describe "commands" do
 
     pry_tester(binding, :commands => set).
       eval('hellojohn #{bing} #{bong} #{bang}').
-      should =~ /hello john bing bong bang/
+      should =~ /hello john #{bing} #{bong} #{bang}/
   end
 
   it 'if a regex capture is missing it should be nil' do
     set = Pry::CommandSet.new do
-      command /hello(.)?/, "" do |c1, a1|
+      command(/hello(.)?/, "") do |c1, a1|
         output.puts "hello #{c1.inspect} #{a1}"
       end
     end
@@ -370,7 +370,7 @@ describe "commands" do
 
     t = pry_tester(:commands => klass)
     t.eval("hello\n")
-    t.last_command_result.should == :kept_hello
+    t.last_command_result.should eq :kept_hello
   end
 
   it 'should define a command that does NOT keep its return value' do
@@ -381,8 +381,8 @@ describe "commands" do
     end
 
     t = pry_tester(:commands => klass)
-    t.eval("hello\n").should == ''
-    t.last_command_result.should == Pry::Command::VOID_VALUE
+    t.eval("hello\n").should eq ''
+    t.last_command_result.should eq Pry::Command::VOID_VALUE
   end
 
   it 'should define a command that keeps its return value even when nil' do
@@ -394,7 +394,7 @@ describe "commands" do
 
     t = pry_tester(:commands => klass)
     t.eval("hello\n")
-    t.last_command_result.should == nil
+    t.last_command_result.should eq nil
   end
 
   it 'should define a command that keeps its return value but does not return when value is void' do
@@ -404,7 +404,7 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => klass).eval("hello\n").empty?.should == true
+    pry_tester(:commands => klass).eval("hello\n").empty?.should eq true
   end
 
   it 'a command (with :keep_retval => false) that replaces eval_string with a valid expression should not have the expression value suppressed' do
@@ -431,7 +431,7 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => klass).eval("def yo\nhello\n").should == 7
+    pry_tester(:commands => klass).eval("def yo\nhello\n").should eq 7
   end
 
   it 'a command that return a value in a multi-line expression should clear the expression and return the value' do
@@ -441,7 +441,7 @@ describe "commands" do
       end
     end
 
-    pry_tester(:commands => klass).eval("def yo\nhello\n").should == 5
+    pry_tester(:commands => klass).eval("def yo\nhello\n").should eq 5
   end
 
   it 'should set the commands default, and the default should be overridable' do
@@ -458,8 +458,8 @@ describe "commands" do
     end
 
     Pry.config.commands = klass
-    pry_tester.eval("hello").should == "hello world\n"
-    pry_tester(:commands => other_klass).eval("goodbye").should == "goodbye world\n"
+    pry_tester.eval("hello").should eq "hello world\n"
+    pry_tester(:commands => other_klass).eval("goodbye").should eq "goodbye world\n"
   end
 
   it 'should inherit commands from Pry::Commands' do
@@ -468,10 +468,10 @@ describe "commands" do
       end
     end
 
-    klass.to_hash.include?("nesting").should == true
-    klass.to_hash.include?("jump-to").should == true
-    klass.to_hash.include?("cd").should == true
-    klass.to_hash.include?("v").should == true
+    klass.to_hash.include?("nesting").should eq true
+    klass.to_hash.include?("jump-to").should eq true
+    klass.to_hash.include?("cd").should eq true
+    klass.to_hash.include?("v").should eq true
   end
 
   it 'should change description of a command using desc' do
@@ -483,8 +483,8 @@ describe "commands" do
       desc "help", "blah"
     end
     commands = klass.to_hash
-    commands["help"].description.should_not == orig
-    commands["help"].description.should == "blah"
+    commands["help"].description.should_not eq orig
+    commands["help"].description.should eq "blah"
   end
 
   it 'should enable an inherited method to access opts and output and target, due to instance_exec' do
@@ -500,7 +500,7 @@ describe "commands" do
     mock_pry(Pry.binding_for('john'), "v", :print => proc {}, :commands => child_klass,
                                            :output => @str_output)
 
-    @str_output.string.should == "john\n"
+    @str_output.string.should eq "john\n"
   end
 
   it 'should import commands from another command object' do
@@ -508,8 +508,8 @@ describe "commands" do
       import_from Pry::Commands, "ls", "jump-to"
     end
 
-    klass.to_hash.include?("ls").should == true
-    klass.to_hash.include?("jump-to").should == true
+    klass.to_hash.include?("ls").should eq true
+    klass.to_hash.include?("jump-to").should eq true
   end
 
   it 'should delete some inherited commands when using delete method' do
@@ -522,13 +522,13 @@ describe "commands" do
     end
 
     commands = klass.to_hash
-    commands.include?("nesting").should == true
-    commands.include?("jump-to").should == true
-    commands.include?("cd").should == true
-    commands.include?("v").should == true
-    commands.include?("show-doc").should == false
-    commands.include?("show-method").should == false
-    commands.include?("ls").should == false
+    commands.include?("nesting").should eq true
+    commands.include?("jump-to").should eq true
+    commands.include?("cd").should eq true
+    commands.include?("v").should eq true
+    commands.include?("show-doc").should eq false
+    commands.include?("show-method").should eq false
+    commands.include?("ls").should eq false
   end
 
   it 'should override some inherited commands' do
@@ -543,17 +543,17 @@ describe "commands" do
     end
 
     t = pry_tester(:commands => klass)
-    t.eval('jump-to').should == "jump-to the music\n"
-    t.eval('help').should == "help to the music\n"
+    t.eval('jump-to').should eq "jump-to the music\n"
+    t.eval('help').should eq "help to the music\n"
   end
 
   it 'should run a command with no parameter' do
     pry_tester(:commands => @command_tester).eval('command1').
-      should == "command1\n"
+      should eq "command1\n"
   end
 
   it 'should run a command with one parameter' do
     pry_tester(:commands => @command_tester).eval('command2 horsey').
-      should == "horsey\n"
+      should eq "horsey\n"
   end
 end

--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -414,13 +414,11 @@ describe "commands" do
       end
     end
 
-    output = StringIO.new
-
-    redirect_pry_io(InputTester.new('def yo', 'hello'), output) do
+    redirect_pry_io(InputTester.new('def yo', 'hello'), @str_output) do
       Pry.start self, :commands => klass
     end
 
-    output.string.should =~ /6/
+    @str_output.string.should =~ /6/
   end
 
   it 'a command (with :keep_retval => true) that replaces eval_string with a valid expression should overwrite the eval_string with the return value' do

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -15,21 +15,21 @@ describe Pry::CommandSet do
 
   describe "[]=" do
     it "removes a command from the command set" do
-      @set["help"].should_not == nil
+      @set["help"].should_not eq nil
       @set["help"] = nil
-      @set["help"].should == nil
+      @set["help"].should eq nil
       expect { @set.run_command(TOPLEVEL_BINDING, "help") }.to raise_error Pry::NoCommandError
     end
 
     it "replaces a command" do
       old_help = @set["help"]
       @set["help"] = @set["pry-version"]
-      @set["help"].should_not == old_help
+      @set["help"].should_not eq old_help
     end
 
     it "rebinds the command with key" do
       @set["help-1"] = @set["help"]
-      @set["help-1"].match.should == "help-1"
+      @set["help-1"].match.should eq "help-1"
     end
 
     it "raises a TypeError when command is not a subclass of Pry::Command" do
@@ -44,7 +44,7 @@ describe Pry::CommandSet do
     end
 
     @set.run_command @ctx, 'foo'
-    run.should == true
+    run.should eq true
   end
 
   it 'should pass arguments of the command to the block' do
@@ -94,7 +94,7 @@ describe Pry::CommandSet do
     @set.import_from(other_set, 'foo')
 
     @set.run_command @ctx, 'foo'
-    run.should == true
+    run.should eq true
 
     expect { @set.run_command @ctx, 'bar' }.to raise_error Pry::NoCommandError
   end
@@ -107,7 +107,7 @@ describe Pry::CommandSet do
       command('bar') {}
     end
 
-    @set.import(other_set).should == @set
+    @set.import(other_set).should eq @set
   end
 
   it 'should return command set after import_from' do
@@ -118,7 +118,7 @@ describe Pry::CommandSet do
       command('bar') {}
     end
 
-    @set.import_from(other_set, 'foo').should == @set
+    @set.import_from(other_set, 'foo').should eq @set
   end
 
   it 'should be able to import some commands from other sets using listing name' do
@@ -131,7 +131,7 @@ describe Pry::CommandSet do
     @set.import_from(other_set, 'foo')
 
     @set.run_command @ctx, /^foo1/
-    run.should == true
+    run.should eq true
   end
 
   it 'should be able to import a whole set' do
@@ -146,7 +146,7 @@ describe Pry::CommandSet do
 
     @set.run_command @ctx, 'foo'
     @set.run_command @ctx, 'bar'
-    run.should == [true, true]
+    run.should eq [true, true]
   end
 
   it 'should be able to import sets at creation' do
@@ -154,12 +154,12 @@ describe Pry::CommandSet do
     @set.command('foo') { run = true }
 
     Pry::CommandSet.new(@set).run_command @ctx, 'foo'
-    run.should == true
+    run.should eq true
   end
 
   it 'should set the descriptions of commands' do
     @set.command('foo', 'some stuff') {}
-    @set['foo'].description.should == 'some stuff'
+    @set['foo'].description.should eq 'some stuff'
   end
 
   describe "aliases" do
@@ -168,11 +168,11 @@ describe Pry::CommandSet do
       @set.command('foo', 'stuff') { run = true }
 
       @set.alias_command 'bar', 'foo'
-      @set['bar'].match.should == 'bar'
-      @set['bar'].description.should == 'Alias for `foo`'
+      @set['bar'].match.should eq 'bar'
+      @set['bar'].description.should eq 'Alias for `foo`'
 
       @set.run_command @ctx, 'bar'
-      run.should == true
+      run.should eq true
     end
 
     it "should be able to alias command with command_prefix" do
@@ -183,11 +183,11 @@ describe Pry::CommandSet do
         @set.alias_command 'owlet', 'owl'
 
         Pry.config.command_prefix = '%'
-        @set['%owlet'].match.should == 'owlet'
-        @set['%owlet'].description.should == 'Alias for `owl`'
+        @set['%owlet'].match.should eq 'owlet'
+        @set['%owlet'].description.should eq 'Alias for `owl`'
 
         @set.run_command @ctx, 'owlet'
-        run.should == true
+        run.should eq true
       ensure
         Pry.config.command_prefix = ''
       end
@@ -198,12 +198,12 @@ describe Pry::CommandSet do
       @set.command('foo', 'stuff', :shellwords => true, :interpolate => false) { run = true }
 
       @set.alias_command 'bar', 'foo'
-      @set['bar'].options[:shellwords].should == @set['foo'].options[:shellwords]
-      @set['bar'].options[:interpolate].should == @set['foo'].options[:interpolate]
+      @set['bar'].options[:shellwords].should eq @set['foo'].options[:shellwords]
+      @set['bar'].options[:interpolate].should eq @set['foo'].options[:interpolate]
 
       # however some options should not be inherited
-      @set['bar'].options[:listing].should_not ==  @set['foo'].options[:listing]
-      @set['bar'].options[:listing].should == "bar"
+      @set['bar'].options[:listing].should_not eq  @set['foo'].options[:listing]
+      @set['bar'].options[:listing].should eq "bar"
     end
 
     it 'should be able to specify alias\'s description when aliasing' do
@@ -211,11 +211,11 @@ describe Pry::CommandSet do
       @set.command('foo', 'stuff') { run = true }
 
       @set.alias_command 'bar', 'foo', :desc => "tobina"
-      @set['bar'].match.should == 'bar'
-      @set['bar'].description.should == "tobina"
+      @set['bar'].match.should eq 'bar'
+      @set['bar'].description.should eq "tobina"
 
       @set.run_command @ctx, 'bar'
-      run.should == true
+      run.should eq true
     end
 
     it "should be able to alias a command by its invocation line" do
@@ -223,19 +223,19 @@ describe Pry::CommandSet do
       @set.command(/^foo1/, 'stuff', :listing => 'foo') { run = true }
 
       @set.alias_command 'bar', 'foo1'
-      @set['bar'].match.should == 'bar'
-      @set['bar'].description.should == 'Alias for `foo1`'
+      @set['bar'].match.should eq 'bar'
+      @set['bar'].description.should eq 'Alias for `foo1`'
 
       @set.run_command @ctx, 'bar'
-      run.should == true
+      run.should eq true
     end
 
     it "should be able to specify options when creating alias" do
       run = false
       @set.command(/^foo1/, 'stuff', :listing => 'foo') { run = true }
 
-      @set.alias_command /^b.r/, 'foo1', :listing => "bar"
-      @set.to_hash[/^b.r/].options[:listing].should == "bar"
+      @set.alias_command(/^b.r/, 'foo1', :listing => "bar")
+      @set.to_hash[/^b.r/].options[:listing].should eq "bar"
     end
 
     it "should set description to default if description parameter is nil" do
@@ -243,7 +243,7 @@ describe Pry::CommandSet do
       @set.command(/^foo1/, 'stuff', :listing => 'foo') { run = true }
 
       @set.alias_command "bar", 'foo1'
-      @set["bar"].description.should == "Alias for `foo1`"
+      @set["bar"].description.should eq "Alias for `foo1`"
     end
   end
 
@@ -251,32 +251,32 @@ describe Pry::CommandSet do
     @set.command('foo', 'bar') {}
     @set.desc 'foo', 'baz'
 
-    @set['foo'].description.should == 'baz'
+    @set['foo'].description.should eq 'baz'
   end
 
   it 'should get the descriptions of commands' do
     @set.command('foo', 'bar') {}
-    @set.desc('foo').should == 'bar'
+    @set.desc('foo').should eq 'bar'
   end
 
   it 'should get the descriptions of commands, by listing' do
     @set.command(/^foo1/, 'bar', :listing => 'foo') {}
-    @set.desc('foo').should == 'bar'
+    @set.desc('foo').should eq 'bar'
   end
 
   it 'should return Pry::Command::VOID_VALUE for commands by default' do
     @set.command('foo') { 3 }
-    @set.run_command(@ctx, 'foo').should == Pry::Command::VOID_VALUE
+    @set.run_command(@ctx, 'foo').should eq Pry::Command::VOID_VALUE
   end
 
   it 'should be able to keep return values' do
     @set.command('foo', '', :keep_retval => true) { 3 }
-    @set.run_command(@ctx, 'foo').should == 3
+    @set.run_command(@ctx, 'foo').should eq 3
   end
 
   it 'should be able to keep return values, even if return value is nil' do
     @set.command('foo', '', :keep_retval => true) { nil }
-    @set.run_command(@ctx, 'foo').should == nil
+    @set.run_command(@ctx, 'foo').should eq nil
   end
 
   it 'should be able to have its own helpers' do
@@ -334,12 +334,12 @@ describe Pry::CommandSet do
 
   it 'should provide a :listing for a command that defaults to its name' do
     @set.command 'foo', "" do;end
-    @set['foo'].options[:listing].should == 'foo'
+    @set['foo'].options[:listing].should eq 'foo'
   end
 
   it 'should provide a :listing for a command that differs from its name' do
     @set.command 'foo', "", :listing => 'bar' do;end
-    @set['foo'].options[:listing].should == 'bar'
+    @set['foo'].options[:listing].should eq 'bar'
   end
 
   it "should provide a 'help' command" do
@@ -356,7 +356,7 @@ describe Pry::CommandSet do
       @set.command('foo') { run = true }
       @set.rename_command('bar', 'foo')
       @set.run_command(@ctx, 'bar')
-      run.should == true
+      run.should eq true
     end
 
     it 'should accept listing name when renaming a command' do
@@ -364,7 +364,7 @@ describe Pry::CommandSet do
       @set.command('foo', "", :listing => 'love') { run = true }
       @set.rename_command('bar', 'love')
       @set.run_command(@ctx, 'bar')
-      run.should == true
+      run.should eq true
     end
 
     it 'should raise exception trying to rename non-existent command' do
@@ -382,9 +382,9 @@ describe Pry::CommandSet do
       listing = "bing"
       @set.command('foo') { }
       @set.rename_command('bar', 'foo', :description => desc, :listing => listing, :keep_retval => true)
-      @set['bar'].description.should           == desc
-      @set['bar'].options[:listing].should     == listing
-      @set['bar'].options[:keep_retval].should == true
+      @set['bar'].description.should           eq desc
+      @set['bar'].options[:listing].should     eq listing
+      @set['bar'].options[:keep_retval].should eq true
     end
   end
 
@@ -396,7 +396,7 @@ describe Pry::CommandSet do
         @set.before_command('foo') { foo << 2 }
         @set.run_command(@ctx, 'foo')
 
-        foo.should == [2, 1]
+        foo.should eq [2, 1]
       end
 
       it 'should be called before the original command, using listing name' do
@@ -405,7 +405,7 @@ describe Pry::CommandSet do
         @set.before_command('foo') { foo << 2 }
         @set.run_command(@ctx, /^foo1/)
 
-        foo.should == [2, 1]
+        foo.should eq [2, 1]
       end
 
       it 'should share the context with the original command' do
@@ -416,8 +416,8 @@ describe Pry::CommandSet do
         @set.before_command('foo') { before_val = target }
         @set.run_command(@ctx, 'foo')
 
-        before_val.should == @ctx[:target]
-        orig_val.should == @ctx[:target]
+        before_val.should eq @ctx[:target]
+        orig_val.should eq @ctx[:target]
       end
 
       it 'should work when applied multiple times' do
@@ -428,7 +428,7 @@ describe Pry::CommandSet do
         @set.before_command('foo') { foo << 4 }
         @set.run_command(@ctx, 'foo')
 
-        foo.should == [4, 3, 2, 1]
+        foo.should eq [4, 3, 2, 1]
       end
 
     end
@@ -440,7 +440,7 @@ describe Pry::CommandSet do
         @set.after_command('foo') { foo << 2 }
         @set.run_command(@ctx, 'foo')
 
-        foo.should == [1, 2]
+        foo.should eq [1, 2]
       end
 
       it 'should be called after the original command, using listing name' do
@@ -449,7 +449,7 @@ describe Pry::CommandSet do
         @set.after_command('foo') { foo << 2 }
         @set.run_command(@ctx, /^foo1/)
 
-        foo.should == [1, 2]
+        foo.should eq [1, 2]
       end
 
       it 'should share the context with the original command' do
@@ -460,14 +460,14 @@ describe Pry::CommandSet do
         @set.after_command('foo') { after_val = target }
         @set.run_command(@ctx, 'foo')
 
-        after_val.should == @ctx[:target]
-        orig_val.should == @ctx[:target]
+        after_val.should eq @ctx[:target]
+        orig_val.should eq @ctx[:target]
       end
 
       it 'should determine the return value for the command' do
         @set.command('foo', 'bar', :keep_retval => true) { 1 }
         @set.after_command('foo') { 2 }
-        @set.run_command(@ctx, 'foo').should == 2
+        @set.run_command(@ctx, 'foo').should eq 2
       end
 
       it 'should work when applied multiple times' do
@@ -478,7 +478,7 @@ describe Pry::CommandSet do
         @set.after_command('foo') { foo << 4 }
         @set.run_command(@ctx, 'foo')
 
-        foo.should == [1, 2, 3, 4]
+        foo.should eq [1, 2, 3, 4]
       end
     end
 
@@ -490,7 +490,7 @@ describe Pry::CommandSet do
         @set.before_command('foo') { foo << 3 }
         @set.run_command(@ctx, 'foo')
 
-        foo.should == [3, 1, 2]
+        foo.should eq [3, 1, 2]
       end
 
     end
@@ -500,44 +500,44 @@ describe Pry::CommandSet do
   describe 'find_command' do
     it 'should find commands with the right string' do
       cmd = @set.command('rincewind'){ }
-      @set.find_command('rincewind').should == cmd
+      @set.find_command('rincewind').should eq cmd
     end
 
     it 'should not find commands with spaces before' do
-      cmd = @set.command('luggage'){ }
-      @set.find_command(' luggage').should == nil
+      @set.command('luggage'){ }
+      @set.find_command(' luggage').should eq nil
     end
 
     it 'should find commands with arguments after' do
       cmd = @set.command('vetinari'){ }
-      @set.find_command('vetinari --knock 3').should == cmd
+      @set.find_command('vetinari --knock 3').should eq cmd
     end
 
     it 'should find commands with names containing spaces' do
       cmd = @set.command('nobby nobbs'){ }
-      @set.find_command('nobby nobbs --steal petty-cash').should == cmd
+      @set.find_command('nobby nobbs --steal petty-cash').should eq cmd
     end
 
     it 'should find command defined by regex' do
       cmd = @set.command(/(capt|captain) vimes/i){ }
-      @set.find_command('Capt Vimes').should == cmd
+      @set.find_command('Capt Vimes').should eq cmd
     end
 
     it 'should find commands defined by regex with arguments' do
       cmd = @set.command(/(cpl|corporal) Carrot/i){ }
-      @set.find_command('cpl carrot --write-home').should == cmd
+      @set.find_command('cpl carrot --write-home').should eq cmd
     end
 
     it 'should not find commands by listing' do
-      cmd = @set.command(/werewol(f|ve)s?/, 'only once a month', :listing => "angua"){ }
-      @set.find_command('angua').should == nil
+      @set.command(/werewol(f|ve)s?/, 'only once a month', :listing => "angua"){ }
+      @set.find_command('angua').should eq nil
     end
 
     it 'should not find commands without command_prefix' do
       begin
         Pry.config.command_prefix = '%'
-        cmd = @set.command('detritus'){ }
-        @set.find_command('detritus').should == nil
+        @set.command('detritus'){ }
+        @set.find_command('detritus').should eq nil
       ensure
         Pry.config.command_prefix = ''
       end
@@ -547,37 +547,37 @@ describe Pry::CommandSet do
       begin
         Pry.config.command_prefix = '%'
         cmd = @set.command('colon', 'Sergeant Fred', :use_prefix => false){ }
-        @set.find_command('colon').should == cmd
+        @set.find_command('colon').should eq cmd
       ensure
         Pry.config.command_prefix = ''
       end
     end
 
     it "should find the command that has the longest match" do
-      cmd = @set.command(/\.(.*)/){ }
+      @set.command(/\.(.*)/){ }
       cmd2 = @set.command(/\.\|\|(.*)/){ }
-      @set.find_command('.||').should == cmd2
+      @set.find_command('.||').should eq cmd2
     end
 
     it "should find the command that has the longest name" do
-      cmd = @set.command(/\.(.*)/){ }
+      @set.command(/\.(.*)/){ }
       cmd2 = @set.command('.||'){ }
-      @set.find_command('.||').should == cmd2
+      @set.find_command('.||').should eq cmd2
     end
   end
 
   describe '.valid_command?' do
     it 'should be true for commands that can be found' do
-      cmd = @set.command('archchancellor')
-      @set.valid_command?('archchancellor of_the?(:University)').should == true
+      @set.command('archchancellor')
+      @set.valid_command?('archchancellor of_the?(:University)').should eq true
     end
 
     it 'should be false for commands that can\'' do
-      @set.valid_command?('def monkey(ape)').should == false
+      @set.valid_command?('def monkey(ape)').should eq false
     end
 
     it 'should not cause argument interpolation' do
-      cmd = @set.command('hello')
+      @set.command('hello')
       expect { @set.valid_command?('hello #{raise "futz"}') }.to_not raise_error
     end
   end
@@ -586,9 +586,9 @@ describe Pry::CommandSet do
 
     it 'should return Result.new(false) if there is no matching command' do
      result = @set.process_line('1 + 42')
-     result.command?.should == false
-     result.void_command?.should == false
-     result.retval.should == nil
+     result.command?.should eq false
+     result.void_command?.should eq false
+     result.retval.should eq nil
     end
 
     it 'should return Result.new(true, VOID) if the command is not keep_retval' do
@@ -597,9 +597,9 @@ describe Pry::CommandSet do
       end
 
       result = @set.process_line('mrs-cake')
-      result.command?.should == true
-      result.void_command?.should == true
-      result.retval.should == Pry::Command::VOID_VALUE
+      result.command?.should eq true
+      result.void_command?.should eq true
+      result.retval.should eq Pry::Command::VOID_VALUE
     end
 
     it 'should return Result.new(true, retval) if the command is keep_retval' do
@@ -608,9 +608,9 @@ describe Pry::CommandSet do
       end
 
       result = @set.process_line('magrat')
-      result.command?.should == true
-      result.void_command?.should == false
-      result.retval.should == 42
+      result.command?.should eq true
+      result.void_command?.should eq false
+      result.retval.should eq 42
     end
 
     it 'should pass through context' do
@@ -657,7 +657,7 @@ describe Pry::CommandSet do
 
       it "should delegate to commands" do
         @set.create_command('susan'){ def complete(search); ['--foo']; end }
-        @set.complete('susan ').should == ['--foo']
+        @set.complete('susan ').should eq ['--foo']
       end
     end
   end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -32,7 +32,7 @@ describe "Pry::Command" do
         end
       end
 
-      mock_command(cmd).return.should == Pry::Command::VOID_VALUE
+      mock_command(cmd).return.should eq Pry::Command::VOID_VALUE
     end
 
     it 'should return the return value with keep_retval' do
@@ -42,7 +42,7 @@ describe "Pry::Command" do
         end
       end
 
-      mock_command(cmd).return.should == 5
+      mock_command(cmd).return.should eq 5
     end
 
     it 'should call hooks in the right order' do
@@ -67,7 +67,7 @@ describe "Pry::Command" do
         output.puts 5 + i.to_i
       end
 
-      mock_command(cmd, %w(2)).output.should == "3\n4\n5\n6\n7\n"
+      mock_command(cmd, %w(2)).output.should eq "3\n4\n5\n6\n7\n"
     end
 
     # TODO: This strikes me as rather silly...
@@ -82,7 +82,7 @@ describe "Pry::Command" do
         10
       end
 
-      mock_command(cmd).return.should == 10
+      mock_command(cmd).return.should eq 10
     end
   end
 
@@ -202,7 +202,7 @@ describe "Pry::Command" do
         end
       end
 
-      mock_command(cmd).output.should == "setup\nsubcommands\noptions\nprocess\n"
+      mock_command(cmd).output.should eq "setup\nsubcommands\noptions\nprocess\n"
     end
 
     it 'should raise a command error if process is not overridden' do
@@ -222,7 +222,7 @@ describe "Pry::Command" do
         end
       end
 
-      mock_command(cmd).return.should == 5
+      mock_command(cmd).return.should eq 5
     end
 
     it 'should provide opts and args as provided by slop' do
@@ -241,13 +241,13 @@ describe "Pry::Command" do
     end
 
     it 'should allow overriding options after definition' do
-      cmd = @set.create_command /number-(one|two)/, "Lieutenants of the Golgafrinchan Captain", :shellwords => false do
+      cmd = @set.create_command(/number-(one|two)/, "Lieutenants of the Golgafrinchan Captain", :shellwords => false) do
 
         command_options :listing => 'number-one'
       end
 
-      cmd.command_options[:shellwords].should == false
-      cmd.command_options[:listing].should == 'number-one'
+      cmd.command_options[:shellwords].should eq false
+      cmd.command_options[:listing].should eq 'number-one'
     end
 
     it "should create subcommands" do
@@ -301,16 +301,16 @@ describe "Pry::Command" do
       before do
         @x = Class.new(Pry::ClassCommand) do
           options :baby => :pig
-          match /goat/
+          match(/goat/)
           description "waaaninngggiiigygygygygy"
         end
       end
 
       it 'subclasses should inherit options, match and description from superclass' do
         k = Class.new(@x)
-        k.options.should == @x.options
-        k.match.should == @x.match
-        k.description.should == @x.description
+        k.options.should eq @x.options
+        k.match.should eq @x.match
+        k.description.should eq @x.description
       end
     end
   end
@@ -320,8 +320,8 @@ describe "Pry::Command" do
       expect { |probe|
         cmd = @set.command('random-dent', &probe)
 
-        foo = 5
-        cmd.new(:target => binding).process_line 'random-dent #{1 + 2} #{3 + foo}'
+        _foo = 5
+        cmd.new(:target => binding).process_line 'random-dent #{1 + 2} #{3 + _foo}'
       }.to yield_with_args('3', '8')
     end
 
@@ -371,13 +371,13 @@ describe "Pry::Command" do
       old = Pry.config.collision_warning
       Pry.config.collision_warning = true
 
-      cmd = @set.command 'frankie' do
+      cmd = @set.command '_frankie' do
 
       end
 
-      frankie = 'boyle'
+      _frankie = 'boyle'
       output = StringIO.new
-      cmd.new(:target => binding, :output => output).process_line %(frankie mouse)
+      cmd.new(:target => binding, :output => output).process_line %(_frankie mouse)
 
       output.string.should =~ /command .* conflicts/
 
@@ -435,7 +435,7 @@ describe "Pry::Command" do
         end
       EOS
 
-      @context.instance_variable_get(:@x).should == :jesus
+      @context.instance_variable_get(:@x).should eq :jesus
     end
 
     it 'should accept normal parameters along with block' do
@@ -449,25 +449,25 @@ describe "Pry::Command" do
 
       @t.eval 'walking-spanish john carl| { :jesus }'
 
-      @context.instance_variable_get(:@x).should == "john"
-      @context.instance_variable_get(:@y).should == "carl"
-      @context.instance_variable_get(:@block_var).should == :jesus
+      @context.instance_variable_get(:@x).should eq "john"
+      @context.instance_variable_get(:@y).should eq "carl"
+      @context.instance_variable_get(:@block_var).should eq :jesus
     end
 
     describe "single line blocks" do
       it 'should accept blocks with do ; end' do
         @t.eval 'walking-spanish | do ; :jesus; end'
-        @context.instance_variable_get(:@x).should == :jesus
+        @context.instance_variable_get(:@x).should eq :jesus
       end
 
       it 'should accept blocks with do; end' do
         @t.eval 'walking-spanish | do; :jesus; end'
-        @context.instance_variable_get(:@x).should == :jesus
+        @context.instance_variable_get(:@x).should eq :jesus
       end
 
       it 'should accept blocks with { }' do
         @t.eval 'walking-spanish | { :jesus }'
-        @context.instance_variable_get(:@x).should == :jesus
+        @context.instance_variable_get(:@x).should eq :jesus
       end
     end
 
@@ -482,7 +482,7 @@ describe "Pry::Command" do
 
           @t.eval 'walking-spanish john| { :jesus }'
 
-          @context.instance_variable_get(:@arg_string).should == @context.instance_variable_get(:@x)
+          @context.instance_variable_get(:@arg_string).should eq @context.instance_variable_get(:@x)
         end
 
         it 'should remove block-related content from arg_string (with no normal args)' do
@@ -492,7 +492,7 @@ describe "Pry::Command" do
 
           @t.eval 'walking-spanish | { :jesus }'
 
-          @context.instance_variable_get(:@arg_string).should == ""
+          @context.instance_variable_get(:@arg_string).should eq ""
         end
 
         it 'should NOT remove block-related content from arg_string when :takes_block => false' do
@@ -503,7 +503,7 @@ describe "Pry::Command" do
 
           @t.eval "walking-spanish #{block_string}"
 
-          @context.instance_variable_get(:@arg_string).should == block_string
+          @context.instance_variable_get(:@arg_string).should eq block_string
         end
       end
 
@@ -517,8 +517,8 @@ describe "Pry::Command" do
 
             @t.eval 'walking-spanish | { :jesus }'
 
-            @context.instance_variable_get(:@x).should == nil
-            @context.instance_variable_get(:@y).should == nil
+            @context.instance_variable_get(:@x).should eq nil
+            @context.instance_variable_get(:@y).should eq nil
           end
 
           it "should NOT remove block-related content from arguments if :takes_block => false" do
@@ -529,8 +529,8 @@ describe "Pry::Command" do
 
             @t.eval 'walking-spanish | { :jesus }'
 
-            @context.instance_variable_get(:@x).should == "|"
-            @context.instance_variable_get(:@y).should == "{"
+            @context.instance_variable_get(:@x).should eq "|"
+            @context.instance_variable_get(:@y).should eq "{"
           end
         end
 
@@ -545,8 +545,8 @@ describe "Pry::Command" do
 
             @t.eval 'walking-spanish | { :jesus }'
 
-            @context.instance_variable_get(:@x).should == nil
-            @context.instance_variable_get(:@y).should == nil
+            @context.instance_variable_get(:@x).should eq nil
+            @context.instance_variable_get(:@y).should eq nil
           end
 
           it "should NOT remove block-related content from arguments if :takes_block => false" do
@@ -559,8 +559,8 @@ describe "Pry::Command" do
 
             @t.eval 'walking-spanish | { :jesus }'
 
-            @context.instance_variable_get(:@x).should == "|"
-            @context.instance_variable_get(:@y).should == "{"
+            @context.instance_variable_get(:@x).should eq "|"
+            @context.instance_variable_get(:@y).should eq "{"
           end
         end
       end
@@ -575,7 +575,7 @@ describe "Pry::Command" do
 
           @t.eval 'walking-spanish | { |x, y| [x, y] }'
 
-          @context.instance_variable_get(:@x).should == [1, 2]
+          @context.instance_variable_get(:@x).should eq [1, 2]
         end
       end
 
@@ -593,7 +593,7 @@ describe "Pry::Command" do
             end
           EOS
 
-          @context.instance_variable_get(:@x).should == [1, 2]
+          @context.instance_variable_get(:@x).should eq [1, 2]
         end
       end
     end
@@ -601,7 +601,7 @@ describe "Pry::Command" do
     describe "closure behaviour" do
       it 'should close over locals in the definition context' do
         @t.eval 'var = :hello', 'walking-spanish | { var }'
-        @context.instance_variable_get(:@x).should == :hello
+        @context.instance_variable_get(:@x).should eq :hello
       end
     end
 
@@ -614,7 +614,7 @@ describe "Pry::Command" do
 
           @t.eval 'walking-spanish | { :jesus }'
 
-          @context.instance_variable_get(:@x).should == :jesus
+          @context.instance_variable_get(:@x).should eq :jesus
         end
       end
 
@@ -639,7 +639,7 @@ describe "Pry::Command" do
 
           @t.eval 'walking-spanish | { :jesus }'
 
-          @context.instance_variable_get(:@x).should == :jesus
+          @context.instance_variable_get(:@x).should eq :jesus
         end
       end
     end
@@ -649,10 +649,12 @@ describe "Pry::Command" do
 
     before do
       class MyTestCommand < Pry::ClassCommand
-        match /my-*test/
+        match(/my-*test/)
         description 'So just how many sound technicians does it take to' \
           'change a lightbulb? 1? 2? 3? 1-2-3? Testing?'
         options :shellwords => false, :listing => 'my-test'
+
+        undef process if method_defined? :process
 
         def process
           output.puts command_name * 2
@@ -686,7 +688,7 @@ describe "Pry::Command" do
           :use_prefix        => true,
           :takes_block       => false
         }
-        MyTestCommand.options.should == options_hash
+        MyTestCommand.options.should eq options_hash
       end
 
       describe ":listing option" do
@@ -697,7 +699,7 @@ describe "Pry::Command" do
           end
           Pry.config.commands.add_command HappyNewYear
 
-          HappyNewYear.options[:listing].should == 'happy-new-year'
+          HappyNewYear.options[:listing].should eq 'happy-new-year'
 
           Pry.config.commands.delete 'happy-new-year'
         end
@@ -710,7 +712,7 @@ describe "Pry::Command" do
           end
           Pry.config.commands.add_command MerryChristmas
 
-          MerryChristmas.options[:listing].should == 'happy-holidays'
+          MerryChristmas.options[:listing].should eq 'happy-holidays'
 
           Pry.config.commands.delete 'merry-christmas'
         end
@@ -722,9 +724,9 @@ describe "Pry::Command" do
           end
           Pry.config.commands.add_command CoolWinter
 
-          CoolWinter.options[:listing].should == '/.*winter/'
+          CoolWinter.options[:listing].should eq '/.*winter/'
 
-          Pry.config.commands.delete /.*winter/
+          Pry.config.commands.delete(/.*winter/)
         end
       end
     end
@@ -747,7 +749,7 @@ describe "Pry::Command" do
           end
         end
 
-        create_command /[Hh]ello-world/, "desc" do
+        create_command(/[Hh]ello-world/, "desc") do
           def process
             state.my_state ||= 0
             state.my_state += 2
@@ -761,25 +763,25 @@ describe "Pry::Command" do
 
     it 'should save state for the command on the Pry#command_state hash' do
       @t.eval 'litella'
-      @t.pry.command_state["litella"].my_state.should == 1
+      @t.pry.command_state["litella"].my_state.should eq 1
     end
 
     it 'should ensure state is maintained between multiple invocations of command' do
       @t.eval 'litella'
       @t.eval 'litella'
-      @t.pry.command_state["litella"].my_state.should == 2
+      @t.pry.command_state["litella"].my_state.should eq 2
     end
 
     it 'should ensure state with same name stored seperately for each command' do
       @t.eval 'litella', 'sanders'
 
-      @t.pry.command_state["litella"].my_state.should == 1
+      @t.pry.command_state["litella"].my_state.should eq 1
       @t.pry.command_state["sanders"].my_state.should =="wood"
     end
 
     it 'should ensure state is properly saved for regex commands' do
       @t.eval 'hello-world', 'Hello-world'
-      @t.pry.command_state[/[Hh]ello-world/].my_state.should == 4
+      @t.pry.command_state[/[Hh]ello-world/].my_state.should eq 4
     end
   end
 
@@ -809,17 +811,17 @@ describe "Pry::Command" do
     end
 
     it 'should be correct for default commands' do
-      @set["help"].group.should == "Help"
+      @set["help"].group.should eq "Help"
     end
 
     it 'should not change once it is initialized' do
       @set["magic"].group("-==CD COMMAND==-")
-      @set["magic"].group.should == "Not for a public use"
+      @set["magic"].group.should eq "Not for a public use"
     end
 
     it 'should not disappear after the call without parameters' do
       @set["magic"].group
-      @set["magic"].group.should == "Not for a public use"
+      @set["magic"].group.should eq "Not for a public use"
     end
   end
 end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -232,12 +232,13 @@ describe "Pry::Command" do
         end
 
         def process
-          args.should == ['four']
-          opts[:f].should == 4
+          output.puts args.inspect
+          output.puts opts[:f]
         end
       end
 
-      mock_command(cmd, %w(--four 4 four))
+      result = mock_command(cmd, %w(--four 4 four))
+      result.output.split.should eq ['["four"]', '4']
     end
 
     it 'should allow overriding options after definition' do
@@ -257,12 +258,13 @@ describe "Pry::Command" do
         end
 
         def process
-          opts.fetch_command(:blahblah).should == nil
-          opts.fetch_command(:yell).present?.should == true
+          output.puts opts.fetch_command(:blahblah).inspect
+          output.puts opts.fetch_command(:yell).present?
         end
       end
 
-      mock_command(cmd, ['yell'])
+      result = mock_command(cmd, ['yell'])
+      result.output.split.should eq ['nil', 'true']
     end
 
     it "should create subcommand options" do
@@ -274,13 +276,14 @@ describe "Pry::Command" do
         end
 
         def process
-          args.should == ['papa']
-          opts.fetch_command(:yell).present?.should == true
-          opts.fetch_command(:yell).person?.should == true
+          output.puts args.inspect
+          output.puts opts.fetch_command(:yell).present?
+          output.puts opts.fetch_command(:yell).person?
         end
       end
 
-      mock_command(cmd, %w|yell --person papa|)
+      result = mock_command(cmd, %w|yell --person papa|)
+      result.output.split.should eq ['["papa"]', 'true', 'true']
     end
 
     it "should accept top-level arguments" do

--- a/spec/commands/amend_line_spec.rb
+++ b/spec/commands/amend_line_spec.rb
@@ -6,21 +6,21 @@ describe "amend-line" do
   end
 
   it 'should amend the last line of input when no line number specified' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
     STR
 
     @t.process_command 'amend-line   puts :blah'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def hello
         puts :blah
     STR
   end
 
   it 'should amend the specified line of input when line number given' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -28,7 +28,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 1 def goodbye'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def goodbye
         puts :bing
         puts :bang
@@ -36,7 +36,7 @@ describe "amend-line" do
   end
 
   it 'should amend the first line of input when 0 given as line number' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -44,7 +44,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 0 def goodbye'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def goodbye
         puts :bing
         puts :bang
@@ -52,7 +52,7 @@ describe "amend-line" do
   end
 
   it 'should amend a specified line when negative number given' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -60,7 +60,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line -1   puts :bink'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def hello
         puts :bing
         puts :bink
@@ -68,7 +68,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line -2   puts :bink'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def hello
         puts :bink
         puts :bink
@@ -76,7 +76,7 @@ describe "amend-line" do
   end
 
   it 'should amend a range of lines of input when negative numbers given' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -85,7 +85,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line -3..-2   puts :bink'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def hello
         puts :bink
         puts :boat
@@ -93,7 +93,7 @@ describe "amend-line" do
   end
 
   it 'should correctly amend the specified line with interpolated text' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -101,7 +101,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line   puts "#{goodbye}"'
 
-    @t.eval_string.should == unindent(<<-'STR')
+    @t.eval_string.should eq unindent(<<-'STR')
       def hello
         puts :bing
         puts "#{goodbye}"
@@ -122,7 +122,7 @@ describe "amend-line" do
   end
 
   it 'should correctly amend the specified range of lines' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -131,7 +131,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 2..3   puts :bong'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def hello
         puts :bong
         puts :heart
@@ -139,7 +139,7 @@ describe "amend-line" do
   end
 
   it 'should correctly delete a specific line using the ! for content' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -149,7 +149,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 3 !'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def hello
         puts :bing
         puts :boast
@@ -158,7 +158,7 @@ describe "amend-line" do
   end
 
   it 'should correctly delete a range of lines using the ! for content' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -168,14 +168,14 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 2..4 !'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def hello
         puts :heart
     STR
   end
 
   it 'should correctly delete the previous line using the ! for content' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -185,7 +185,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line !'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def hello
         puts :bing
         puts :bang
@@ -194,7 +194,7 @@ describe "amend-line" do
   end
 
   it 'should amend the specified range of lines, with numbers < 0 in range' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -204,7 +204,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 2..-2   puts :bong'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def hello
         puts :bong
         puts :heart
@@ -212,7 +212,7 @@ describe "amend-line" do
   end
 
   it 'should correctly insert a line before a specified line using >' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -220,7 +220,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 2 >  puts :inserted'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def hello
         puts :inserted
         puts :bing
@@ -229,7 +229,7 @@ describe "amend-line" do
   end
 
   it 'should ignore second value of range with > syntax' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
         puts :bang
@@ -237,7 +237,7 @@ describe "amend-line" do
 
     @t.process_command 'amend-line 2..21 >  puts :inserted'
 
-    @t.eval_string.should == unindent(<<-STR)
+    @t.eval_string.should eq unindent(<<-STR)
       def hello
         puts :inserted
         puts :bing

--- a/spec/commands/cat/file_formatter_spec.rb
+++ b/spec/commands/cat/file_formatter_spec.rb
@@ -13,32 +13,32 @@ describe Pry::Command::Cat::FileFormatter do
         file_with_embedded_line = "C:/Ruby193/pry_instance.rb"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "C:/Ruby193/pry_instance.rb"
-        line_num.should == nil
+        file_name.should eq "C:/Ruby193/pry_instance.rb"
+        line_num.should eq nil
       end
 
       it "should parse '/'style absolute path with line_num" do
         file_with_embedded_line = "C:/Ruby193/pry_instance.rb:2"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "C:/Ruby193/pry_instance.rb"
-        line_num.should == 2
+        file_name.should eq "C:/Ruby193/pry_instance.rb"
+        line_num.should eq 2
       end
 
       it "should parse '\\'style absolute path without line_num" do
         file_with_embedded_line = "C:\\Ruby193\\pry_instance.rb"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "C:\\Ruby193\\pry_instance.rb"
-        line_num.should == nil
+        file_name.should eq "C:\\Ruby193\\pry_instance.rb"
+        line_num.should eq nil
       end
 
       it "should parse '\\'style absolute path with line_num" do
         file_with_embedded_line = "C:\\Ruby193\\pry_instance.rb:2"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "C:\\Ruby193\\pry_instance.rb"
-        line_num.should == 2
+        file_name.should eq "C:\\Ruby193\\pry_instance.rb"
+        line_num.should eq 2
       end
     end
 
@@ -47,16 +47,16 @@ describe Pry::Command::Cat::FileFormatter do
         file_with_embedded_line = "/Ruby193/pry_instance.rb"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "/Ruby193/pry_instance.rb"
-        line_num.should == nil
+        file_name.should eq "/Ruby193/pry_instance.rb"
+        line_num.should eq nil
       end
 
       it "should parse absolute path with line_num" do
         file_with_embedded_line = "/Ruby193/pry_instance.rb:2"
         ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
         file_name, line_num = ff.file_and_line
-        file_name.should == "/Ruby193/pry_instance.rb"
-        line_num.should == 2
+        file_name.should eq "/Ruby193/pry_instance.rb"
+        line_num.should eq 2
       end
     end
 
@@ -64,16 +64,16 @@ describe Pry::Command::Cat::FileFormatter do
       file_with_embedded_line = "pry_instance.rb"
       ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
       file_name, line_num = ff.file_and_line
-      file_name.should == "pry_instance.rb"
-      line_num.should == nil
+      file_name.should eq "pry_instance.rb"
+      line_num.should eq nil
     end
 
     it "should parse relative path with line_num" do
       file_with_embedded_line = "pry_instance.rb:2"
       ff = Pry::Command::Cat::FileFormatter.new(file_with_embedded_line, @p, @opt)
       file_name, line_num = ff.file_and_line
-      file_name.should == "pry_instance.rb"
-      line_num.should == 2
+      file_name.should eq "pry_instance.rb"
+      line_num.should eq 2
     end
   end
 end

--- a/spec/commands/disable_pry_spec.rb
+++ b/spec/commands/disable_pry_spec.rb
@@ -14,8 +14,8 @@ describe "disable-pry" do
   end
 
   it "should set DISABLE_PRY" do
-    ENV['DISABLE_PRY'].should == nil
+    ENV['DISABLE_PRY'].should eq nil
     expect { @t.process_command 'disable-pry' }.to throw_symbol :breakout
-    ENV['DISABLE_PRY'].should == 'true'
+    ENV['DISABLE_PRY'].should eq 'true'
   end
 end

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -314,11 +314,13 @@ describe "edit" do
     end
 
     it "should edit the previous expression if the current is empty" do
+      @t.eval 'undef a if self.singleton_class.method_defined? :a'
       @t.eval 'def a; 2; end', 'edit'
       @contents.should eq "def a; 2; end\n"
     end
 
     it "should use a blank file if -t is specified" do
+      @t.eval 'undef a if self.singleton_class.method_defined? :a'
       @t.eval 'def a; 5; end', 'edit -t'
       @contents.should eq "\n"
     end
@@ -330,6 +332,7 @@ describe "edit" do
     end
 
     it "should position the cursor at the end of the expression" do
+      @t.eval 'undef a if self.singleton_class.method_defined? :a'
       @t.eval "def a; 2;\nend"
       @t.process_command 'edit'
       @line.should eq 2

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -31,7 +31,7 @@ describe "edit" do
     end
 
     after do
-      FileUtils.rm(@tf_path) if File.exists?(@tf_path)
+      FileUtils.rm(@tf_path) if File.exist?(@tf_path)
     end
 
     it "should not allow patching any known kind of file" do
@@ -43,32 +43,32 @@ describe "edit" do
 
     it "should invoke Pry.config.editor with absolutified filenames" do
       pry_eval 'edit lib/pry.rb'
-      @file.should == File.expand_path('lib/pry.rb')
+      @file.should eq File.expand_path('lib/pry.rb')
 
       pry_eval "edit #@tf_path"
-      @file.should == @tf_path
+      @file.should eq @tf_path
     end
 
     it "should guess the line number from a colon" do
       pry_eval 'edit lib/pry.rb:10'
-      @line.should == 10
+      @line.should eq 10
     end
 
     it "should use the line number from -l" do
       pry_eval 'edit -l 10 lib/pry.rb'
-      @line.should == 10
+      @line.should eq 10
     end
 
     it "should not delete the file!" do
       pry_eval 'edit Rakefile'
-      File.exist?(@file).should == true
+      File.exist?(@file).should eq true
     end
 
     it "works with files that contain blanks in their names" do
       tf_path = File.join(File.dirname(@tf_path), 'swoop and doop.rb')
       FileUtils.touch(tf_path)
       pry_eval "edit #{ tf_path }"
-      @file.should == tf_path
+      @file.should eq tf_path
       FileUtils.rm(tf_path)
     end
 
@@ -84,7 +84,7 @@ describe "edit" do
           nil
         }
         pry_eval "edit #@tf_path"
-        Pad.required.should == true
+        Pad.required.should eq true
       end
     end
 
@@ -104,7 +104,7 @@ describe "edit" do
 
           pry_eval "edit #{path}"
 
-          Pad.counter.should == counter + 1
+          Pad.counter.should eq counter + 1
         end
       end
 
@@ -115,7 +115,7 @@ describe "edit" do
 
           pry_eval "edit #{path}"
 
-          Pad.counter.should == counter
+          Pad.counter.should eq counter
         end
       end
 
@@ -124,7 +124,9 @@ describe "edit" do
           counter = Pad.counter
           path    = tf.path
 
-          Pad.counter.should == counter
+          pry_eval "edit -n #{path}"
+
+          Pad.counter.should eq counter
         end
       end
 
@@ -135,7 +137,7 @@ describe "edit" do
 
           pry_eval "edit -r #{path}"
 
-          Pad.counter.should == counter + 1
+          Pad.counter.should eq counter + 1
         end
       end
     end
@@ -151,9 +153,9 @@ describe "edit" do
 
       it "should pass the editor a reloading arg" do
         pry_eval 'edit lib/pry.rb'
-        @reloading.should == true
+        @reloading.should eq true
         pry_eval 'edit -n lib/pry.rb'
-        @reloading.should == false
+        @reloading.should eq false
       end
     end
   end
@@ -184,7 +186,7 @@ describe "edit" do
 
       after do
         @tf.close(true)
-        File.unlink("#{@path}c") if File.exists?("#{@path}c") #rbx
+        File.unlink("#{@path}c") if File.exist?("#{@path}c") #rbx
       end
 
       it "should reload the file" do
@@ -200,7 +202,7 @@ describe "edit" do
 
         @t.eval 'edit --ex'
 
-        FOO.should == 'BAR'
+        FOO.should eq 'BAR'
       end
 
       # regression test (this used to edit the current method instead
@@ -220,7 +222,7 @@ describe "edit" do
           Object.new.pry
         end
 
-        source_location.should == [@path, 3]
+        source_location.should eq [@path, 3]
         Pad.clear
       end
 
@@ -250,11 +252,11 @@ describe "edit" do
 
           @t.eval 'edit --ex --patch'
 
-          FOO3.should == 'PIYO'
+          FOO3.should eq 'PIYO'
 
           @tf.rewind
-          @tf.read.should == "1\n2\nraise RuntimeError"
-          @patched_def.should == "FOO3 = 'PIYO'"
+          @tf.read.should eq "1\n2\nraise RuntimeError"
+          @patched_def.should eq "FOO3 = 'PIYO'"
         end
       end
     end
@@ -272,26 +274,26 @@ describe "edit" do
 
       it 'should start on first level of backtrace with just --ex' do
         @t.eval 'edit -n --ex'
-        @__ex_file__.should == "a"
-        @__ex_line__.should == 1
+        @__ex_file__.should eq "a"
+        @__ex_line__.should eq 1
       end
 
       it 'should start editor on first level of backtrace with --ex 0' do
         @t.eval 'edit -n --ex 0'
-        @__ex_file__.should == "a"
-        @__ex_line__.should == 1
+        @__ex_file__.should eq "a"
+        @__ex_line__.should eq 1
       end
 
       it 'should start editor on second level of backtrace with --ex 1' do
         @t.eval 'edit -n --ex 1'
-        @__ex_file__.should == "b"
-        @__ex_line__.should == 2
+        @__ex_file__.should eq "b"
+        @__ex_line__.should eq 2
       end
 
       it 'should start editor on third level of backtrace with --ex 2' do
         @t.eval 'edit -n --ex 2'
-        @__ex_file__.should == "c"
-        @__ex_line__.should == 3
+        @__ex_file__.should eq "c"
+        @__ex_line__.should eq 3
       end
 
       it 'should display error message when backtrace level is invalid' do
@@ -308,29 +310,29 @@ describe "edit" do
     it "should edit the current expression if it's incomplete" do
       @t.push 'def a'
       @t.process_command 'edit'
-      @contents.should == "def a\n"
+      @contents.should eq "def a\n"
     end
 
     it "should edit the previous expression if the current is empty" do
       @t.eval 'def a; 2; end', 'edit'
-      @contents.should == "def a; 2; end\n"
+      @contents.should eq "def a; 2; end\n"
     end
 
     it "should use a blank file if -t is specified" do
       @t.eval 'def a; 5; end', 'edit -t'
-      @contents.should == "\n"
+      @contents.should eq "\n"
     end
 
     it "should use a blank file if -t given, even during an expression" do
       @t.push 'def a;'
       @t.process_command 'edit -t'
-      @contents.should == "\n"
+      @contents.should eq "\n"
     end
 
     it "should position the cursor at the end of the expression" do
       @t.eval "def a; 2;\nend"
       @t.process_command 'edit'
-      @line.should == 2
+      @line.should eq 2
     end
 
     it "should evaluate the expression" do
@@ -339,7 +341,7 @@ describe "edit" do
         nil
       }
       @t.process_command 'edit'
-      @t.eval_string.should == "'FOO'\n"
+      @t.eval_string.should eq "'FOO'\n"
     end
 
     it "should ignore -n for tempfiles" do
@@ -348,7 +350,7 @@ describe "edit" do
         nil
       }
       @t.process_command "edit -n"
-      @t.eval_string.should == "'FOO'\n"
+      @t.eval_string.should eq "'FOO'\n"
     end
 
     it "should not evaluate a file with -n" do
@@ -358,8 +360,8 @@ describe "edit" do
       }
       begin
         @t.process_command 'edit -n spec/fixtures/foo.rb'
-        File.read("spec/fixtures/foo.rb").should == "'FOO'\n"
-        @t.eval_string.should == ''
+        File.read("spec/fixtures/foo.rb").should eq "'FOO'\n"
+        @t.eval_string.should eq ''
       ensure
         FileUtils.rm "spec/fixtures/foo.rb"
       end
@@ -369,22 +371,22 @@ describe "edit" do
   describe "with --in" do
     it "should edit the nth line of _in_" do
       pry_eval '10', '11', 'edit --in -2'
-      @contents.should == "10\n"
+      @contents.should eq "10\n"
     end
 
     it "should edit the last line if no argument is given" do
       pry_eval '10', '11', 'edit --in'
-      @contents.should == "11\n"
+      @contents.should eq "11\n"
     end
 
     it "should edit a range of lines if a range is given" do
       pry_eval "10", "11", "edit -i 1,2"
-      @contents.should == "10\n11\n"
+      @contents.should eq "10\n11\n"
     end
 
     it "should edit a multi-line expression as it occupies one line of _in_" do
       pry_eval "class Fixnum\n  def invert; -self; end\nend", "edit -i 1"
-      @contents.should == "class Fixnum\n  def invert; -self; end\nend\n"
+      @contents.should eq "class Fixnum\n  def invert; -self; end\nend\n"
     end
 
     it "should not work with a filename" do
@@ -398,7 +400,6 @@ describe "edit" do
 
   describe 'when editing a method by name' do
     def use_editor(tester, options)
-      initial_editor = tester.pry.editor
       tester.pry.config.editor = lambda do |filename, line|
         File.open(filename, 'w') { |f| f.write options.fetch(:replace_all) }
         nil
@@ -414,18 +415,18 @@ describe "edit" do
       klass    = Class.new do
         def m; 1; end
       end
-      klass.new.m.should == 1
+      klass.new.m.should eq 1
 
       # now patch it
       use_editor(tester, replace_all: 'def m; 2; end').eval('edit --patch klass#m')
-      klass.new.m.should == 2
+      klass.new.m.should eq 2
 
       # edit by name, no --patch
       use_editor(tester, replace_all: 'def m; 3; end').eval("edit klass#m")
-      klass.new.m.should == 3
+      klass.new.m.should eq 3
 
       # original file is unchanged
-      File.readlines(filename)[line-1].strip.should == 'def m; 1; end'
+      File.readlines(filename)[line-1].strip.should eq 'def m; 1; end'
     end
 
     it 'can repeatedly edit methods that were defined in the console' do
@@ -434,21 +435,23 @@ describe "edit" do
       tester.eval("klass = Class.new do\n"\
                   "  def m; 1; end\n"\
                   "end")
-      tester.eval("klass.new.m").should == 1
+      tester.eval("klass.new.m").should eq 1
 
       # first edit
       use_editor(tester, replace_all: 'def m; 2; end').eval('edit klass#m')
-      tester.eval('klass.new.m').should == 2
+      tester.eval('klass.new.m').should eq 2
 
       # repeat edit
       use_editor(tester, replace_all: 'def m; 3; end').eval('edit klass#m')
-      tester.eval('klass.new.m').should == 3
+      tester.eval('klass.new.m').should eq 3
     end
   end
 
   describe "old edit-method tests now migrated to edit" do
     describe "on a method defined in a file" do
       before do
+        Object.remove_const :X if defined? ::X
+        Object.remove_const :A if defined? ::A
         @tempfile = (Tempfile.new(['pry', '.rb']))
         @tempfile.puts <<-EOS
         module A
@@ -485,7 +488,7 @@ describe "edit" do
             G = :nawt
 
             def foo
-              :possibly
+              _foo = :possibly
               G
             end
           end
@@ -513,33 +516,33 @@ describe "edit" do
         it "should correctly find a class method" do
           pry_eval 'edit X.x'
 
-          @file.should == @tempfile_path
-          @line.should == 14
+          @file.should eq @tempfile_path
+          @line.should eq 14
 
         end
 
         it "should correctly find an instance method" do
           pry_eval 'edit X#x'
-          @file.should == @tempfile_path
-          @line.should == 18
+          @file.should eq @tempfile_path
+          @line.should eq 18
         end
 
         it "should correctly find a method on an instance" do
           pry_eval 'x = X.new', 'edit x.x'
-          @file.should == @tempfile_path
-          @line.should == 18
+          @file.should eq @tempfile_path
+          @line.should eq 18
         end
 
         it "should correctly find a method from a module" do
           pry_eval 'edit X#a'
-          @file.should == @tempfile_path
-          @line.should == 2
+          @file.should eq @tempfile_path
+          @line.should eq 2
         end
 
         it "should correctly find an aliased method" do
           pry_eval 'edit X#c'
-          @file.should == @tempfile_path
-          @line.should == 22
+          @file.should eq @tempfile_path
+          @line.should eq 22
         end
       end
 
@@ -562,44 +565,44 @@ describe "edit" do
           class << X
             X.method(:x).owner.should == self
           end
-          X.method(:x).receiver.should == X
-          X.x.should == :maybe
+          X.method(:x).receiver.should eq X
+          X.x.should eq :maybe
         end
 
         it "should successfully replace an instance method" do
           pry_eval 'edit -p X#x'
 
-          X.instance_method(:x).owner.should == X
-          X.new.x.should == :maybe
+          X.instance_method(:x).owner.should eq X
+          X.new.x.should eq :maybe
         end
 
         it "should successfully replace a method on an instance" do
           pry_eval 'instance = X.new', 'edit -p instance.x'
 
           instance = X.new
-          instance.method(:x).owner.should == X
-          instance.x.should == :maybe
+          instance.method(:x).owner.should eq X
+          instance.x.should eq :maybe
         end
 
         it "should successfully replace a method from a module" do
           pry_eval 'edit -p X#a'
 
-          X.instance_method(:a).owner.should == A
-          X.new.a.should == :maybe
+          X.instance_method(:a).owner.should eq A
+          X.new.a.should eq :maybe
         end
 
         it "should successfully replace a method with a question mark" do
           pry_eval 'edit -p X#y?'
 
-          X.instance_method(:y?).owner.should == X
-          X.new.y?.should == :maybe
+          X.instance_method(:y?).owner.should eq X
+          X.new.y?.should eq :maybe
         end
 
         it "should preserve module nesting" do
           pry_eval 'edit -p X::B#foo'
 
-          X::B.instance_method(:foo).owner.should == X::B
-          X::B.new.foo.should == :nawt
+          X::B.instance_method(:foo).owner.should eq X::B
+          X::B.new.foo.should eq :nawt
         end
 
         describe "monkey-patching" do
@@ -611,7 +614,7 @@ describe "edit" do
           # @return [String] the stripped line from the tempfile at +lineno+
           def stripped_line_at(lineno)
             @tempfile.rewind
-            @tempfile.lines.to_a[lineno].strip
+            @tempfile.each_line.to_a[lineno].strip
           end
 
           # Applies the monkey patch for +method+ with help of evaluation of
@@ -638,54 +641,54 @@ describe "edit" do
             def_before, def_after =
               apply_monkey_patch(X.method(:x), "#@edit X.x")
 
-            def_before.should   == ':double_yup'
-            def_after.should    == ':double_yup'
-            @patched_def.should == ':maybe'
+            def_before.should   eq ':double_yup'
+            def_after.should    eq ':double_yup'
+            @patched_def.should eq ':maybe'
           end
 
           it "should work for an instance method" do
             def_before, def_after =
               apply_monkey_patch(X.instance_method(:x), "#@edit X#x")
 
-            def_before.should   == ':nope'
-            def_after.should    == ':nope'
-            @patched_def.should == ':maybe'
+            def_before.should   eq ':nope'
+            def_after.should    eq ':nope'
+            @patched_def.should eq ':maybe'
           end
 
           it "should work for a method on an instance" do
             def_before, def_after =
               apply_monkey_patch(X.instance_method(:x), 'instance = X.new', "#@edit instance.x")
 
-            def_before.should   == ':nope'
-            def_after.should    == ':nope'
-            @patched_def.should == ':maybe'
+            def_before.should   eq ':nope'
+            def_after.should    eq ':nope'
+            @patched_def.should eq ':maybe'
           end
 
           it "should work for a method from a module" do
             def_before, def_after =
               apply_monkey_patch(X.instance_method(:a), "#@edit X#a")
 
-            def_before.should   == ':yup'
-            def_after.should    == ':yup'
-            @patched_def.should == ':maybe'
+            def_before.should   eq ':yup'
+            def_after.should    eq ':yup'
+            @patched_def.should eq ':maybe'
           end
 
           it "should work for a method with a question mark" do
             def_before, def_after =
               apply_monkey_patch(X.instance_method(:y?), "#@edit X#y?")
 
-            def_before.should   == ':because'
-            def_after.should    == ':because'
-            @patched_def.should == ':maybe'
+            def_before.should   eq ':because'
+            def_after.should    eq ':because'
+            @patched_def.should eq ':maybe'
           end
 
           it "should work with nesting" do
             def_before, def_after =
               apply_monkey_patch(X::B.instance_method(:foo), "#@edit X::B#foo")
 
-            def_before.should   == ':possibly'
-            def_after.should    == ':possibly'
-            @patched_def.should == ':maybe'
+            def_before.should   eq '_foo = :possibly'
+            def_after.should    eq '_foo = :possibly'
+            @patched_def.should eq ':maybe'
           end
         end
       end
@@ -708,10 +711,10 @@ describe "edit" do
           pry_eval 'edit -p X#c'
 
 
-          Pry::Method.from_str("X#c").alias?.should == true
+          Pry::Method.from_str("X#c").alias?.should eq true
 
-          X.new.b.should == :kinda
-          X.new.c.should == :kindaaa
+          X.new.b.should eq :kinda
+          X.new.c.should eq :kindaaa
           $x = nil
         end
       end
@@ -727,9 +730,9 @@ describe "edit" do
 
         it "should pass the editor a reloading arg" do
           pry_eval 'edit X.x'
-          @reloading.should == true
+          @reloading.should eq true
           pry_eval 'edit -n X.x'
-          @reloading.should == false
+          @reloading.should eq false
         end
       end
     end
@@ -746,7 +749,7 @@ describe "edit" do
         }
 
         def m2
-          :jeremy_jones
+          _foo = :jeremy_jones
           binding
         end
       end
@@ -758,7 +761,7 @@ describe "edit" do
 
     it 'should edit method context' do
       Pry.config.editor = lambda do |file, line|
-        [file, line].should == BinkyWink.instance_method(:m2).source_location
+        [file, line].should eq BinkyWink.instance_method(:m2).source_location
         nil
       end
 
@@ -768,7 +771,7 @@ describe "edit" do
 
     it 'errors when cannot find method context' do
       Pry.config.editor = lambda do |file, line|
-        [file, line].should == BinkyWink.instance_method(:m1).source_location
+        [file, line].should eq BinkyWink.instance_method(:m1).source_location
         nil
       end
 

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -550,7 +550,11 @@ describe "edit" do
         before do
           Pry.config.editor = lambda do |file, line|
             lines = File.read(file).lines.to_a
-            lines[1] = ":maybe\n"
+            lines[1] = if lines[2] =~ /end/
+                         ":maybe\n"
+                       else
+                         "_foo = :maybe\n"
+                       end
             File.open(file, 'w') do |f|
               f.write(lines.join)
             end
@@ -688,7 +692,7 @@ describe "edit" do
 
             def_before.should   eq '_foo = :possibly'
             def_after.should    eq '_foo = :possibly'
-            @patched_def.should eq ':maybe'
+            @patched_def.should eq '_foo = :maybe'
           end
         end
       end

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -174,7 +174,7 @@ describe "edit" do
       before do
         @tf = Tempfile.new(["pry", ".rb"])
         @path = @tf.path
-        @tf << "1\n2\nraise RuntimeError"
+        @tf << "_foo = 1\n_bar = 2\nraise RuntimeError"
         @tf.flush
 
         begin
@@ -255,7 +255,7 @@ describe "edit" do
           FOO3.should eq 'PIYO'
 
           @tf.rewind
-          @tf.read.should eq "1\n2\nraise RuntimeError"
+          @tf.read.should eq "_foo = 1\n_bar = 2\nraise RuntimeError"
           @patched_def.should eq "FOO3 = 'PIYO'"
         end
       end

--- a/spec/commands/exit_spec.rb
+++ b/spec/commands/exit_spec.rb
@@ -5,9 +5,9 @@ describe "exit" do
 
   it "should pop a binding" do
     @pry.eval "cd :inner"
-    @pry.evaluate_ruby("self").should == :inner
+    @pry.evaluate_ruby("self").should eq :inner
     @pry.eval "exit"
-    @pry.evaluate_ruby("self").should == :outer
+    @pry.evaluate_ruby("self").should eq :outer
   end
 
   it "should break out of the repl when binding_stack has only one binding" do
@@ -17,7 +17,7 @@ describe "exit" do
 
   it "should break out of the repl and return user-given value" do
     @pry.eval("exit :john").should equal false
-    @pry.exit_value.should == :john
+    @pry.exit_value.should eq :john
   end
 
   it "should break out of the repl even after an exception" do

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -17,7 +17,7 @@ describe "help" do
   end
 
   it 'should display help for a regex command with a "listing"' do
-    @set.command /bar(.*)/, "Test listing", :listing => "foo" do; end
+    @set.command(/bar(.*)/, "Test listing", :listing => "foo") do; end
     pry_eval('help foo').should =~ /Test listing/
   end
 
@@ -27,7 +27,7 @@ describe "help" do
   end
 
   it 'should display help for all commands with a description' do
-    @set.command /bar(.*)/, "Test listing", :listing => "foo" do; end
+    @set.command(/bar(.*)/, "Test listing", :listing => "foo") do; end
     @set.command "b", "description for b", :listing => "foo" do; end
     @set.command "c" do;end
     @set.command "d", "" do;end

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -24,7 +24,7 @@ describe "hist" do
     @t.push_binding o
     @t.eval 'hist --replay -1'
 
-    o.instance_variable_get(:@z).should == 30
+    o.instance_variable_get(:@z).should eq 30
   end
 
   it 'should replay a range of history correctly (range of items)' do
@@ -34,19 +34,18 @@ describe "hist" do
 
     @t.push_binding o
     @t.eval 'hist --replay 0..2'
-    @t.eval('[@x, @y]').should == [10, 20]
+    @t.eval('[@x, @y]').should eq [10, 20]
   end
 
   # this is to prevent a regression where input redirection is
   # replaced by just appending to `eval_string`
   it 'should replay a range of history correctly (range of commands)' do
-    o = Object.new
     @hist.push "cd 1"
     @hist.push "cd 2"
 
     @t.eval("hist --replay 0..2")
     stack = @t.eval("Pad.stack = _pry_.binding_stack.dup")
-    stack.map{ |b| b.eval("self") }.should == [TOPLEVEL_BINDING.eval("self"), 1, 2]
+    stack.map{ |b| b.eval("self") }.should eq [TOPLEVEL_BINDING.eval("self"), 1, 2]
   end
 
   it 'should grep for correct lines in history' do
@@ -75,7 +74,7 @@ describe "hist" do
     end
 
     out = @t.eval 'hist --tail 3'
-    out.each_line.count.should == 3
+    out.each_line.count.should eq 3
     out.should =~ /x\n\d+:.*y\n\d+:.*z/
   end
 
@@ -93,7 +92,7 @@ describe "hist" do
     @hist.push "puts  5"
 
     out = @t.eval 'hist --tail 2 --grep print'
-    out.each_line.count.should == 2
+    out.each_line.count.should eq 2
     out.should =~ /\d:.*?print 2\n\d:.*?print 4/
   end
 
@@ -105,7 +104,7 @@ describe "hist" do
     @hist.push "print 5"
 
     out = @t.eval 'hist --head 2 --grep print'
-    out.each_line.count.should == 2
+    out.each_line.count.should eq 2
     out.should =~ /\d:.*?print 2\n\d:.*?print 4/
   end
 
@@ -117,7 +116,7 @@ describe "hist" do
     end
 
     out = @t.eval 'hist --head 4'
-    out.each_line.count.should == 4
+    out.each_line.count.should eq 4
     out.should =~ /a\n\d+:.*b\n\d+:.*c/
   end
 
@@ -129,7 +128,7 @@ describe "hist" do
     end
 
     out = @t.eval 'hist --show 1..4'
-    out.each_line.count.should == 4
+    out.each_line.count.should eq 4
     out.should =~ /b\n\d+:.*c\n\d+:.*d/
   end
 
@@ -146,7 +145,7 @@ describe "hist" do
     @t.eval("hist --replay 1..3")
 
     output = @t.eval("hist")
-    output.should == "1: :banzai\n2: :geronimo\n3: :huzzah\n4: hist --replay 1..3\n"
+    output.should eq "1: :banzai\n2: :geronimo\n3: :huzzah\n4: hist --replay 1..3\n"
   end
 
   it "should raise CommandError when index of `--replay` points out to another `hist --replay`" do
@@ -161,14 +160,14 @@ describe "hist" do
     @t.eval "a += 1"
     @t.eval "hist --replay 2"
     expect { @t.eval "hist --replay 3" }.to raise_error Pry::CommandError
-    @t.eval("a").should == 2
-    @t.eval("hist").lines.to_a.size.should == 5
+    @t.eval("a").should eq 2
+    @t.eval("hist").lines.to_a.size.should eq 5
   end
 
   it "excludes Pry commands from the history with `-e` switch" do
     @hist.push('a = 20')
     @hist.push('ls')
-    pry_eval('hist -e').should == "1: a = 20\n"
+    pry_eval('hist -e').should eq "1: a = 20\n"
   end
 
   describe "sessions" do

--- a/spec/commands/jump_to_spec.rb
+++ b/spec/commands/jump_to_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe "jump-to" do
   end
 
   it 'prints an error when trying to jump to the same binding index' do
-    expect(pry_eval obj,  "cd 1", "cd 2", "jump-to 2").to match /Already/
+    expect(pry_eval obj,  "cd 1", "cd 2", "jump-to 2").to match(/Already/)
   end
 
   it 'prints error when trying to jump to a non-existent binding index' do
-    expect(pry_eval obj, "cd 1", "cd 2", "jump-to 3").to match /Invalid nest level/
+    expect(pry_eval obj, "cd 1", "cd 2", "jump-to 3").to match(/Invalid nest level/)
   end
 end

--- a/spec/commands/play_spec.rb
+++ b/spec/commands/play_spec.rb
@@ -39,7 +39,7 @@ describe "play" do
   describe "playing a file" do
     it 'should play a file' do
       @t.process_command 'play spec/fixtures/whereami_helper.rb'
-      @t.eval_string.should == unindent(<<-STR)
+      @t.eval_string.should eq unindent(<<-STR)
         class Cor
           def a; end
           def b; end
@@ -52,7 +52,7 @@ describe "play" do
 
     it 'should output file contents with print option' do
       @t.process_command 'play --print spec/fixtures/whereami_helper.rb'
-      @t.last_output.should == unindent(<<-STR)
+      @t.last_output.should eq unindent(<<-STR)
         1: class Cor
         2:   def a; end
         3:   def b; end
@@ -71,6 +71,8 @@ describe "play" do
     end
 
     it 'should play documentation with the -d switch' do
+      @o.singleton_class.send :remove_method, :test_method
+
       # @v = 10
       # @y = 20
       def @o.test_method
@@ -78,13 +80,15 @@ describe "play" do
       end
 
       @t.process_command 'play -d test_method'
-      @t.eval_string.should == unindent(<<-STR)
+      @t.eval_string.should eq unindent(<<-STR)
         @v = 10
         @y = 20
       STR
     end
 
     it 'should restrict -d switch with --lines' do
+      @o.singleton_class.send :remove_method, :test_method
+
       # @x = 0
       # @v = 10
       # @y = 20
@@ -94,7 +98,7 @@ describe "play" do
       end
 
       @t.process_command 'play -d test_method --lines 2..3'
-      @t.eval_string.should == unindent(<<-STR)
+      @t.eval_string.should eq unindent(<<-STR)
         @v = 10
         @y = 20
       STR
@@ -106,16 +110,18 @@ describe "play" do
 
     it 'should play a method (a single line)' do
       @t.process_command 'play test_method --lines 2'
-      @t.eval_string.should == ":test_method_content\n"
+      @t.eval_string.should eq ":test_method_content\n"
     end
 
     it 'should properly reindent lines' do
+      @o.singleton_class.send :remove_method, :test_method
+
       def @o.test_method
         'hello world'
       end
 
       @t.process_command 'play test_method --lines 2'
-      @t.eval_string.should == "'hello world'\n"
+      @t.eval_string.should eq "'hello world'\n"
     end
 
     it 'should APPEND to the input buffer when playing a method line, not replace it' do
@@ -125,13 +131,15 @@ describe "play" do
 
       @t.process_command 'play test_method --lines 2'
 
-      @t.eval_string.should == unindent(<<-STR)
+      @t.eval_string.should eq unindent(<<-STR)
         def another_test_method
           :test_method_content
       STR
     end
 
     it 'should play a method (multiple lines)' do
+      @o.singleton_class.send :remove_method, :test_method
+
       def @o.test_method
         @var0 = 10
         @var1 = 20
@@ -140,7 +148,7 @@ describe "play" do
       end
 
       @t.process_command 'play test_method --lines 3..4'
-      @t.eval_string.should == unindent(<<-STR, 0)
+      @t.eval_string.should eq unindent(<<-STR, 0)
         @var1 = 20
         @var2 = 30
       STR
@@ -155,13 +163,16 @@ describe "play" do
           binding.pry
         end
 
-        [a, b, c].all? { |v| v.should == 2 }
-        d.should == 1
+        [a, b, c].all? { |v| v.should eq 2 }
+        d.should eq 1
+        e.should eq 1
       end
     end
 
     describe "play -e" do
       it 'should run an expression from given line number' do
+        @o.singleton_class.send :remove_method, :test_method
+
         def @o.test_method
           @s = [
             1,2,3,
@@ -170,7 +181,7 @@ describe "play" do
         end
 
         @t.process_command 'play test_method -e 2'
-        @t.eval_string.should == unindent(<<-STR, 0)
+        @t.eval_string.should eq unindent(<<-STR, 0)
           @s = [
             1,2,3,
             4,5,6

--- a/spec/commands/raise_up_spec.rb
+++ b/spec/commands/raise_up_spec.rb
@@ -29,8 +29,8 @@ describe "raise-up" do
       Pry.start(:outer)
     end
 
-    Pad.inner.should == :inner
-    Pad.outer.should == :outer
+    Pad.inner.should eq :inner
+    Pad.outer.should eq :outer
   end
 
   it "should raise the most recently raised exception" do
@@ -45,9 +45,9 @@ describe "raise-up" do
       expect { Pry.start(:outer) }.to raise_error NoMethodError
     end
 
-    Pad.deep.should  == :deep
-    Pad.inner.should == :inner
-    Pad.outer.should == :outer
+    Pad.deep.should  eq :deep
+    Pad.inner.should eq :inner
+    Pad.outer.should eq :outer
   end
 
   it "should jump immediately out of nested contexts with !" do

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -115,10 +115,10 @@ describe "show-doc" do
 
   describe "rdoc highlighting" do
     it "should syntax highlight code in rdoc" do
-      c = Class.new{
+      _c = Class.new{
         # This can initialize your class:
         #
-        #   a = c.new :foo
+        #   a = _c.new :foo
         #
         # @param foo
         def initialize(foo); end
@@ -126,19 +126,19 @@ describe "show-doc" do
 
       begin
         t = pry_tester(binding)
-        t.eval("show-doc c#initialize").should =~ /c.new :foo/
+        t.eval("show-doc _c#initialize").should =~ /_c.new :foo/
         Pry.config.color = true
         # I don't want the test to rely on which colour codes are there, just to
         # assert that "something" is being colourized.
-        t.eval("show-doc c#initialize").should_not =~ /c.new :foo/
+        t.eval("show-doc _c#initialize").should_not =~ /_c.new :foo/
       ensure
         Pry.config.color = false
       end
     end
 
     it "should syntax highlight `code` in rdoc" do
-      c = Class.new{
-        # After initializing your class with `c.new(:foo)`, go have fun!
+      _c = Class.new{
+        # After initializing your class with `_c.new(:foo)`, go have fun!
         #
         # @param foo
         def initialize(foo); end
@@ -146,11 +146,11 @@ describe "show-doc" do
 
       begin
         t = pry_tester(binding)
-        t.eval("show-doc c#initialize").should =~ /c.new\(:foo\)/
+        t.eval("show-doc _c#initialize").should =~ /_c.new\(:foo\)/
         Pry.config.color = true
         # I don't want the test to rely on which colour codes are there, just to
         # assert that "something" is being colourized.
-        t.eval("show-doc c#initialize").should_not =~ /c.new\(:foo\)/
+        t.eval("show-doc _c#initialize").should_not =~ /_c.new\(:foo\)/
       ensure
         Pry.config.color = false
       end
@@ -158,7 +158,7 @@ describe "show-doc" do
     end
 
     it "should not syntax highlight `` inside code" do
-      c = Class.new{
+      _c = Class.new{
         # Convert aligned output (from many shell commands) into nested arrays:
         #
         #   a = decolumnize `ls -l $HOME`
@@ -170,8 +170,8 @@ describe "show-doc" do
       begin
         t = pry_tester(binding)
         Pry.config.color = true
-        t.eval("show-doc c#decolumnize").should =~ /ls -l \$HOME/
-        t.eval("show-doc c#decolumnize").should_not =~ /`ls -l \$HOME`/
+        t.eval("show-doc _c#decolumnize").should =~ /ls -l \$HOME/
+        t.eval("show-doc _c#decolumnize").should_not =~ /`ls -l \$HOME`/
       ensure
         Pry.config.color = false
       end
@@ -181,8 +181,8 @@ describe "show-doc" do
   describe "on sourcable objects" do
     it "should show documentation for object" do
       # this is a documentation
-      hello = proc { puts 'hello world!' }
-      mock_pry(binding, "show-doc hello").should =~ /this is a documentation/
+      _hello = proc { puts 'hello world!' }
+      mock_pry(binding, "show-doc _hello").should =~ /this is a documentation/
     end
   end
 
@@ -296,7 +296,7 @@ describe "show-doc" do
       it 'should show the docs for all monkeypatches defined in different files' do
         # local monkeypatch
         class TestClassForShowSource
-          def beta
+          def epsilon
           end
         end
 
@@ -321,7 +321,7 @@ describe "show-doc" do
           '(when -a not used and more than one candidate exists for class)' do
           # Still reading boring tests, eh?
           class TestClassForShowSource
-            def beta
+            def delta
             end
           end
 
@@ -413,7 +413,7 @@ describe "show-doc" do
     end
 
     it 'should display help for a regex command with a "listing"' do
-      @set.command /bar(.*)/, "Test listing", :listing => "foo" do; end
+      @set.command(/bar(.*)/, "Test listing", :listing => "foo") do; end
       pry_eval('show-doc foo').should =~ /Test listing/
     end
 

--- a/spec/commands/show_input_spec.rb
+++ b/spec/commands/show_input_spec.rb
@@ -6,7 +6,7 @@ describe "show-input" do
   end
 
   it 'should correctly show the current lines in the input buffer' do
-    @t.push *unindent(<<-STR).split("\n")
+    @t.push(*unindent(<<-STR).split("\n"))
       def hello
         puts :bing
     STR

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -8,6 +8,7 @@ describe "show-source" do
       :sample
     end
 
+    Object.remove_const :Test if Object.const_defined? :Test
     Object.const_set(:Test, Module.new)
   end
 
@@ -47,7 +48,7 @@ describe "show-source" do
 
   it "should find methods even if there are spaces in the arguments" do
     def @o.foo(*bars)
-      "Mr flibble"
+      @foo = "Mr flibble"
       self
     end
 
@@ -56,22 +57,22 @@ describe "show-source" do
   end
 
   it "should find methods even if the object overrides method method" do
-    c = Class.new{
+    _c = Class.new{
       def method;
         98
       end
     }
 
-    pry_eval(binding, "show-source c.new.method").should =~ /98/
+    pry_eval(binding, "show-source _c.new.method").should =~ /98/
   end
 
   it "should not show the source when a non-extant method is requested" do
-    c = Class.new{ def method; 98; end }
-    mock_pry(binding, "show-source c#wrongmethod").should =~ /Couldn't locate/
+    _c = Class.new{ def method; 98; end }
+    mock_pry(binding, "show-source _c#wrongmethod").should =~ /Couldn't locate/
   end
 
   it "should find instance_methods if the class overrides instance_method" do
-    c = Class.new{
+    _c = Class.new{
       def method;
         98
       end
@@ -79,43 +80,43 @@ describe "show-source" do
       def self.instance_method; 789; end
     }
 
-    pry_eval(binding, "show-source c#method").should =~ /98/
+    pry_eval(binding, "show-source _c#method").should =~ /98/
   end
 
   it "should find instance methods with self#moo" do
-    c = Class.new{ def moo; "ve over!"; end }
+    _c = Class.new{ def moo; "ve over!"; end }
 
-    pry_eval(binding, "cd c", "show-source self#moo").should =~ /ve over/
+    pry_eval(binding, "cd _c", "show-source self#moo").should =~ /ve over/
   end
 
   it "should not find instance methods with self.moo" do
-    c = Class.new{ def moo; "ve over!"; end }
+    _c = Class.new{ def moo; "ve over!"; end }
 
-    expect { pry_eval(binding, 'cd c', 'show-source self.moo') }.to raise_error(Pry::CommandError, /Couldn't locate/)
+    expect { pry_eval(binding, 'cd _c', 'show-source self.moo') }.to raise_error(Pry::CommandError, /Couldn't locate/)
   end
 
   it "should find normal methods with self.moo" do
-    c = Class.new{ def self.moo; "ve over!"; end }
+    _c = Class.new{ def self.moo; "ve over!"; end }
 
-    pry_eval(binding, 'cd c', 'show-source self.moo').should =~ /ve over/
+    pry_eval(binding, 'cd _c', 'show-source self.moo').should =~ /ve over/
   end
 
   it "should not find normal methods with self#moo" do
-    c = Class.new{ def self.moo; "ve over!"; end }
+    _c = Class.new{ def self.moo; "ve over!"; end }
 
-    expect { pry_eval(binding, 'cd c', 'show-source self#moo') }.to raise_error(Pry::CommandError, /Couldn't locate/)
+    expect { pry_eval(binding, 'cd _c', 'show-source self#moo') }.to raise_error(Pry::CommandError, /Couldn't locate/)
   end
 
   it "should find normal methods (i.e non-instance methods) by default" do
-    c = Class.new{ def self.moo; "ve over!"; end }
+    _c = Class.new{ def self.moo; "ve over!"; end }
 
-    pry_eval(binding, "cd c", "show-source moo").should =~ /ve over/
+    pry_eval(binding, "cd _c", "show-source moo").should =~ /ve over/
   end
 
   it "should find instance methods if no normal methods available" do
-    c = Class.new{ def moo; "ve over!"; end }
+    _c = Class.new{ def moo; "ve over!"; end }
 
-    pry_eval(binding, "cd c", "show-source moo").should =~ /ve over/
+    pry_eval(binding, "cd _c", "show-source moo").should =~ /ve over/
   end
 
   describe "with -e option" do
@@ -134,7 +135,7 @@ describe "show-source" do
     it "evaluates the argument as ruby and shows the source code for the returned value" do
       ReplTester.start target: binding do
         input 'show-source -e FooBar.new'
-        output /class FooBar/
+        output(/class FooBar/)
       end
     end
   end
@@ -202,7 +203,7 @@ describe "show-source" do
     it "finds super methods without explicit method argument" do
       o = Foo.new
       def o.foo(*bars)
-        :wibble
+        @foo = :wibble
         pry_eval(binding, 'show-source --super')
       end
 
@@ -219,7 +220,7 @@ describe "show-source" do
       }
 
       def o.foo(*bars)
-        :wibble
+        @foo = :wibble
         pry_eval(binding, 'show-source --super --super')
       end
 
@@ -236,8 +237,8 @@ describe "show-source" do
     end
 
     it "should output source for procs/lambdas stored in variables" do
-      hello = proc { puts 'hello world!' }
-      pry_eval(binding, 'show-source hello').should =~ /proc \{ puts/
+      _hello = proc { puts 'hello world!' }
+      pry_eval(binding, 'show-source _hello').should =~ /proc \{ puts/
     end
 
     it "should output source for procs/lambdas stored in constants" do
@@ -248,8 +249,8 @@ describe "show-source" do
 
     it "should output source for method objects" do
       def @o.hi; puts 'hi world'; end
-      meth = @o.method(:hi)
-      pry_eval(binding, "show-source meth").should =~ /puts 'hi world'/
+      _meth = @o.method(:hi)
+      pry_eval(binding, "show-source _meth").should =~ /puts 'hi world'/
     end
 
     describe "on variables that shadow methods" do
@@ -296,8 +297,8 @@ describe "show-source" do
       end
 
       it "should output source of its class if variable doesn't respond to source_location" do
-        test_host = TestHost.new
-        pry_eval(binding, 'show-source test_host').
+        _test_host = TestHost.new
+        pry_eval(binding, 'show-source _test_host').
           should =~ /class TestHost\n.*def hello/
       end
 
@@ -499,7 +500,7 @@ describe "show-source" do
         describe "messages relating to -a" do
           it 'indicates all available monkeypatches can be shown with -a when (when -a not used and more than one candidate exists for class)' do
             class TestClassForShowSource
-              def beta
+              def gamma
               end
             end
 
@@ -637,7 +638,7 @@ describe "show-source" do
         end
 
         it 'should show source for a command by listing name' do
-          @set.command /foo(.*)/, :body_of_foo_bar_regex, :listing => "bar" do; end
+          @set.command(/foo(.*)/, :body_of_foo_bar_regex, :listing => "bar") do; end
 
           pry_eval('show-source bar').should =~ /:body_of_foo_bar_regex/
         end

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -259,6 +259,7 @@ describe "show-source" do
           class ::TestHost
             def hello
               hello = proc { ' smile ' }
+              _foo = hello
               pry_tester(binding)
             end
           end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -48,11 +48,11 @@ describe Pry::InputCompleter do
     # check to see if variables are in scope
     object.instance_variables.
       map { |v| v.to_sym }.
-      include?(:'@name').should == true
+      include?(:'@name').should eq true
 
     object.class.class_variables.
       map { |v| v.to_sym }.
-      include?(:'@@number').should == true
+      include?(:'@@number').should eq true
 
     # Complete instance variables.
     b = Pry.binding_for(object)
@@ -92,6 +92,7 @@ describe Pry::InputCompleter do
 
     # Constant
     module Mod
+      remove_const :Con if defined? Con
       Con = 'Constant'
       module Mod2
       end
@@ -103,7 +104,7 @@ describe Pry::InputCompleter do
     completer_test(o).call('Mod::Con')
 
     # Symbol
-    foo = :symbol
+    _foo = :symbol
     completer_test(o).call(':symbol')
 
     # Variables
@@ -123,6 +124,7 @@ describe Pry::InputCompleter do
     end
 
     module Baz
+      remove_const :Con if defined? Con
       @bar = Bar
       @bazvar = :baz
       Con = :constant
@@ -163,6 +165,7 @@ describe Pry::InputCompleter do
 
     # Constant
     module Mod
+      remove_const :Con if defined? Con
       Con = 'Constant'
       module Mod2
       end
@@ -174,7 +177,7 @@ describe Pry::InputCompleter do
     completer_test(o).call('Mod::Con')
 
     # Symbol
-    foo = :symbol
+    _foo = :symbol
     completer_test(o).call(':symbol')
 
     # Variables
@@ -194,6 +197,7 @@ describe Pry::InputCompleter do
     end
 
     module Baz
+      remove_const :Con if defined? Con
       @bar = Bar
       @bazvar = :baz
       Con = :constant

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -33,7 +33,7 @@ describe Pry::Config do
       parent = Pry::Config.from_hash(hooks: "parent_hooks")
       local  = Pry::Config.new parent
       local.hooks.gsub! 'parent', 'local'
-      local.hooks.should == 'local_hooks'
+      local.hooks.should eq 'local_hooks'
       parent.hooks.should == 'parent_hooks'
     end
   end
@@ -69,7 +69,7 @@ describe Pry::Config do
     it "returns a Method object for a dynamic key" do
       @config["key"] = 1
       method_obj = @config.method(:key)
-      method_obj.name.should == :key
+      method_obj.name.should eq :key
       method_obj.call.should == 1
     end
   end
@@ -129,7 +129,7 @@ describe Pry::Config do
     it "forgets a local key" do
       local = Pry::Config.new Pry::Config.from_hash(foo: 1)
       local.foo = 2
-      local.foo.should == 2
+      local.foo.should eq 2
       local.forget(:foo)
       local.foo.should == 1
     end

--- a/spec/control_d_handler_spec.rb
+++ b/spec/control_d_handler_spec.rb
@@ -13,7 +13,7 @@ describe Pry::DEFAULT_CONTROL_D_HANDLER do
       it "should clear out passed string" do
         str = 'hello world'
         Pry::DEFAULT_CONTROL_D_HANDLER.call(str, nil)
-        str.should == ''
+        str.should eq ''
       end
     end
 
@@ -30,9 +30,9 @@ describe Pry::DEFAULT_CONTROL_D_HANDLER do
       it 'should pop last binding from the binding stack' do
         t = pry_tester
         t.eval "cd Object.new"
-        t.eval("_pry_.binding_stack.size").should == 2
+        t.eval("_pry_.binding_stack.size").should eq 2
         t.eval("_pry_.eval(nil)").should equal true
-        t.eval("_pry_.binding_stack.size").should == 1
+        t.eval("_pry_.binding_stack.size").should eq 1
       end
 
       it "breaks out of the parent session" do

--- a/spec/exception_whitelist_spec.rb
+++ b/spec/exception_whitelist_spec.rb
@@ -6,7 +6,7 @@ describe "Pry.config.exception_whitelist" do
   end
 
   it 'should rescue all exceptions NOT specified on whitelist' do
-    Pry.config.exception_whitelist.include?(NameError).should == false
+    Pry.config.exception_whitelist.include?(NameError).should eq false
     expect { Pry.start(self, :input => StringIO.new("raise NameError\nexit"), :output => @str_output) }.not_to raise_error
   end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -14,10 +14,6 @@ class Module
   public :remove_method
 end
 
-# turn warnings off (esp for Pry::Hooks which will generate warnings
-# in tests)
-$VERBOSE = nil
-
 Pad = Class.new do
   include Pry::Config::Behavior
 end.new(nil)

--- a/spec/helpers/table_spec.rb
+++ b/spec/helpers/table_spec.rb
@@ -3,21 +3,21 @@ require_relative '../helper'
 describe 'Formatting Table' do
   it 'knows about colorized fitting' do
     t = Pry::Helpers::Table.new %w(hihi), :column_count => 1
-    t.fits_on_line?(4).should == true
+    t.fits_on_line?(4).should eq true
     t.items = []
-    t.fits_on_line?(4).should == true
+    t.fits_on_line?(4).should eq true
 
     t.items = %w(hi hi)
-    t.fits_on_line?(4).should == true
+    t.fits_on_line?(4).should eq true
     t.column_count = 2
-    t.fits_on_line?(4).should == false
+    t.fits_on_line?(4).should eq false
 
     t.items = %w(
       a   ccc
       bb  dddd
     ).sort
-    t.fits_on_line?(8).should == true
-    t.fits_on_line?(7).should == false
+    t.fits_on_line?(8).should eq true
+    t.fits_on_line?(7).should eq false
   end
 
   describe 'formatting - should order downward and wrap to columns' do
@@ -25,7 +25,7 @@ describe 'Formatting Table' do
     def try_round_trip(expected)
       things = expected.split(/\s+/).sort
       actual = Pry::Helpers.tablify(things, FAKE_COLUMNS).to_s.strip
-      [expected, actual].each{|e| e.gsub! /\s+$/, ''}
+      [expected, actual].each{|e| e.gsub!(/\s+$/, '')}
       if actual != expected
         bar = '-'*25
         puts \
@@ -34,7 +34,7 @@ describe 'Formatting Table' do
           bar+'actual'+bar,
           actual
       end
-      actual.should == expected
+      actual.should eq expected
     end
 
     it 'should handle a tiny case' do
@@ -94,11 +94,11 @@ asfadsssaaad    fasfaafdssd     s
 
     it 'should format output as one column' do
       table = Pry::Helpers.tablify(@out, @elem_len - 1).to_s
-      table.should == "swizzle\ncrime  \nfun    "
+      table.should eq "swizzle\ncrime  \nfun    "
     end
   end
 
   specify 'decide between one-line or indented output' do
-    Pry::Helpers.tablify_or_one_line('head', %w(ing)).should == "head: ing\n"
+    Pry::Helpers.tablify_or_one_line('head', %w(ing)).should eq "head: ing\n"
   end
 end

--- a/spec/history_array_spec.rb
+++ b/spec/history_array_spec.rb
@@ -7,65 +7,65 @@ describe Pry::HistoryArray do
   end
 
   it 'should have a maximum size specifed at creation time' do
-    @array.max_size.should == 10
+    @array.max_size.should eq 10
   end
 
   it 'should be able to be added objects to' do
-    @populated.size.should == 4
-    @populated.to_a.should == [1, 2, 3, 4]
+    @populated.size.should eq 4
+    @populated.to_a.should eq [1, 2, 3, 4]
   end
 
   it 'should be able to access single elements' do
-    @populated[2].should == 3
+    @populated[2].should eq 3
   end
 
   it 'should be able to access negative indices' do
-    @populated[-1].should == 4
+    @populated[-1].should eq 4
   end
 
   it 'should be able to access ranges' do
-    @populated[1..2].should == [2, 3]
+    @populated[1..2].should eq [2, 3]
   end
 
   it 'should be able to access ranges starting from a negative index' do
-    @populated[-2..3].should == [3, 4]
+    @populated[-2..3].should eq [3, 4]
   end
 
   it 'should be able to access ranges ending at a negative index' do
-    @populated[2..-1].should == [3, 4]
+    @populated[2..-1].should eq [3, 4]
   end
 
   it 'should be able to access ranges using only negative indices' do
-    @populated[-2..-1].should == [3, 4]
+    @populated[-2..-1].should eq [3, 4]
   end
 
   it 'should be able to use range where end is excluded' do
-    @populated[-2...-1].should == [3]
+    @populated[-2...-1].should eq [3]
   end
 
   it 'should be able to access slices using a size' do
-    @populated[-3, 2].should == [2, 3]
+    @populated[-3, 2].should eq [2, 3]
   end
 
   it 'should remove older entries' do
     11.times { |n| @array << n }
 
-    @array[0].should  == nil
-    @array[1].should  == 1
-    @array[10].should == 10
+    @array[0].should  eq nil
+    @array[1].should  eq 1
+    @array[10].should eq 10
   end
 
   it 'should not be larger than specified maximum size' do
     12.times { |n| @array << n }
-    @array.entries.compact.size.should == 10
+    @array.entries.compact.size.should eq 10
   end
 
   it 'should pop!' do
     @populated.pop!
-    @populated.to_a.should == [1, 2, 3]
+    @populated.to_a.should eq [1, 2, 3]
   end
 
   it 'should return an indexed hash' do
-    @populated.to_h[0].should == @populated[0]
+    @populated.to_h[0].should eq @populated[0]
   end
 end

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -25,13 +25,13 @@ describe Pry do
       Pry.history << '3'
       Pry.history << '_ += 1'
       Pry.history << '_ += 1'
-      Pry.history.to_a.grep('_ += 1').count.should == 1
+      Pry.history.to_a.grep('_ += 1').count.should eq 1
     end
 
     it "does not record empty lines" do
       c = Pry.history.to_a.count
       Pry.history << ''
-      Pry.history.to_a.count.should == c
+      Pry.history.to_a.count.should eq c
     end
   end
 
@@ -50,20 +50,20 @@ describe Pry do
     end
 
     it "clears this session's history" do
-      Pry.history.to_a.size.should > 0
+      Pry.history.to_a.size.should be > 0
       Pry.history.clear
-      Pry.history.to_a.size.should == 0
+      Pry.history.to_a.size.should eq 0
     end
 
     it "doesn't affect the contents of the history file" do
-      Pry.history.to_a.size.should == 3
+      Pry.history.to_a.size.should eq 3
       Pry.history.clear
 
       File.open(@hist_file_path, 'r') { |fh|
         file = fh.to_a
 
-        file.length.should == 3
-        file.any? { |a| a =~ /athos/ }.should == true
+        file.length.should eq 3
+        file.any? { |a| a =~ /athos/ }.should eq true
       }
     end
   end
@@ -77,7 +77,7 @@ describe Pry do
       end
       Pry.load_history
 
-      Pry.history.history_line_count.should == 5
+      Pry.history.history_line_count.should eq 5
     end
   end
 
@@ -85,29 +85,29 @@ describe Pry do
     it "restores loader" do
       Pry.history.loader = proc {}
       Pry.history.restore_default_behavior
-      Pry.history.loader.class.should == Method
-      Pry.history.loader.name.to_sym.should == :read_from_file
+      Pry.history.loader.class.should eq Method
+      Pry.history.loader.name.to_sym.should eq :read_from_file
     end
 
     it "restores saver" do
       Pry.history.saver = proc {}
       Pry.history.restore_default_behavior
-      Pry.history.saver.class.should == Method
-      Pry.history.saver.name.to_sym.should == :save_to_file
+      Pry.history.saver.class.should eq Method
+      Pry.history.saver.name.to_sym.should eq :save_to_file
     end
 
     it "restores pusher" do
       Pry.history.pusher = proc {}
       Pry.history.restore_default_behavior
-      Pry.history.pusher.class.should == Method
-      Pry.history.pusher.name.to_sym.should == :push_to_readline
+      Pry.history.pusher.class.should eq Method
+      Pry.history.pusher.name.to_sym.should eq :push_to_readline
     end
 
     it "restores clearer" do
       Pry.history.clearer = proc {}
       Pry.history.restore_default_behavior
-      Pry.history.clearer.class.should == Method
-      Pry.history.clearer.name.to_sym.should == :clear_readline
+      Pry.history.clearer.class.should eq Method
+      Pry.history.clearer.name.to_sym.should eq :clear_readline
     end
   end
 
@@ -115,13 +115,13 @@ describe Pry do
     it "returns the number of lines in history from just this session" do
       Pry.history << 'you?'
       Pry.history << 'you are so precious'
-      Pry.history.session_line_count.should == 2
+      Pry.history.session_line_count.should eq 2
     end
   end
 
   describe ".load_history" do
     it "reads the contents of the file" do
-      Pry.history.to_a[-2..-1].should == %w(2 3)
+      Pry.history.to_a[-2..-1].should eq %w(2 3)
     end
   end
 
@@ -140,7 +140,7 @@ describe Pry do
 
     it "saves lines to a file as they are written" do
       @history.push "5"
-      File.read(@histfile.path).should == "5\n"
+      File.read(@histfile.path).should eq "5\n"
     end
 
     it "interleaves lines from many places" do
@@ -148,7 +148,7 @@ describe Pry do
       File.open(@histfile.path, 'a'){ |f| f.puts "6" }
       @history.push "7"
 
-      File.read(@histfile.path).should == "5\n6\n7\n"
+      File.read(@histfile.path).should eq "5\n6\n7\n"
     end
   end
 

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -9,7 +9,7 @@ describe Pry::Hooks do
     it 'should not execute hook while adding it' do
       run = false
       @hooks.add_hook(:test_hook, :my_name) { run = true }
-      run.should == false
+      run.should eq false
     end
 
     it 'should not allow adding of a hook with a duplicate name' do
@@ -20,22 +20,22 @@ describe Pry::Hooks do
 
     it 'should create a new hook with a block' do
       @hooks.add_hook(:test_hook, :my_name) { }
-      @hooks.hook_count(:test_hook).should == 1
+      @hooks.hook_count(:test_hook).should eq 1
     end
 
     it 'should create a new hook with a callable' do
       @hooks.add_hook(:test_hook, :my_name, proc { })
-      @hooks.hook_count(:test_hook).should == 1
+      @hooks.hook_count(:test_hook).should eq 1
     end
 
     it 'should use block if given both block and callable' do
       run = false
       foo = false
       @hooks.add_hook(:test_hook, :my_name, proc { foo = true }) { run = true }
-      @hooks.hook_count(:test_hook).should == 1
+      @hooks.hook_count(:test_hook).should eq 1
       @hooks.exec_hook(:test_hook)
-      run.should == true
-      foo.should == false
+      run.should eq true
+      foo.should eq false
     end
 
     it 'should raise if not given a block or any other object' do
@@ -45,11 +45,11 @@ describe Pry::Hooks do
     it 'should create multiple hooks for an event' do
       @hooks.add_hook(:test_hook, :my_name) {}
       @hooks.add_hook(:test_hook, :my_name2) {}
-      @hooks.hook_count(:test_hook).should == 2
+      @hooks.hook_count(:test_hook).should eq 2
     end
 
     it 'should return a count of 0 for an empty hook' do
-      @hooks.hook_count(:test_hook).should == 0
+      @hooks.hook_count(:test_hook).should eq 0
     end
   end
 
@@ -60,7 +60,7 @@ describe Pry::Hooks do
         h2 = Pry::Hooks.new
 
         h2.merge!(h1)
-        h2.get_hook(:test_hook, :testing).should == h1.get_hook(:test_hook, :testing)
+        h2.get_hook(:test_hook, :testing).should eq h1.get_hook(:test_hook, :testing)
       end
 
       it 'should not share merged elements with original' do
@@ -69,7 +69,7 @@ describe Pry::Hooks do
 
         h2.merge!(h1)
         h2.add_hook(:test_hook, :testing2) {}
-        h2.get_hook(:test_hook, :testing2).should_not == h1.get_hook(:test_hook, :testing2)
+        h2.get_hook(:test_hook, :testing2).should_not eq h1.get_hook(:test_hook, :testing2)
       end
 
       it 'should NOT overwrite hooks belonging to shared event in receiver' do
@@ -78,7 +78,7 @@ describe Pry::Hooks do
         h2 = Pry::Hooks.new.add_hook(:test_hook, :testing2, callable)
 
         h2.merge!(h1)
-        h2.get_hook(:test_hook, :testing2).should == callable
+        h2.get_hook(:test_hook, :testing2).should eq callable
       end
 
       it 'should overwrite identical hook in receiver' do
@@ -88,8 +88,8 @@ describe Pry::Hooks do
         h2 = Pry::Hooks.new.add_hook(:test_hook, :testing, callable2)
 
         h2.merge!(h1)
-        h2.get_hook(:test_hook, :testing).should == callable1
-        h2.hook_count(:test_hook).should == 1
+        h2.get_hook(:test_hook, :testing).should eq callable1
+        h2.hook_count(:test_hook).should eq 1
       end
 
       it 'should preserve hook order' do
@@ -105,7 +105,7 @@ describe Pry::Hooks do
         h2.merge!(h1)
         h2.exec_hook(:test_hook)
 
-        name.should == "john"
+        name.should eq "john"
       end
 
       describe "merge" do
@@ -114,8 +114,8 @@ describe Pry::Hooks do
           h2 = Pry::Hooks.new
 
           h3 = h2.merge(h1)
-          h3.should_not == h1
-          h3.should_not == h2
+          h3.should_not eq h1
+          h3.should_not eq h2
         end
 
         it 'should contain hooks from original instance' do
@@ -123,8 +123,8 @@ describe Pry::Hooks do
           h2 = Pry::Hooks.new.add_hook(:test_hook2, :testing) {}
 
           h3 = h2.merge(h1)
-          h3.get_hook(:test_hook, :testing).should == h1.get_hook(:test_hook, :testing)
-          h3.get_hook(:test_hook2, :testing).should == h2.get_hook(:test_hook2, :testing)
+          h3.get_hook(:test_hook, :testing).should eq h1.get_hook(:test_hook, :testing)
+          h3.get_hook(:test_hook2, :testing).should eq h2.get_hook(:test_hook2, :testing)
         end
 
         it 'should not affect original instances when new hooks are added' do
@@ -134,8 +134,8 @@ describe Pry::Hooks do
           h3 = h2.merge(h1)
           h3.add_hook(:test_hook3, :testing) {}
 
-          h1.get_hook(:test_hook3, :testing).should == nil
-          h2.get_hook(:test_hook3, :testing).should == nil
+          h1.get_hook(:test_hook3, :testing).should eq nil
+          h2.get_hook(:test_hook3, :testing).should eq nil
         end
       end
 
@@ -149,7 +149,7 @@ describe Pry::Hooks do
       end
 
       hooks_dup = @hooks.dup
-      hooks_dup.get_hook(:test_hook, :testing).should == @hooks.get_hook(:test_hook, :testing)
+      hooks_dup.get_hook(:test_hook, :testing).should eq @hooks.get_hook(:test_hook, :testing)
     end
 
     it 'adding a new event to dupped instance should not affect original' do
@@ -158,7 +158,7 @@ describe Pry::Hooks do
 
       hooks_dup.add_hook(:other_test_hook, :testing) { :okay_man }
 
-      hooks_dup.get_hook(:other_test_hook, :testing).should_not == @hooks.get_hook(:other_test_hook, :testing)
+      hooks_dup.get_hook(:other_test_hook, :testing).should_not eq @hooks.get_hook(:other_test_hook, :testing)
     end
 
     it 'adding a new hook to dupped instance should not affect original' do
@@ -167,7 +167,7 @@ describe Pry::Hooks do
 
       hooks_dup.add_hook(:test_hook, :testing2) { :okay_man }
 
-      hooks_dup.get_hook(:test_hook, :testing2).should_not == @hooks.get_hook(:test_hook, :testing2)
+      hooks_dup.get_hook(:test_hook, :testing2).should_not eq @hooks.get_hook(:test_hook, :testing2)
     end
 
   end
@@ -180,12 +180,12 @@ describe Pry::Hooks do
         @hooks.add_hook(:test_hook, :my_name) { run = true }
         @hooks.add_hook(:test_hook, :my_name2) { fun = true }
         @hooks.get_hook(:test_hook, :my_name).call
-        run.should == true
-        fun.should == false
+        run.should eq true
+        fun.should eq false
       end
 
       it 'should return nil if hook does not exist' do
-        @hooks.get_hook(:test_hook, :my_name).should == nil
+        @hooks.get_hook(:test_hook, :my_name).should eq nil
       end
     end
 
@@ -196,9 +196,9 @@ describe Pry::Hooks do
         @hooks.add_hook(:test_hook, :my_name1, hook1)
         @hooks.add_hook(:test_hook, :my_name2, hook2)
         hash = @hooks.get_hooks(:test_hook)
-        hash.size.should == 2
-        hash[:my_name1].should == hook1
-        hash[:my_name2].should == hook2
+        hash.size.should eq 2
+        hash[:my_name1].should eq hook1
+        hash[:my_name2].should eq hook2
       end
 
       it 'should return an empty hash if no hooks defined' do
@@ -213,7 +213,7 @@ describe Pry::Hooks do
       @hooks.add_hook(:test_hook, :my_name2) { }
       @hooks.add_hook(:test_hook, :my_name3) { }
       @hooks.clear(:test_hook)
-      @hooks.hook_count(:test_hook).should == 0
+      @hooks.hook_count(:test_hook).should eq 0
     end
   end
 
@@ -221,18 +221,18 @@ describe Pry::Hooks do
     it 'should successfully delete a hook' do
       @hooks.add_hook(:test_hook, :my_name) {}
       @hooks.delete_hook(:test_hook, :my_name)
-      @hooks.hook_count(:test_hook).should == 0
+      @hooks.hook_count(:test_hook).should eq 0
     end
 
     it 'should return the deleted hook' do
       run = false
       @hooks.add_hook(:test_hook, :my_name) { run = true }
       @hooks.delete_hook(:test_hook, :my_name).call
-      run.should == true
+      run.should eq true
     end
 
     it 'should return nil if hook does not exist' do
-      @hooks.delete_hook(:test_hook, :my_name).should == nil
+      @hooks.delete_hook(:test_hook, :my_name).should eq nil
     end
   end
 
@@ -241,14 +241,14 @@ describe Pry::Hooks do
       run = false
       @hooks.add_hook(:test_hook, :my_name) { run = true }
       @hooks.exec_hook(:test_hook)
-      run.should == true
+      run.should eq true
     end
 
     it 'should execute proc hook' do
       run = false
       @hooks.add_hook(:test_hook, :my_name, proc { run = true })
       @hooks.exec_hook(:test_hook)
-      run.should == true
+      run.should eq true
     end
 
     it 'should execute a general callable hook' do
@@ -262,7 +262,7 @@ describe Pry::Hooks do
 
       @hooks.add_hook(:test_hook, :my_name, callable)
       @hooks.exec_hook(:test_hook)
-      callable.test_var.should == true
+      callable.test_var.should eq true
     end
 
     it 'should execute all hooks for an event if more than one is defined' do
@@ -271,8 +271,8 @@ describe Pry::Hooks do
       @hooks.add_hook(:test_hook, :my_name1) { y = true }
       @hooks.add_hook(:test_hook, :my_name2) { x = true }
       @hooks.exec_hook(:test_hook)
-      x.should == true
-      y.should == true
+      x.should eq true
+      y.should eq true
     end
 
     it 'should execute hooks in order' do
@@ -281,14 +281,14 @@ describe Pry::Hooks do
       @hooks.add_hook(:test_hook, :my_name2) { array << 2 }
       @hooks.add_hook(:test_hook, :my_name3) { array << 3 }
       @hooks.exec_hook(:test_hook)
-      array.should == [1, 2, 3]
+      array.should eq [1, 2, 3]
     end
 
     it 'return value of exec_hook should be that of last executed hook' do
       @hooks.add_hook(:test_hook, :my_name1) { 1 }
       @hooks.add_hook(:test_hook, :my_name2) { 2 }
       @hooks.add_hook(:test_hook, :my_name3) { 3 }
-      @hooks.exec_hook(:test_hook).should == 3
+      @hooks.exec_hook(:test_hook).should eq 3
     end
 
     it 'should add exceptions to the errors array' do
@@ -296,14 +296,14 @@ describe Pry::Hooks do
       @hooks.add_hook(:test_hook, :foo2) { raise 'two' }
       @hooks.add_hook(:test_hook, :foo3) { raise 'three' }
       @hooks.exec_hook(:test_hook)
-      @hooks.errors.map(&:message).should == ['one', 'two', 'three']
+      @hooks.errors.map(&:message).should eq ['one', 'two', 'three']
     end
 
     it 'should return the last exception raised as the return value' do
       @hooks.add_hook(:test_hook, :foo1) { raise 'one' }
       @hooks.add_hook(:test_hook, :foo2) { raise 'two' }
       @hooks.add_hook(:test_hook, :foo3) { raise 'three' }
-      @hooks.exec_hook(:test_hook).should == @hooks.errors.last
+      @hooks.exec_hook(:test_hook).should eq @hooks.errors.last
     end
   end
 
@@ -313,11 +313,11 @@ describe Pry::Hooks do
         options = nil
         Pry.config.hooks.add_hook(:when_started, :test_hook) { |target, opt, _| options = opt }
 
-        redirect_pry_io(StringIO.new("exit"), out=StringIO.new) do
+        redirect_pry_io(StringIO.new("exit"), StringIO.new) do
           Pry.start binding, :hello => :baby
         end
 
-        options[:hello].should == :baby
+        options[:hello].should eq :baby
 
         Pry.config.hooks.delete_hook(:when_started, :test_hook)
       end
@@ -328,11 +328,11 @@ describe Pry::Hooks do
           b = nil
           Pry.config.hooks.add_hook(:when_started, :test_hook) { |target, opt, _| b = target }
 
-          redirect_pry_io(StringIO.new("exit"), out=StringIO.new) do
+          redirect_pry_io(StringIO.new("exit"), StringIO.new) do
             Pry.start 5, :hello => :baby
           end
 
-          b.is_a?(Binding).should == true
+          b.is_a?(Binding).should eq true
           Pry.config.hooks.delete_hook(:when_started, :test_hook)
         end
 
@@ -340,17 +340,16 @@ describe Pry::Hooks do
           b = nil
           Pry.config.hooks.add_hook(:when_started, :test_hook) { |target, opt, _| b = target }
 
-          redirect_pry_io(StringIO.new("exit"), out=StringIO.new) do
+          redirect_pry_io(StringIO.new("exit"), StringIO.new) do
             Pry.start 5, :hello => :baby
           end
 
-          b.eval('self').should == 5
+          b.eval('self').should eq 5
           Pry.config.hooks.delete_hook(:when_started, :test_hook)
         end
       end
 
       it 'should allow overriding of target (and binding_stack)' do
-        options = nil
         o = Object.new
         class << o; attr_accessor :value; end
 
@@ -360,7 +359,7 @@ describe Pry::Hooks do
           Pry.start binding, :hello => :baby
         end
 
-        o.value.should == true
+        o.value.should eq true
         Pry.config.hooks.delete_hook(:when_started, :test_hook)
       end
 
@@ -377,7 +376,7 @@ describe Pry::Hooks do
         array = [1, 2, 3, 4, 5]
 
         begin
-          redirect_pry_io(StringIO.new("raise great_escape"), out=StringIO.new) do
+          redirect_pry_io(StringIO.new("raise great_escape"), StringIO.new) do
             Pry.start o, :hooks => Pry::Hooks.new.add_hook(:after_session, :cleanup) { array = nil }
           end
         rescue => ex
@@ -386,10 +385,10 @@ describe Pry::Hooks do
 
         # ensure that an exception really was raised and it broke out
         # of the repl
-        exception.is_a?(o.great_escape).should == true
+        exception.is_a?(o.great_escape).should eq true
 
         # check that after_session hook ran
-        array.should == nil
+        array.should eq nil
 
         # cleanup after test
         Pry.config.exception_whitelist = old_ew
@@ -450,13 +449,13 @@ describe Pry::Hooks do
   describe "anonymous hooks" do
     it 'should allow adding of hook without a name' do
       @hooks.add_hook(:test_hook, nil) {}
-      @hooks.hook_count(:test_hook).should == 1
+      @hooks.hook_count(:test_hook).should eq 1
     end
 
     it 'should only allow one anonymous hook to exist' do
       @hooks.add_hook(:test_hook, nil) {  }
       @hooks.add_hook(:test_hook, nil) {  }
-      @hooks.hook_count(:test_hook).should == 1
+      @hooks.hook_count(:test_hook).should eq 1
     end
 
     it 'should execute most recently added anonymous hook' do
@@ -465,8 +464,8 @@ describe Pry::Hooks do
       @hooks.add_hook(:test_hook, nil) { y = 1 }
       @hooks.add_hook(:test_hook, nil) { x = 2 }
       @hooks.exec_hook(:test_hook)
-      y.should == nil
-      x.should == 2
+      y.should eq nil
+      x.should eq 2
     end
   end
 

--- a/spec/indent_spec.rb
+++ b/spec/indent_spec.rb
@@ -12,21 +12,21 @@ describe Pry::Indent do
     input  = "array = [\n10,\n15\n]"
     output = "array = [\n  10,\n  15\n]"
 
-    @indent.indent(input).should == output
+    @indent.indent(input).should eq output
   end
 
   it 'should indent a hash' do
     input  = "hash = {\n:name => 'Ruby'\n}"
     output = "hash = {\n  :name => 'Ruby'\n}"
 
-    @indent.indent(input).should == output
+    @indent.indent(input).should eq output
   end
 
   it 'should indent a function' do
     input  = "def\nreturn 10\nend"
     output = "def\n  return 10\nend"
 
-    @indent.indent(input).should == output
+    @indent.indent(input).should eq output
   end
 
   it 'should indent a module and class' do
@@ -35,14 +35,14 @@ describe Pry::Indent do
     input_class  = "class Foo\n# Hello world\nend"
     output_class = "class Foo\n  # Hello world\nend"
 
-    @indent.indent(input).should       == output
-    @indent.indent(input_class).should == output_class
+    @indent.indent(input).should       eq output
+    @indent.indent(input_class).should eq output_class
   end
 
   it 'should indent separate lines' do
-    @indent.indent('def foo').should   == 'def foo'
-    @indent.indent('return 10').should == '  return 10'
-    @indent.indent('end').should       == 'end'
+    @indent.indent('def foo').should   eq 'def foo'
+    @indent.indent('return 10').should eq '  return 10'
+    @indent.indent('end').should       eq 'end'
   end
 
   it 'should not indent single line statements' do
@@ -51,7 +51,7 @@ def hello; end
 puts "Hello"
 TXT
 
-    @indent.indent(input).should == input
+    @indent.indent(input).should eq input
   end
 
   it 'should handle multiple open and closing tokens on a line' do
@@ -67,7 +67,7 @@ TXT
 end
 TXT
 
-    @indent.indent(input).should == output
+    @indent.indent(input).should eq output
   end
 
   it 'should properly indent nested code' do
@@ -99,7 +99,7 @@ module A
 end
 TXT
 
-    @indent.indent(input).should == output
+    @indent.indent(input).should eq output
   end
 
   it 'should indent statements such as if, else, etc' do
@@ -147,12 +147,12 @@ for num in [10, 15, 20] do
 end
 TXT
 
-    @indent.indent(input).should == output
+    @indent.indent(input).should eq output
   end
 
   it "should correctly handle while <foo> do" do
     input = "while 5 do\n5\nend"
-    @indent.indent(input).should == "while 5 do\n  5\nend"
+    @indent.indent(input).should eq "while 5 do\n  5\nend"
   end
 
   it "should ident case statements" do
@@ -186,42 +186,42 @@ else
 end
 TXT
 
-    @indent.indent(input).should == output
+    @indent.indent(input).should eq output
   end
 
   it "should indent correctly with nesting" do
-    @indent.indent("[[\n[]]\n]").should == "[[\n  []]\n]"
-    @indent.reset.indent("[[\n[]]\n]").should == "[[\n  []]\n]"
-    @indent.reset.indent("[[{\n[] =>\n[]}]\n]").should == "[[{\n      [] =>\n  []}]\n]"
+    @indent.indent("[[\n[]]\n]").should eq "[[\n  []]\n]"
+    @indent.reset.indent("[[\n[]]\n]").should eq "[[\n  []]\n]"
+    @indent.reset.indent("[[{\n[] =>\n[]}]\n]").should eq "[[{\n      [] =>\n  []}]\n]"
   end
 
   it "should not indent single-line ifs" do
-    @indent.indent("foo if bar\n#").should == "foo if bar\n#"
-    @indent.reset.indent("foo() if bar\n#").should == "foo() if bar\n#"
-    @indent.reset.indent("foo 'hi' if bar\n#").should == "foo 'hi' if bar\n#"
-    @indent.reset.indent("foo 1 while bar\n#").should == "foo 1 while bar\n#"
-    @indent.reset.indent("$foo if false\n#").should == "$foo if false\n#"
-    @indent.reset.indent("@foo if false\n#").should == "@foo if false\n#"
-    @indent.reset.indent("@@foo if false\n#").should == "@@foo if false\n#"
-    @indent.reset.indent("super if true\n#").should == "super if true\n#"
-    @indent.reset.indent("true if false\n#").should == "true if false\n#"
-    @indent.reset.indent("String if false\n#").should == "String if false\n#"
+    @indent.indent("foo if bar\n#").should eq "foo if bar\n#"
+    @indent.reset.indent("foo() if bar\n#").should eq "foo() if bar\n#"
+    @indent.reset.indent("foo 'hi' if bar\n#").should eq "foo 'hi' if bar\n#"
+    @indent.reset.indent("foo 1 while bar\n#").should eq "foo 1 while bar\n#"
+    @indent.reset.indent("$foo if false\n#").should eq "$foo if false\n#"
+    @indent.reset.indent("@foo if false\n#").should eq "@foo if false\n#"
+    @indent.reset.indent("@@foo if false\n#").should eq "@@foo if false\n#"
+    @indent.reset.indent("super if true\n#").should eq "super if true\n#"
+    @indent.reset.indent("true if false\n#").should eq "true if false\n#"
+    @indent.reset.indent("String if false\n#").should eq "String if false\n#"
   end
 
   it "should indent cunningly disguised ifs" do
-    @indent.indent("{1 => if bar\n#").should == "{1 => if bar\n    #"
-    @indent.reset.indent("foo(if bar\n#").should == "foo(if bar\n    #"
-    @indent.reset.indent("bar(baz, if bar\n#").should == "bar(baz, if bar\n    #"
-    @indent.reset.indent("[if bar\n#").should == "[if bar\n    #"
-    @indent.reset.indent("true; while bar\n#").should == "true; while bar\n  #"
+    @indent.indent("{1 => if bar\n#").should eq "{1 => if bar\n    #"
+    @indent.reset.indent("foo(if bar\n#").should eq "foo(if bar\n    #"
+    @indent.reset.indent("bar(baz, if bar\n#").should eq "bar(baz, if bar\n    #"
+    @indent.reset.indent("[if bar\n#").should eq "[if bar\n    #"
+    @indent.reset.indent("true; while bar\n#").should eq "true; while bar\n  #"
   end
 
   it "should differentiate single/multi-line unless" do
-    @indent.indent("foo unless bar\nunless foo\nbar\nend").should == "foo unless bar\nunless foo\n  bar\nend"
+    @indent.indent("foo unless bar\nunless foo\nbar\nend").should eq "foo unless bar\nunless foo\n  bar\nend"
   end
 
   it "should not indent single/multi-line until" do
-    @indent.indent("%w{baz} until bar\nuntil foo\nbar\nend").should == "%w{baz} until bar\nuntil foo\n  bar\nend"
+    @indent.indent("%w{baz} until bar\nuntil foo\nbar\nend").should eq "%w{baz} until bar\nuntil foo\n  bar\nend"
   end
 
   it "should indent begin rescue end" do
@@ -240,17 +240,17 @@ rescue => e
 end
 OUTPUT
 
-    @indent.indent(input).should == output
+    @indent.indent(input).should eq output
   end
 
   it "should not indent inside strings" do
-    @indent.indent(%(def a\n"foo\nbar"\n  end)).should == %(def a\n  "foo\nbar"\nend)
-    @indent.indent(%(def a\nputs %w(foo\nbar), 'foo\nbar'\n  end)).should == %(def a\n  puts %w(foo\nbar), 'foo\nbar'\nend)
+    @indent.indent(%(def a\n"foo\nbar"\n  end)).should eq %(def a\n  "foo\nbar"\nend)
+    @indent.indent(%(def a\nputs %w(foo\nbar), 'foo\nbar'\n  end)).should eq %(def a\n  puts %w(foo\nbar), 'foo\nbar'\nend)
   end
 
   it "should not indent inside HEREDOCs" do
-    @indent.indent(%(def a\nputs <<FOO\n bar\nFOO\nbaz\nend)).should == %(def a\n  puts <<FOO\n bar\nFOO\n  baz\nend)
-    @indent.indent(%(def a\nputs <<-'^^'\n bar\n\t^^\nbaz\nend)).should == %(def a\n  puts <<-'^^'\n bar\n\t^^\n  baz\nend)
+    @indent.indent(%(def a\nputs <<FOO\n bar\nFOO\nbaz\nend)).should eq %(def a\n  puts <<FOO\n bar\nFOO\n  baz\nend)
+    @indent.indent(%(def a\nputs <<-'^^'\n bar\n\t^^\nbaz\nend)).should eq %(def a\n  puts <<-'^^'\n bar\n\t^^\n  baz\nend)
   end
 
   it "should not indent nested HEREDOCs" do
@@ -280,7 +280,7 @@ tongue
 end
 OUTPUT
 
-    @indent.indent(input).should == output
+    @indent.indent(input).should eq output
   end
 
   describe "nesting" do
@@ -294,7 +294,7 @@ OUTPUT
           end
         else
           it "should parse nesting on line #{i + 1} of example_nesting.rb" do
-            Pry::Indent.nesting_at(test, i + 1).should == eval(result)
+            Pry::Indent.nesting_at(test, i + 1).should eq eval(result)
           end
         end
       end

--- a/spec/method/patcher_spec.rb
+++ b/spec/method/patcher_spec.rb
@@ -9,26 +9,26 @@ describe Pry::Method::Patcher do
   end
 
   it "should change the behaviour of the method" do
-    @x.test.should == :before
+    @x.test.should eq :before
     @method.redefine "def @x.test; :after; end\n"
-    @x.test.should == :after
+    @x.test.should eq :after
   end
 
   it "should return a new method with new source" do
-    @method.source.strip.should == "def @x.test; :before; end"
+    @method.source.strip.should eq "def @x.test; :before; end"
     @method.redefine("def @x.test; :after; end\n").
-      source.strip.should == "def @x.test; :after; end"
+      source.strip.should eq "def @x.test; :after; end"
   end
 
   it "should change the source of new Pry::Method objects" do
     @method.redefine "def @x.test; :after; end\n"
-    Pry::Method(@x.method(:test)).source.strip.should == "def @x.test; :after; end"
+    Pry::Method(@x.method(:test)).source.strip.should eq "def @x.test; :after; end"
   end
 
   it "should preserve visibility" do
     class << @x; private :test; end
-    @method.visibility.should == :private
+    @method.visibility.should eq :private
     @method.redefine "def @x.test; :after; end\n"
-    Pry::Method(@x.method(:test)).visibility.should == :private
+    Pry::Method(@x.method(:test)).visibility.should eq :private
   end
 end

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -4,92 +4,92 @@ require 'set'
 describe Pry::Method do
   it "should use String names for compatibility" do
     klass = Class.new { def hello; end }
-    Pry::Method.new(klass.instance_method(:hello)).name.should == "hello"
+    Pry::Method.new(klass.instance_method(:hello)).name.should eq "hello"
   end
 
   describe ".from_str" do
     it 'should look up instance methods if no methods available and no options provided' do
       klass = Class.new { def hello; end }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass))
-      meth.should == klass.instance_method(:hello)
+      meth.should eq klass.instance_method(:hello)
     end
 
     it 'should look up methods if no instance methods available and no options provided' do
       klass = Class.new { def self.hello; end }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass))
-      meth.should == klass.method(:hello)
+      meth.should eq klass.method(:hello)
     end
 
     it 'should look up instance methods first even if methods available and no options provided' do
       klass = Class.new { def hello; end; def self.hello; end  }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass))
-      meth.should == klass.instance_method(:hello)
+      meth.should eq klass.instance_method(:hello)
     end
 
     it 'should look up instance methods if "instance-methods"  option provided' do
       klass = Class.new { def hello; end; def self.hello; end  }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass), {"instance-methods" => true})
-      meth.should == klass.instance_method(:hello)
+      meth.should eq klass.instance_method(:hello)
     end
 
     it 'should look up methods if :methods  option provided' do
       klass = Class.new { def hello; end; def self.hello; end  }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass), {:methods => true})
-      meth.should == klass.method(:hello)
+      meth.should eq klass.method(:hello)
     end
 
     it 'should look up instance methods using the Class#method syntax' do
       klass = Class.new { def hello; end; def self.hello; end  }
       meth = Pry::Method.from_str("klass#hello", Pry.binding_for(binding))
-      meth.should == klass.instance_method(:hello)
+      meth.should eq klass.instance_method(:hello)
     end
 
     it 'should look up methods using the object.method syntax' do
       klass = Class.new { def hello; end; def self.hello; end  }
       meth = Pry::Method.from_str("klass.hello", Pry.binding_for(binding))
-      meth.should == klass.method(:hello)
+      meth.should eq klass.method(:hello)
     end
 
     it 'should NOT look up instance methods using the Class#method syntax if no instance methods defined' do
-      klass = Class.new { def self.hello; end  }
-      meth = Pry::Method.from_str("klass#hello", Pry.binding_for(binding))
-      meth.should == nil
+      _klass = Class.new { def self.hello; end  }
+      meth = Pry::Method.from_str("_klass#hello", Pry.binding_for(binding))
+      meth.should eq nil
     end
 
     it 'should NOT look up methods using the object.method syntax if no methods defined' do
-      klass = Class.new { def hello; end  }
-      meth = Pry::Method.from_str("klass.hello", Pry.binding_for(binding))
-      meth.should == nil
+      _klass = Class.new { def hello; end  }
+      meth = Pry::Method.from_str("_klass.hello", Pry.binding_for(binding))
+      meth.should eq nil
     end
 
     it 'should look up methods using klass.new.method syntax' do
-      klass = Class.new { def hello; :hello; end }
-      meth = Pry::Method.from_str("klass.new.hello", Pry.binding_for(binding))
-      meth.name.should == "hello"
+      _klass = Class.new { def hello; :hello; end }
+      meth = Pry::Method.from_str("_klass.new.hello", Pry.binding_for(binding))
+      meth.name.should eq "hello"
     end
 
     it 'should take care of corner cases like mongo[] e.g Foo::Bar.new[]- issue 998' do
-      klass = Class.new { def []; :hello; end }
-      meth = Pry::Method.from_str("klass.new[]", Pry.binding_for(binding))
-      meth.name.should == "[]"
+      _klass = Class.new { def []; :hello; end }
+      meth = Pry::Method.from_str("_klass.new[]", Pry.binding_for(binding))
+      meth.name.should eq "[]"
     end
 
     it 'should take care of cases like $ mongo[] - issue 998' do
       f = Class.new { def []; :hello; end }.new
       meth = Pry::Method.from_str("f[]", Pry.binding_for(binding))
-      meth.name.should == "[]"
+      meth.should eq f.method(:[])
     end
 
     it 'should look up instance methods using klass.meth#method syntax' do
-      klass = Class.new { def self.meth; Class.new; end }
-      meth = Pry::Method.from_str("klass.meth#initialize", Pry.binding_for(binding))
-      meth.name.should == "initialize"
+      _klass = Class.new { def self.meth; Class.new; end }
+      meth = Pry::Method.from_str("_klass.meth#initialize", Pry.binding_for(binding))
+      meth.name.should eq "initialize"
     end
 
     it 'should look up methods using instance::bar syntax' do
-      klass = Class.new{ def self.meth; Class.new; end }
-      meth = Pry::Method.from_str("klass::meth", Pry.binding_for(binding))
-      meth.name.should == "meth"
+      _klass = Class.new{ def self.meth; Class.new; end }
+      meth = Pry::Method.from_str("_klass::meth", Pry.binding_for(binding))
+      meth.name.should eq "meth"
     end
 
     it 'should not raise an exception if receiver does not exist' do
@@ -99,11 +99,11 @@ describe Pry::Method do
 
   describe '.from_binding' do
     it 'should be able to pick a method out of a binding' do
-      Pry::Method.from_binding(Class.new{ def self.foo; binding; end }.foo).name.should == "foo"
+      Pry::Method.from_binding(Class.new{ def self.foo; binding; end }.foo).name.should eq "foo"
     end
 
     it 'should NOT find a method from the toplevel binding' do
-      Pry::Method.from_binding(TOPLEVEL_BINDING).should == nil
+      Pry::Method.from_binding(TOPLEVEL_BINDING).should eq nil
     end
 
     it "should find methods that have been undef'd" do
@@ -115,7 +115,7 @@ describe Pry::Method do
       end
 
       m = Pry::Method.from_binding(c.bar)
-      m.name.should == "bar"
+      m.name.should eq "bar"
     end
 
     # Our source_location trick doesn't work, due to https://github.com/rubinius/rubinius/issues/953
@@ -127,9 +127,9 @@ describe Pry::Method do
         g = b.new.gag33
         m = Pry::Method.from_binding(g)
 
-        m.owner.should == a
-        m.source_line.should == a.line
-        m.name.should == "gag33"
+        m.owner.should eq a
+        m.source_line.should eq a.line
+        m.name.should eq "gag33"
       end
     end
 
@@ -139,9 +139,9 @@ describe Pry::Method do
 
       m = Pry::Method.from_binding(b.new.gag)
 
-      m.owner.should == b
-      m.source_line.should == b.line
-      m.name.should == "gag"
+      m.owner.should eq b
+      m.source_line.should eq b.line
+      m.name.should eq "gag"
     end
 
     # Temporarily disabled to work around rubinius/rubinius#2871.
@@ -150,9 +150,9 @@ describe Pry::Method do
         a = Class.new(BasicObject) { def gag; ::Kernel.binding; end; def self.line; __LINE__; end }
 
         m = Pry::Method.from_binding(a.new.gag)
-        m.owner.should == a
-        m.source_file.should == __FILE__
-        m.source_line.should == a.line
+        m.owner.should eq a
+        m.source_file.should eq __FILE__
+        m.source_line.should eq a.line
       end
     end
 
@@ -160,7 +160,7 @@ describe Pry::Method do
       o = Object.new
       class << o
         def borscht
-          "nips"
+          @nips = "nips"
           binding
         end
         alias paella borscht
@@ -168,7 +168,7 @@ describe Pry::Method do
       end
 
       m = Pry::Method.from_binding(o.borscht)
-      m.source.should == Pry::Method(o.method(:paella)).source
+      m.source.should eq Pry::Method(o.method(:paella)).source
     end
   end
 
@@ -180,8 +180,8 @@ describe Pry::Method do
       obj = b.new
 
       zuper = Pry::Method(obj.method(:rar)).super
-      zuper.owner.should == a
-      zuper.receiver.should == obj
+      zuper.owner.should eq a
+      zuper.receiver.should eq obj
     end
 
     it 'should be able to find the super method of an unbound method' do
@@ -189,13 +189,13 @@ describe Pry::Method do
       b = Class.new(a){ def rar; super; end }
 
       zuper = Pry::Method(b.instance_method(:rar)).super
-      zuper.owner.should == a
+      zuper.owner.should eq a
     end
 
     it 'should return nil if no super method exists' do
       a = Class.new{ def rar; super; end }
 
-      Pry::Method(a.instance_method(:rar)).super.should == nil
+      Pry::Method(a.instance_method(:rar)).super.should eq nil
     end
 
     it 'should be able to find super methods defined on modules' do
@@ -203,7 +203,7 @@ describe Pry::Method do
       a = Class.new{ def rar; super; end; include m }
 
       zuper = Pry::Method(a.new.method(:rar)).super
-      zuper.owner.should == m
+      zuper.owner.should eq m
     end
 
     it 'should be able to find super methods defined on super-classes when there are modules in the way' do
@@ -212,7 +212,7 @@ describe Pry::Method do
       b = Class.new(a){ def rar; super; end; include m }
 
       zuper = Pry::Method(b.new.method(:rar)).super
-      zuper.owner.should == a
+      zuper.owner.should eq a
     end
 
     it 'should be able to jump up multiple levels of bound method, even through modules' do
@@ -221,8 +221,8 @@ describe Pry::Method do
       b = Class.new(a){ def rar; super; end; include m }
 
       zuper = Pry::Method(b.new.method(:rar)).super
-      zuper.owner.should == m
-      zuper.super.owner.should == a
+      zuper.owner.should eq m
+      zuper.super.owner.should eq a
     end
   end
 
@@ -264,7 +264,7 @@ describe Pry::Method do
 
     it 'should attribute overridden methods to the sub-class' do
       @class = Class.new(Class.new{ include Module.new{ def meth; 1; end; } }) { def meth; 2; end }
-      Pry::Method.all_from_class(@class).detect{ |x| x.name == 'meth' }.owner.should == @class
+      Pry::Method.all_from_class(@class).detect{ |x| x.name == 'meth' }.owner.should eq @class
     end
 
     it 'should be able to find methods defined on a singleton class' do
@@ -344,7 +344,7 @@ describe Pry::Method do
 
       it "should not find methods defined within the class" do
         @class = Class.new{ def meth; 1; end }
-        Pry::Method.all_from_obj(@obj).map(&:name).should_not include 'meth'
+        Pry::Method.all_from_obj(@class).map(&:name).should_not include 'meth'
       end
 
       it "should find methods defined on Class" do
@@ -359,17 +359,17 @@ describe Pry::Method do
 
       it "should attribute overridden methods to the sub-class' singleton class" do
         @class = Class.new(Class.new{ class << self; def meth; 1; end; end }) { class << self; def meth; 1; end; end }
-        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner.should == (class << @class; self; end)
+        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner.should eq (class << @class; self; end)
       end
 
       it "should attrbute overridden methods to the class not the module" do
         @class = Class.new { class << self; def meth; 1; end; end; extend Module.new{ def meth; 1; end; } }
-        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner.should == (class << @class; self; end)
+        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner.should eq (class << @class; self; end)
       end
 
       it "should attribute overridden methods to the relevant singleton class in preference to Class" do
         @class = Class.new { class << self; def allocate; 1; end; end }
-        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'allocate' }.owner.should == (class << @class; self; end)
+        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'allocate' }.owner.should eq (class << @class; self; end)
       end
     end
 
@@ -392,44 +392,44 @@ describe Pry::Method do
       def singleton_class(obj); class << obj; self; end; end
 
       it "should look at a class and then its superclass" do
-        Pry::Method.instance_resolution_order(LS::Next).should == [LS::Next] + Pry::Method.instance_resolution_order(LS::Top)
+        Pry::Method.instance_resolution_order(LS::Next).should eq [LS::Next] + Pry::Method.instance_resolution_order(LS::Top)
       end
 
       it "should include the included modules between a class and its superclass" do
-        Pry::Method.instance_resolution_order(LS::Low).should == [LS::Low, LS::P, LS::N, LS::M] + Pry::Method.instance_resolution_order(LS::Next)
+        Pry::Method.instance_resolution_order(LS::Low).should eq [LS::Low, LS::P, LS::N, LS::M] + Pry::Method.instance_resolution_order(LS::Next)
       end
 
       it "should not include modules extended into the class" do
-        Pry::Method.instance_resolution_order(LS::Bottom).should == [LS::Bottom] + Pry::Method.instance_resolution_order(LS::Lower)
+        Pry::Method.instance_resolution_order(LS::Bottom).should eq [LS::Bottom] + Pry::Method.instance_resolution_order(LS::Lower)
       end
 
       it "should include included modules for Modules" do
-        Pry::Method.instance_resolution_order(LS::O).should == [LS::O, LS::M]
+        Pry::Method.instance_resolution_order(LS::O).should eq [LS::O, LS::M]
       end
 
       it "should include the singleton class of objects" do
         obj = LS::Low.new
-        Pry::Method.resolution_order(obj).should == [singleton_class(obj)] + Pry::Method.instance_resolution_order(LS::Low)
+        Pry::Method.resolution_order(obj).should eq [singleton_class(obj)] + Pry::Method.instance_resolution_order(LS::Low)
       end
 
       it "should not include singleton classes of numbers" do
-        Pry::Method.resolution_order(4).should == Pry::Method.instance_resolution_order(Fixnum)
+        Pry::Method.resolution_order(4).should eq Pry::Method.instance_resolution_order(Fixnum)
       end
 
       it "should include singleton classes for classes" do
-        Pry::Method.resolution_order(LS::Low).should == [singleton_class(LS::Low)] + Pry::Method.resolution_order(LS::Next)
+        Pry::Method.resolution_order(LS::Low).should eq [singleton_class(LS::Low)] + Pry::Method.resolution_order(LS::Next)
       end
 
       it "should include modules included into singleton classes" do
-        Pry::Method.resolution_order(LS::Lower).should == [singleton_class(LS::Lower), LS::N, LS::M] + Pry::Method.resolution_order(LS::Low)
+        Pry::Method.resolution_order(LS::Lower).should eq [singleton_class(LS::Lower), LS::N, LS::M] + Pry::Method.resolution_order(LS::Low)
       end
 
       it "should include modules at most once" do
-        Pry::Method.resolution_order(LS::Bottom).count(LS::M).should == 1
+        Pry::Method.resolution_order(LS::Bottom).count(LS::M).should eq 1
       end
 
       it "should include modules at the point which they would be reached" do
-        Pry::Method.resolution_order(LS::Bottom).should == [singleton_class(LS::Bottom), LS::O] + (Pry::Method.resolution_order(LS::Lower))
+        Pry::Method.resolution_order(LS::Bottom).should eq [singleton_class(LS::Bottom), LS::O] + (Pry::Method.resolution_order(LS::Lower))
       end
 
       it "should include the Pry::Method.instance_resolution_order of Class after the singleton classes" do
@@ -443,10 +443,10 @@ describe Pry::Method do
   describe 'method_name_from_first_line' do
     it 'should work in all simple cases' do
       meth = Pry::Method.new(nil)
-      meth.send(:method_name_from_first_line, "def x").should == "x"
-      meth.send(:method_name_from_first_line, "def self.x").should == "x"
-      meth.send(:method_name_from_first_line, "def ClassName.x").should == "x"
-      meth.send(:method_name_from_first_line, "def obj_name.x").should == "x"
+      meth.send(:method_name_from_first_line, "def x").should eq "x"
+      meth.send(:method_name_from_first_line, "def self.x").should eq "x"
+      meth.send(:method_name_from_first_line, "def ClassName.x").should eq "x"
+      meth.send(:method_name_from_first_line, "def obj_name.x").should eq "x"
     end
   end
 
@@ -468,7 +468,7 @@ describe Pry::Method do
       meth = Pry::Method(@class.new.method(:eat))
       aliases = Set.new(meth.aliases)
 
-      aliases.should == Set.new(["fress", "omnomnom"])
+      aliases.should eq Set.new(["fress", "omnomnom"])
     end
 
     it 'should return an empty Array if cannot find aliases' do
@@ -501,7 +501,7 @@ describe Pry::Method do
       meth = Pry::Method(Hash.new.method(:key?))
       aliases = Set.new(meth.aliases)
 
-      aliases.should == Set.new(["include?", "member?", "has_key?"])
+      aliases.should eq Set.new(["include?", "member?", "has_key?"])
     end
   end
 end

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -359,17 +359,17 @@ describe Pry::Method do
 
       it "should attribute overridden methods to the sub-class' singleton class" do
         @class = Class.new(Class.new{ class << self; def meth; 1; end; end }) { class << self; def meth; 1; end; end }
-        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner.should eq (class << @class; self; end)
+        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner.should eq(class << @class; self; end)
       end
 
       it "should attrbute overridden methods to the class not the module" do
         @class = Class.new { class << self; def meth; 1; end; end; extend Module.new{ def meth; 1; end; } }
-        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner.should eq (class << @class; self; end)
+        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner.should eq(class << @class; self; end)
       end
 
       it "should attribute overridden methods to the relevant singleton class in preference to Class" do
         @class = Class.new { class << self; def allocate; 1; end; end }
-        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'allocate' }.owner.should eq (class << @class; self; end)
+        Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'allocate' }.owner.should eq(class << @class; self; end)
       end
     end
 

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -7,15 +7,15 @@ describe "Prompts" do
       redirect_pry_io(InputTester.new("exit-all")) do
         Pry.start(self, :prompt => proc { |v| config = v })
       end
-      config.is_a?(Pry::Config).should == true
+      config.is_a?(Pry::Config).should eq true
     end
 
     it 'should get full config object, when using a proc array' do
       config1 = nil
       redirect_pry_io(InputTester.new("exit-all")) do
-        Pry.start(self, :prompt => [proc { |v| config1 = v }, proc { |v| config2 = v }])
+        Pry.start(self, :prompt => [proc { |v| config1 = v }, proc { |_v| _config2 = v }])
       end
-      config1.is_a?(Pry::Config).should == true
+      config1.is_a?(Pry::Config).should eq true
     end
 
     it 'should receive correct data in the config object' do
@@ -25,10 +25,10 @@ describe "Prompts" do
       end
 
       config.eval_string.should =~ /def hello/
-      config.nesting_level.should == 0
-      config.expr_number.should == 1
-      config.cont.should == true
-      config._pry_.is_a?(Pry).should == true
+      config.nesting_level.should eq 0
+      config.expr_number.should eq 1
+      config.cont.should eq true
+      config._pry_.is_a?(Pry).should eq true
       expect(config.object).to eq self
     end
   end
@@ -40,9 +40,9 @@ describe "Prompts" do
         Pry.start(:test, :prompt => proc { |obj, nesting, _pry_|
                     o, n, p = obj, nesting, _pry_ })
       end
-      o.should == :test
-      n.should == 0
-      p.is_a?(Pry).should == true
+      o.should eq :test
+      n.should eq 0
+      p.is_a?(Pry).should eq true
     end
 
     it 'should get 3 parameters, when using proc array' do
@@ -51,11 +51,11 @@ describe "Prompts" do
         Pry.start(:test, :prompt => [proc { |obj, nesting, _pry_|
                                        o1, n1, p1 = obj, nesting, _pry_ },
                                      proc { |obj, nesting, _pry_|
-                                       o2, n2, p2 = obj, nesting, _pry_ }])
+                                       _o2, _n2, _p2 = obj, nesting, _pry_ }])
       end
-      o1.should == :test
-      n1.should == 0
-      p1.is_a?(Pry).should == true
+      o1.should eq :test
+      n1.should eq 0
+      p1.is_a?(Pry).should eq true
     end
   end
 end

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -13,7 +13,7 @@ describe "Prompts" do
     it 'should get full config object, when using a proc array' do
       config1 = nil
       redirect_pry_io(InputTester.new("exit-all")) do
-        Pry.start(self, :prompt => [proc { |v| config1 = v }, proc { |_v| _config2 = v }])
+        Pry.start(self, :prompt => [proc { |v| config1 = v }, proc { |v| _config2 = v }])
       end
       config1.is_a?(Pry::Config).should eq true
     end

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -1,6 +1,6 @@
 require_relative 'helper'
 
-version = 1
+_version = 1
 
 describe "test Pry defaults" do
   before do
@@ -41,7 +41,7 @@ describe "test Pry defaults" do
       end.new
 
       Pry.start(self, :input => arity_one_input, :output => StringIO.new)
-      arity_one_input.prompt.should == Pry.prompt.call
+      arity_one_input.prompt.should eq Pry.prompt.call
     end
 
     it 'should not pass in the prompt if the arity is 0' do
@@ -69,7 +69,7 @@ describe "test Pry defaults" do
       end.new
 
       Pry.start(self, :input => arity_multi_input, :output => StringIO.new)
-      arity_multi_input.prompt.should == nil
+      arity_multi_input.prompt.should eq nil
     end
 
   end
@@ -96,40 +96,40 @@ describe "test Pry defaults" do
     new_print = proc { |out, value| out.puts "=> LOL" }
     Pry.config.print =  new_print
 
-    Pry.new.print.should == Pry.config.print
+    Pry.new.print.should eq Pry.config.print
     Object.new.pry :input => InputTester.new("\"test\""), :output => @str_output
-    @str_output.string.should == "=> LOL\n"
+    @str_output.string.should eq "=> LOL\n"
 
     @str_output = StringIO.new
     Object.new.pry :input => InputTester.new("\"test\""), :output => @str_output,
                    :print => proc { |out, value| out.puts value.reverse }
-    @str_output.string.should == "tset\n"
+    @str_output.string.should eq "tset\n"
 
-    Pry.new.print.should == Pry.config.print
+    Pry.new.print.should eq Pry.config.print
     @str_output = StringIO.new
     Object.new.pry :input => InputTester.new("\"test\""), :output => @str_output
-    @str_output.string.should == "=> LOL\n"
+    @str_output.string.should eq "=> LOL\n"
   end
 
   describe "pry return values" do
     it 'should return nil' do
-      Pry.start(self, :input => StringIO.new("exit-all"), :output => StringIO.new).should == nil
+      Pry.start(self, :input => StringIO.new("exit-all"), :output => StringIO.new).should eq nil
     end
 
     it 'should return the parameter given to exit-all' do
-      Pry.start(self, :input => StringIO.new("exit-all 10"), :output => StringIO.new).should == 10
+      Pry.start(self, :input => StringIO.new("exit-all 10"), :output => StringIO.new).should eq 10
     end
 
     it 'should return the parameter (multi word string) given to exit-all' do
-      Pry.start(self, :input => StringIO.new("exit-all \"john mair\""), :output => StringIO.new).should == "john mair"
+      Pry.start(self, :input => StringIO.new("exit-all \"john mair\""), :output => StringIO.new).should eq "john mair"
     end
 
     it 'should return the parameter (function call) given to exit-all' do
-      Pry.start(self, :input => StringIO.new("exit-all 'abc'.reverse"), :output => StringIO.new).should == 'cba'
+      Pry.start(self, :input => StringIO.new("exit-all 'abc'.reverse"), :output => StringIO.new).should eq 'cba'
     end
 
     it 'should return the parameter (self) given to exit-all' do
-      Pry.start("carl", :input => StringIO.new("exit-all self"), :output => StringIO.new).should == "carl"
+      Pry.start("carl", :input => StringIO.new("exit-all self"), :output => StringIO.new).should eq "carl"
     end
   end
 
@@ -151,17 +151,17 @@ describe "test Pry defaults" do
       new_prompt = proc { "A" }
 
       pry = Pry.new
-      pry.prompt.should == Pry.prompt
-      get_prompts(pry).should == ["test prompt> ",  "test prompt> "]
+      pry.prompt.should eq Pry.prompt
+      get_prompts(pry).should eq ["test prompt> ",  "test prompt> "]
 
 
       pry = Pry.new(:prompt => new_prompt)
-      pry.prompt.should == new_prompt
-      get_prompts(pry).should == ["A",  "A"]
+      pry.prompt.should eq new_prompt
+      get_prompts(pry).should eq ["A",  "A"]
 
       pry = Pry.new
-      pry.prompt.should == Pry.prompt
-      get_prompts(pry).should == ["test prompt> ",  "test prompt> "]
+      pry.prompt.should eq Pry.prompt
+      get_prompts(pry).should eq ["test prompt> ",  "test prompt> "]
     end
 
     it 'should set the prompt default, and the default should be overridable (multi prompt)' do
@@ -169,17 +169,17 @@ describe "test Pry defaults" do
       new_prompt = [proc { "A" }, proc { "B" }]
 
       pry = Pry.new
-      pry.prompt.should == Pry.prompt
-      get_prompts(pry).should == ["test prompt> ",  "test prompt* "]
+      pry.prompt.should eq Pry.prompt
+      get_prompts(pry).should eq ["test prompt> ",  "test prompt* "]
 
 
       pry = Pry.new(:prompt => new_prompt)
-      pry.prompt.should == new_prompt
-      get_prompts(pry).should == ["A",  "B"]
+      pry.prompt.should eq new_prompt
+      get_prompts(pry).should eq ["A",  "B"]
 
       pry = Pry.new
-      pry.prompt.should == Pry.prompt
-      get_prompts(pry).should == ["test prompt> ",  "test prompt* "]
+      pry.prompt.should eq Pry.prompt
+      get_prompts(pry).should eq ["test prompt> ",  "test prompt* "]
     end
 
     describe 'storing and restoring the prompt' do
@@ -195,49 +195,49 @@ describe "test Pry defaults" do
       it 'should have a prompt stack' do
         @pry.push_prompt @b
         @pry.push_prompt @c
-        @pry.prompt.should == @c
+        @pry.prompt.should eq @c
         @pry.pop_prompt
-        @pry.prompt.should == @b
+        @pry.prompt.should eq @b
         @pry.pop_prompt
-        @pry.prompt.should == @a
+        @pry.prompt.should eq @a
       end
 
       it 'should restore overridden prompts when returning from file-mode' do
         pry = Pry.new(:prompt => [ proc { 'P>' } ] * 2)
-        pry.select_prompt.should == "P>"
+        pry.select_prompt.should eq "P>"
         pry.process_command('shell-mode')
         pry.select_prompt.should =~ /\Apry .* \$ \z/
         pry.process_command('shell-mode')
-        pry.select_prompt.should == "P>"
+        pry.select_prompt.should eq "P>"
       end
 
       it '#pop_prompt should return the popped prompt' do
         @pry.push_prompt @b
         @pry.push_prompt @c
-        @pry.pop_prompt.should == @c
-        @pry.pop_prompt.should == @b
+        @pry.pop_prompt.should eq @c
+        @pry.pop_prompt.should eq @b
       end
 
       it 'should not pop the last prompt' do
         @pry.push_prompt @b
-        @pry.pop_prompt.should == @b
-        @pry.pop_prompt.should == @a
-        @pry.pop_prompt.should == @a
-        @pry.prompt.should == @a
+        @pry.pop_prompt.should eq @b
+        @pry.pop_prompt.should eq @a
+        @pry.pop_prompt.should eq @a
+        @pry.prompt.should eq @a
       end
 
       describe '#prompt= should replace the current prompt with the new prompt' do
         it 'when only one prompt on the stack' do
           @pry.prompt = @b
-          @pry.prompt.should == @b
-          @pry.pop_prompt.should == @b
-          @pry.pop_prompt.should == @b
+          @pry.prompt.should eq @b
+          @pry.pop_prompt.should eq @b
+          @pry.pop_prompt.should eq @b
         end
         it 'when several prompts on the stack' do
           @pry.push_prompt @b
           @pry.prompt = @c
-          @pry.pop_prompt.should == @c
-          @pry.pop_prompt.should == @a
+          @pry.pop_prompt.should eq @c
+          @pry.pop_prompt.should eq @a
         end
       end
     end
@@ -261,14 +261,14 @@ describe "test Pry defaults" do
     describe "given the 'main' object" do
       it "returns the #to_s of main (special case)" do
         o = TOPLEVEL_BINDING.eval('self')
-        Pry.view_clip(o, DEFAULT_OPTIONS).should == o.to_s
+        Pry.view_clip(o, DEFAULT_OPTIONS).should eq o.to_s
       end
     end
 
     describe "the list of prompt safe objects" do
       [1, 2.0, -5, "hello", :test].each do |o|
         it "returns the #inspect of the special-cased immediate object: #{o}" do
-          Pry.view_clip(o, DEFAULT_OPTIONS).should == o.inspect
+          Pry.view_clip(o, DEFAULT_OPTIONS).should eq o.inspect
         end
       end
 
@@ -281,7 +281,7 @@ describe "test Pry defaults" do
         Barbie = Class.new { def inspect; "life is plastic, it's fantastic" end }
         Pry.config.prompt_safe_objects << Barbie
         output = Pry.view_clip(Barbie.new, DEFAULT_OPTIONS)
-        output.should == "life is plastic, it's fantastic"
+        output.should eq "life is plastic, it's fantastic"
       end
     end
 
@@ -335,8 +335,8 @@ describe "test Pry defaults" do
             def c.name; "a" * MAX_LENGTH; end
             def m.name; "a" * MAX_LENGTH; end
 
-            Pry.view_clip(c, DEFAULT_OPTIONS).should == c.name
-            Pry.view_clip(m, DEFAULT_OPTIONS).should == m.name
+            Pry.view_clip(c, DEFAULT_OPTIONS).should eq c.name
+            Pry.view_clip(m, DEFAULT_OPTIONS).should eq m.name
           end
         end
 
@@ -361,13 +361,13 @@ describe "test Pry defaults" do
               :quiet => true,
               :hooks => Pry::DEFAULT_HOOKS)
 
-      @str_output.string.should == ""
+      @str_output.string.should eq ""
     end
   end
 
   describe 'toplevel_binding' do
     it 'should be devoid of local variables' do
-      pry_eval(Pry.toplevel_binding, "ls -l").should_not =~ /version/
+      pry_eval(Pry.toplevel_binding, "ls -l").should_not =~ /_version/
     end
 
     it 'should have self the same as TOPLEVEL_BINDING' do
@@ -378,8 +378,8 @@ describe "test Pry defaults" do
     unless Pry::Helpers::BaseHelpers.rbx?
       it 'should define private methods on Object' do
         TOPLEVEL_BINDING.eval 'def gooey_fooey; end'
-        method(:gooey_fooey).owner.should == Object
-        Pry::Method(method(:gooey_fooey)).visibility.should == :private
+        method(:gooey_fooey).owner.should eq Object
+        Pry::Method(method(:gooey_fooey)).visibility.should eq :private
       end
     end
   end

--- a/spec/pry_repl_spec.rb
+++ b/spec/pry_repl_spec.rb
@@ -5,7 +5,7 @@ describe "The whole thing" do
     ReplTester.start do
       input  'def a'
       input  '!'
-      output /^Input buffer cleared/
+      output(/^Input buffer cleared/)
 
       input  '5'
       output '=> 5'
@@ -15,14 +15,14 @@ describe "The whole thing" do
   it "should rescue exceptions" do
     ReplTester.start do
       input  'raise "lorum"'
-      output /^RuntimeError: lorum/
+      output(/^RuntimeError: lorum/)
 
       if defined?(java)
         input  'raise java.lang.Exception.new("foo")'
-        output /Exception: foo/
+        output(/Exception: foo/)
 
         input  'raise java.io.IOException.new("bar")'
-        output /IOException: bar/
+        output(/IOException: bar/)
       end
     end
   end
@@ -32,7 +32,7 @@ describe "The whole thing" do
       ReplTester.start do
         input  'Pry::REPL.new(_pry_, :target => 10).start'
         output ''
-        prompt /10.*> $/
+        prompt(/10.*> $/)
 
         input  'self'
         output '=> 10'
@@ -49,7 +49,7 @@ describe "The whole thing" do
       ReplTester.start do
         input  'Pry.start(10, _pry_.config)'
         output ''
-        prompt /10.*> $/
+        prompt(/10.*> $/)
 
         input  'self'
         output '=> 10'
@@ -66,14 +66,14 @@ describe "The whole thing" do
       ReplTester.start do
         input  'cd 10'
         output ''
-        prompt /10.*> $/
+        prompt(/10.*> $/)
 
         input  '_pry_.binding_stack.pop'
-        output /^=> #<Binding/
-        prompt /main.*> $/
+        output(/^=> #<Binding/)
+        prompt(/main.*> $/)
 
         input  '_pry_.binding_stack.pop'
-        output /^=> #<Binding/
+        output(/^=> #<Binding/)
         assert_exited
       end
     end
@@ -90,11 +90,11 @@ describe "The whole thing" do
       ReplTester.start(:commands => set) do
         input  'def x'
         output ''
-        prompt /\*   $/
+        prompt(/\*   $/)
 
         input  'hello!'
         output '=> "hello"'
-        prompt /> $/
+        prompt(/> $/)
       end
     end
   end

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -24,11 +24,11 @@ describe Pry do
     end
 
     it 'should not binding.pry' do
-      binding.pry.should == nil
+      binding.pry.should eq nil
     end
 
     it 'should not Pry.start' do
-      Pry.start.should == nil
+      Pry.start.should eq nil
     end
   end
 
@@ -75,7 +75,7 @@ describe Pry do
 
     it "returns an instance of Pry::LastException" do
       @pry.last_exception = @e
-      @pry.last_exception.wrapped_exception.should == @e
+      @pry.last_exception.wrapped_exception.should eq @e
     end
 
     it "returns a frozen exception" do
@@ -107,13 +107,13 @@ describe Pry do
 
       it 'should be able to operate inside the BasicObject class' do
         pry_eval(BasicObject, ":foo", "Pad.obj = _")
-        Pad.obj.should == :foo
+        Pad.obj.should eq :foo
       end
 
       it 'should set an ivar on an object' do
         o = Object.new
         pry_eval(o, "@x = 10")
-        o.instance_variable_get(:@x).should == 10
+        o.instance_variable_get(:@x).should eq 10
       end
 
       it 'should display error if Pry instance runs out of input' do
@@ -125,32 +125,32 @@ describe Pry do
 
       it 'should make self evaluate to the receiver of the rep session' do
         o = :john
-        pry_eval(o, "self").should == o
+        pry_eval(o, "self").should eq o
       end
 
       it 'should define a nested class under Hello and not on top-level or Pry' do
         mock_pry(Pry.binding_for(Hello), "class Nested", "end")
-        Hello.const_defined?(:Nested).should == true
+        Hello.const_defined?(:Nested).should eq true
       end
 
       it 'should suppress output if input ends in a ";" and is an Exception object (single line)' do
-        mock_pry("Exception.new;").should == ""
+        mock_pry("Exception.new;").should eq ""
       end
 
       it 'should suppress output if input ends in a ";" (single line)' do
-        mock_pry("x = 5;").should == ""
+        mock_pry("x = 5;").should eq ""
       end
 
       it 'should be able to evaluate exceptions normally' do
         was_called = false
         mock_pry("RuntimeError.new", :exception_handler => proc{ was_called = true })
-        was_called.should == false
+        was_called.should eq false
       end
 
       it 'should notice when exceptions are raised' do
         was_called = false
         mock_pry("raise RuntimeError", :exception_handler => proc{ was_called = true })
-        was_called.should == true
+        was_called.should eq true
       end
 
       it 'should not try to catch intended exceptions' do
@@ -165,7 +165,7 @@ describe Pry do
         end
 
         it 'should suppress output if input ends in a ";" (multi-line)' do
-          mock_pry('def self.blah', ':test', 'end;').should == ''
+          mock_pry('def self.blah', ':test', 'end;').should eq ''
         end
 
         describe "newline stripping from an empty string" do
@@ -215,9 +215,9 @@ describe Pry do
 
           o = Object.new
 
-          pry_tester = Pry.start(o, :input => input, :output => StringIO.new)
+          Pry.start(o, :input => input, :output => StringIO.new)
 
-          o.instance_variable_get(:@x).should == 10
+          o.instance_variable_get(:@x).should eq 10
         end
       end
 
@@ -226,7 +226,7 @@ describe Pry do
           clean = "puts <<-FOO\nhi\nFOO\n"
           a = clean.dup
           Pry::Code.complete_expression?(a)
-          a.should == clean
+          a.should eq clean
         end
       end
 
@@ -234,9 +234,9 @@ describe Pry do
         it 'sets _ to the last result' do
           t = pry_tester
           t.eval ":foo"
-          t.eval("_").should == :foo
+          t.eval("_").should eq :foo
           t.eval "42"
-          t.eval("_").should == 42
+          t.eval("_").should eq 42
         end
 
         it 'sets out to an array with the result' do
@@ -246,7 +246,7 @@ describe Pry do
           res = t.eval "_out_"
 
           res.should be_a_kind_of Pry::HistoryArray
-          res[1..2].should == [:foo, 42]
+          res[1..2].should eq [:foo, 42]
         end
 
         it 'sets _in_ to an array with the entered lines' do
@@ -256,28 +256,28 @@ describe Pry do
           res = t.eval "_in_"
 
           res.should be_a_kind_of Pry::HistoryArray
-          res[1..2].should == [":foo\n", "42\n"]
+          res[1..2].should eq [":foo\n", "42\n"]
         end
 
         it 'uses 100 as the size of _in_ and _out_' do
-          pry_tester.eval("[_in_.max_size, _out_.max_size]").should == [100, 100]
+          pry_tester.eval("[_in_.max_size, _out_.max_size]").should eq [100, 100]
         end
 
         it 'can change the size of the history arrays' do
-          pry_tester(:memory_size => 1000).eval("[_out_, _in_].map(&:max_size)").should == [1000, 1000]
+          pry_tester(:memory_size => 1000).eval("[_out_, _in_].map(&:max_size)").should eq [1000, 1000]
         end
 
         it 'store exceptions' do
           mock_pry("foo!", "Pad.in = _in_[-1]; Pad.out = _out_[-1]")
 
-          Pad.in.should == "foo!\n"
+          Pad.in.should eq "foo!\n"
           expect(Pad.out).to be_a_kind_of NoMethodError
         end
       end
 
       describe "last_result" do
         it "should be set to the most recent value" do
-          pry_eval("2", "_ + 82").should == 84
+          pry_eval("2", "_ + 82").should eq 84
         end
 
         # This test needs mock_pry because the command retvals work by
@@ -292,11 +292,11 @@ describe Pry do
         end
 
         it "should be preserved over an empty line" do
-          pry_eval("2 + 2", " ", "\t",  " ", "_ + 92").should == 96
+          pry_eval("2 + 2", " ", "\t",  " ", "_ + 92").should eq 96
         end
 
         it "should be preserved when evalling a  command without :keep_retval" do
-          pry_eval("2 + 2", "ls -l", "_ + 96").should == 100
+          pry_eval("2 + 2", "ls -l", "_ + 96").should eq 100
         end
       end
 
@@ -312,8 +312,8 @@ describe Pry do
           Pry.config.output = @str_output
 
           o = Object.new
+          o.pry
 
-          pry_tester = o.pry
           @str_output.string.should =~ /nest:3/
         end
       end
@@ -322,27 +322,27 @@ describe Pry do
         it 'should define a method on the singleton class of an object when performing "def meth;end" inside the object' do
           [Object.new, {}, []].each do |val|
             pry_eval(val, 'def hello; end')
-            val.methods(false).map(&:to_sym).include?(:hello).should == true
+            val.methods(false).map(&:to_sym).include?(:hello).should eq true
           end
         end
 
         it 'should define an instance method on the module when performing "def meth;end" inside the module' do
           hello = Module.new
           pry_eval(hello, "def hello; end")
-          hello.instance_methods(false).map(&:to_sym).include?(:hello).should == true
+          hello.instance_methods(false).map(&:to_sym).include?(:hello).should eq true
         end
 
         it 'should define an instance method on the class when performing "def meth;end" inside the class' do
           hello = Class.new
           pry_eval(hello, "def hello; end")
-          hello.instance_methods(false).map(&:to_sym).include?(:hello).should == true
+          hello.instance_methods(false).map(&:to_sym).include?(:hello).should eq true
         end
 
         it 'should define a method on the class of an object when performing "def meth;end" inside an immediate value or Numeric' do
           [:test, 0, true, false, nil,
               (0.0 unless Pry::Helpers::BaseHelpers.jruby?)].each do |val|
             pry_eval(val, "def hello; end");
-            val.class.instance_methods(false).map(&:to_sym).include?(:hello).should == true
+            val.class.instance_methods(false).map(&:to_sym).include?(:hello).should eq true
           end
         end
       end
@@ -384,9 +384,9 @@ describe Pry do
       describe "Pry.binding_for" do
         it 'should return TOPLEVEL_BINDING if parameter self is main' do
           _main_ = lambda { TOPLEVEL_BINDING.eval('self') }
-          Pry.binding_for(_main_.call).is_a?(Binding).should == true
-          Pry.binding_for(_main_.call).should == TOPLEVEL_BINDING
-          Pry.binding_for(_main_.call).should == Pry.binding_for(_main_.call)
+          Pry.binding_for(_main_.call).is_a?(Binding).should eq true
+          Pry.binding_for(_main_.call).should eq TOPLEVEL_BINDING
+          Pry.binding_for(_main_.call).should eq Pry.binding_for(_main_.call)
         end
       end
     end
@@ -394,12 +394,12 @@ describe Pry do
 
   describe 'setting custom options' do
     it 'does not raise for unrecognized options' do
-      expect { instance = Pry.new(:custom_option => 'custom value') }.to_not raise_error
+      expect { Pry.new(:custom_option => 'custom value') }.to_not raise_error
     end
 
     it 'correctly handles the :quiet option (#1261)' do
       instance = Pry.new(:quiet => true)
-      instance.quiet?.should == true
+      instance.quiet?.should eq true
     end
   end
 

--- a/spec/pryrc_spec.rb
+++ b/spec/pryrc_spec.rb
@@ -19,10 +19,10 @@ describe Pry do
 
     it "should never run the rc file twice" do
       Pry.start(self, :input => StringIO.new("exit-all\n"), :output => StringIO.new)
-      TEST_RC.should == [0]
+      TEST_RC.should eq [0]
 
       Pry.start(self, :input => StringIO.new("exit-all\n"), :output => StringIO.new)
-      TEST_RC.should == [0]
+      TEST_RC.should eq [0]
     end
 
     # Resolving symlinks doesn't work on jruby 1.9 [jruby issue #538]
@@ -33,7 +33,7 @@ describe Pry do
 
         Pry.start(self, :input => StringIO.new("exit-all\n"), :output => StringIO.new)
 
-        TEST_RC.should == [0]
+        TEST_RC.should eq [0]
       end
     end
 
@@ -50,12 +50,12 @@ describe Pry do
       Pry.config.should_load_rc = false
       Pry.config.should_load_local_rc = false
       Pry.start(self, :input => StringIO.new("exit-all\n"), :output => StringIO.new)
-      Object.const_defined?(:TEST_RC).should == false
+      Object.const_defined?(:TEST_RC).should eq false
     end
 
     describe "that raise exceptions" do
       before do
-        Pry::HOME_RC_FILE = "spec/fixtures/testrcbad"
+        Pry::HOME_RC_FILE.replace "spec/fixtures/testrcbad"
         Pry.config.should_load_local_rc = false
 
         putsed = nil
@@ -84,8 +84,8 @@ describe Pry do
 
       it "should continue to run pry" do
         @doing_it[]
-        Object.const_defined?(:TEST_BEFORE_RAISE).should == true
-        Object.const_defined?(:TEST_AFTER_RAISE).should == true
+        Object.const_defined?(:TEST_BEFORE_RAISE).should eq true
+        Object.const_defined?(:TEST_AFTER_RAISE).should eq true
       end
 
       it "should output an error" do

--- a/spec/spec_helpers/repl_tester.rb
+++ b/spec/spec_helpers/repl_tester.rb
@@ -59,6 +59,8 @@ class ReplTester
       end
     end
 
+    @should_exit_naturally = false
+
     wait # wait until the instance reaches its first readline
   end
 

--- a/spec/sticky_locals_spec.rb
+++ b/spec/sticky_locals_spec.rb
@@ -58,14 +58,14 @@ describe "Sticky locals (_file_ and friends)" do
 
   it 'locals should return last result (_)' do
     pry_tester.tap do |t|
-      lam = t.eval 'lambda { |foo| }'
+      lam = t.eval 'lambda { |_foo| }'
       t.eval('_').should == lam
     end
   end
 
   it 'locals should return second last result (__)' do
     pry_tester.tap do |t|
-      lam = t.eval 'lambda { |foo| }'
+      lam = t.eval 'lambda { |_foo| }'
       t.eval 'num = 1'
       t.eval('__').should == lam
     end

--- a/spec/sticky_locals_spec.rb
+++ b/spec/sticky_locals_spec.rb
@@ -80,7 +80,7 @@ describe "Sticky locals (_file_ and friends)" do
                                         "exit-all")) do
           Pry.start(o)
         end
-        o.instance_variable_get(:@value).should == :john
+        o.instance_variable_get(:@value).should eq :john
         Pry.config.extra_sticky_locals = {}
       end
 
@@ -93,7 +93,7 @@ describe "Sticky locals (_file_ and friends)" do
           Pry.start(o)
         end
 
-        o.instance_variable_get(:@value).should == :john
+        o.instance_variable_get(:@value).should eq :john
         Pry.config.extra_sticky_locals = {}
       end
 
@@ -107,7 +107,7 @@ describe "Sticky locals (_file_ and friends)" do
           Pry.start(o, :extra_sticky_locals => { :test_local => :john } )
         end
 
-        o.instance_variable_get(:@value).should == :john
+        o.instance_variable_get(:@value).should eq :john
       end
 
       it 'should define multiple sticky locals' do
@@ -119,8 +119,8 @@ describe "Sticky locals (_file_ and friends)" do
                       :test_local2 => :carl} )
         end
 
-        o.instance_variable_get(:@value1).should == :john
-        o.instance_variable_get(:@value2).should == :carl
+        o.instance_variable_get(:@value1).should eq :john
+        o.instance_variable_get(:@value2).should eq :carl
       end
 
 
@@ -131,7 +131,7 @@ describe "Sticky locals (_file_ and friends)" do
           Pry.start(o, :extra_sticky_locals => { :test_local => proc { :john }} )
         end
 
-        o.instance_variable_get(:@value).should == :john
+        o.instance_variable_get(:@value).should eq :john
       end
     end
 
@@ -145,7 +145,7 @@ describe "Sticky locals (_file_ and friends)" do
           Pry.start(o, :extra_sticky_locals => { :test_local => :carl })
         end
 
-        o.instance_variable_get(:@value).should == :carl
+        o.instance_variable_get(:@value).should eq :carl
         Pry.config.extra_sticky_locals = {}
       end
     end

--- a/spec/syntax_checking_spec.rb
+++ b/spec/syntax_checking_spec.rb
@@ -66,14 +66,14 @@ describe Pry do
   end
 
   it "should allow whitespace delimeted strings" do
-    mock_pry('"%s" %% foo ').should =~ /"foo"/
+    mock_pry('"%s" % % foo ').should =~ /"foo"/
   end
 
   it "should allow newline delimeted strings" do
-    mock_pry('"%s" %%','foo').should =~ /"foo"/
+    mock_pry('"%s" % %','foo').should =~ /"foo"/
   end
 
   it "should allow whitespace delimeted strings ending on the first char of a line" do
-    mock_pry('"%s" %% ', ' #done!').should =~ /"\\n"/
+    mock_pry('"%s" % % ', ' #done!').should =~ /"\\n"/
   end
 end

--- a/spec/syntax_checking_spec.rb
+++ b/spec/syntax_checking_spec.rb
@@ -23,7 +23,7 @@ describe Pry do
     end
   end
 
-  [
+  ([
     ["end"],
     ["puts )("],
     ["1 1"],
@@ -31,7 +31,7 @@ describe Pry do
   ] + (Pry::Helpers::BaseHelpers.rbx? ? [] : [
     ["def", "method(1"], # in this case the syntax error is "expecting ')'".
     ["o = Object.new.tap{ def o.render;","'MEH'", "}"] # in this case the syntax error is "expecting keyword_end".
-  ]).compact.each do |foo|
+  ])).compact.each do |foo|
     it "should raise an error on invalid syntax like #{foo.inspect}" do
       redirect_pry_io(InputTester.new(*foo), @str_output) do
         Pry.start
@@ -50,13 +50,11 @@ describe Pry do
   end
 
   it "should allow trailing , to continue the line" do
-    pry = Pry.new
-    Pry::Code.complete_expression?("puts 1, 2,").should == false
+    Pry::Code.complete_expression?("puts 1, 2,").should eq false
   end
 
   it "should complete an expression that contains a line ending with a ," do
-    pry = Pry.new
-    Pry::Code.complete_expression?("puts 1, 2,\n3").should == true
+    Pry::Code.complete_expression?("puts 1, 2,\n3").should eq true
   end
 
   it "should not suppress the error output if the line ends in ;" do

--- a/spec/wrapped_module_spec.rb
+++ b/spec/wrapped_module_spec.rb
@@ -39,15 +39,15 @@ describe Pry::WrappedModule do
 
     describe "number_of_candidates" do
       it 'should return the correct number of candidates' do
-        Pry::WrappedModule(Host::CandidateTest).number_of_candidates.should == 3
+        Pry::WrappedModule(Host::CandidateTest).number_of_candidates.should eq 3
       end
 
       it 'should return 0 candidates for a class with no nested modules or methods' do
-        Pry::WrappedModule(Host::PitifullyBlank).number_of_candidates.should == 0
+        Pry::WrappedModule(Host::PitifullyBlank).number_of_candidates.should eq 0
       end
 
       it 'should return 1 candidate for a class with a nested module with methods' do
-        Pry::WrappedModule(Host::ForeverAlone).number_of_candidates.should == 1
+        Pry::WrappedModule(Host::ForeverAlone).number_of_candidates.should eq 1
       end
     end
 
@@ -72,24 +72,24 @@ describe Pry::WrappedModule do
     describe "source_location" do
       it 'should return primary candidates source_location by default' do
         wm = Pry::WrappedModule(Host::CandidateTest)
-        wm.source_location.should == wm.candidate(0).source_location
+        wm.source_location.should eq wm.candidate(0).source_location
       end
 
       it 'should return the location of the outer module if an inner module has methods' do
         wm = Pry::WrappedModule(Host::ForeverAlone)
         File.expand_path(wm.source_location.first).should eq File.expand_path(__FILE__)
-        wm.source_location.last.should == Host::FOREVER_ALONE_LINE
+        wm.source_location.last.should eq Host::FOREVER_ALONE_LINE
       end
 
       it 'should return nil if no source_location can be found' do
-        Pry::WrappedModule(Host::PitifullyBlank).source_location.should == nil
+        Pry::WrappedModule(Host::PitifullyBlank).source_location.should eq nil
       end
     end
 
     describe "source" do
       it 'should return primary candidates source by default' do
         wm = Pry::WrappedModule(Host::CandidateTest)
-        wm.source.should == wm.candidate(0).source
+        wm.source.should eq wm.candidate(0).source
       end
 
       it 'should return source for highest ranked candidate' do
@@ -106,14 +106,14 @@ describe Pry::WrappedModule do
 
       it 'should return source for deeply nested class' do
         Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).source.should =~ /nested_method/
-        Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).source.lines.count.should == 4
+        Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).source.lines.count.should eq 4
       end
     end
 
     describe "doc" do
       it 'should return primary candidates doc by default' do
         wm = Pry::WrappedModule(Host::CandidateTest)
-        wm.doc.should == wm.candidate(0).doc
+        wm.doc.should eq wm.candidate(0).doc
       end
 
       it 'should return doc for highest ranked candidate' do
@@ -145,19 +145,19 @@ describe Pry::WrappedModule do
     end
 
     it "should return Foo# for normal classes" do
-      Pry::WrappedModule.new(Foo).method_prefix.should == "Foo#"
+      Pry::WrappedModule.new(Foo).method_prefix.should eq "Foo#"
     end
 
     it "should return Bar# for modules" do
-      Pry::WrappedModule.new(Kernel).method_prefix.should == "Kernel#"
+      Pry::WrappedModule.new(Kernel).method_prefix.should eq "Kernel#"
     end
 
     it "should return Foo. for singleton classes of classes" do
-      Pry::WrappedModule.new(class << Foo; self; end).method_prefix.should == "Foo."
+      Pry::WrappedModule.new(class << Foo; self; end).method_prefix.should eq "Foo."
     end
 
     example "of singleton classes of objects" do
-      Pry::WrappedModule.new(class << @foo; self; end).method_prefix.should == "self."
+      Pry::WrappedModule.new(class << @foo; self; end).method_prefix.should eq "self."
     end
 
     example "of anonymous classes should not be empty" do
@@ -171,15 +171,15 @@ describe Pry::WrappedModule do
 
   describe ".singleton_class?" do
     it "should be true for singleton classes" do
-      Pry::WrappedModule.new(class << ""; self; end).singleton_class?.should == true
+      Pry::WrappedModule.new(class << ""; self; end).singleton_class?.should eq true
     end
 
     it "should be false for normal classes" do
-      Pry::WrappedModule.new(Class.new).singleton_class?.should == false
+      Pry::WrappedModule.new(Class.new).singleton_class?.should eq false
     end
 
     it "should be false for modules" do
-      Pry::WrappedModule.new(Module.new).singleton_class?.should == false
+      Pry::WrappedModule.new(Module.new).singleton_class?.should eq false
     end
   end
 
@@ -205,25 +205,25 @@ describe Pry::WrappedModule do
       end
 
       it 'should return superclass for a wrapped class'  do
-        Pry::WrappedModule(@c).super.wrapped.should == @b
+        Pry::WrappedModule(@c).super.wrapped.should eq @b
       end
 
       it 'should return nth superclass for a wrapped class'  do
         d = Class.new(@c)
-        Pry::WrappedModule(d).super(2).wrapped.should == @b
+        Pry::WrappedModule(d).super(2).wrapped.should eq @b
       end
 
       it 'should ignore modules when retrieving nth superclass'  do
-        Pry::WrappedModule(@c).super(2).wrapped.should == @a
+        Pry::WrappedModule(@c).super(2).wrapped.should eq @a
       end
 
       it 'should return nil when no nth superclass exists' do
-        Pry::WrappedModule(@c).super(10).should == nil
+        Pry::WrappedModule(@c).super(10).should eq nil
       end
 
       it 'should return self when .super(0) is used' do
         c = Pry::WrappedModule(@c)
-        c.super(0).should == c
+        c.super(0).should eq c
       end
     end
 
@@ -235,16 +235,16 @@ describe Pry::WrappedModule do
       end
 
       it 'should not ignore modules when retrieving supers' do
-        Pry::WrappedModule(@m3).super.wrapped.should == @m2
+        Pry::WrappedModule(@m3).super.wrapped.should eq @m2
       end
 
       it 'should retrieve nth super' do
-        Pry::WrappedModule(@m3).super(2).wrapped.should == @m1
+        Pry::WrappedModule(@m3).super(2).wrapped.should eq @m1
       end
 
       it 'should return self when .super(0) is used' do
         m = Pry::WrappedModule(@m1)
-        m.super(0).should == m
+        m.super(0).should eq m
       end
     end
   end
@@ -259,19 +259,19 @@ describe Pry::WrappedModule do
 
     it 'should lookup a constant' do
       m = Pry::WrappedModule.from_str("Namespace::Value", binding)
-      m.wrapped.should == Namespace::Value
+      m.wrapped.should eq Namespace::Value
     end
 
     it 'should lookup a local' do
       local = Namespace::Value
       m = Pry::WrappedModule.from_str("local", binding)
-      m.wrapped.should == local
+      m.wrapped.should eq local
     end
 
     it 'should lookup an ivar' do
       @ivar = Namespace::Value
       m = Pry::WrappedModule.from_str("@ivar", binding)
-      m.wrapped.should == Namespace::Value
+      m.wrapped.should eq Namespace::Value
     end
   end
 end

--- a/spec/wrapped_module_spec.rb
+++ b/spec/wrapped_module_spec.rb
@@ -77,7 +77,7 @@ describe Pry::WrappedModule do
 
       it 'should return the location of the outer module if an inner module has methods' do
         wm = Pry::WrappedModule(Host::ForeverAlone)
-        File.expand_path(wm.source_location.first).should == File.expand_path(__FILE__)
+        File.expand_path(wm.source_location.first).should eq File.expand_path(__FILE__)
         wm.source_location.last.should == Host::FOREVER_ALONE_LINE
       end
 
@@ -189,7 +189,7 @@ describe Pry::WrappedModule do
     end
 
     it "should return the attached object" do
-      Pry::WrappedModule.new(class << "hi"; self; end).singleton_instance.should == "hi"
+      Pry::WrappedModule.new(class << "hi"; self; end).singleton_instance.should eq "hi"
       Pry::WrappedModule.new(class << Object; self; end).singleton_instance.should.equal?(Object)
     end
   end
@@ -252,6 +252,7 @@ describe Pry::WrappedModule do
   describe ".from_str" do
     before do
       class Namespace
+        remove_const :Value if defined? Value
         Value = Class.new
       end
     end
@@ -264,7 +265,7 @@ describe Pry::WrappedModule do
     it 'should lookup a local' do
       local = Namespace::Value
       m = Pry::WrappedModule.from_str("local", binding)
-      m.wrapped.should == Namespace::Value
+      m.wrapped.should == local
     end
 
     it 'should lookup an ivar' do


### PR DESCRIPTION
Makes pry specs run warning free with full warnings enabled. As a result, pry should run cleanly in a session where warnings are enabled.