### PR TITLE
Use _pry_.pager if possible

### DIFF
--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -106,7 +106,11 @@ class Pry
       # enabled). Infers where to send the output if used as a mixin.
       # DEPRECATED.
       def stagger_output(text, out = nil)
-        Pry.new.pager.page text
+        if _pry_
+          _pry_.pager.page text
+        else
+          Pry.new.pager.page text
+        end
       end
     end
   end


### PR DESCRIPTION
The prior code was always using Pry.new.pager -- this was weird for a few reasons:
1) _pry_ is always available (afaict) so why not just call _pry_.pager rather than creating a throway pry object for this?
2) When creating a new Pry instance (via Pry.new) the when_started hook is run...this resulted in some errors and strange behaviour since a naked instance created with Pry.new is not properly configured (it misses a 'target' (binding)

I left the old code in there though to trigger when _pry_ is not available since I assume it's there for good reason?!