### PR TITLE
helpers/text: respect RL_PROMPT_START_IGNORE and RL_PROMPT_END_IGNORE

### DIFF
--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -18,11 +18,11 @@ class Pry
 
       COLORS.each_pair do |color, value|
         define_method color do |text|
-          "\033[0;#{30+value}m#{text}\033[0m"
+          "\001\033[0;#{30+value}m\002#{text}\001\033[0m\002"
         end
 
         define_method "bright_#{color}" do |text|
-          "\033[1;#{30+value}m#{text}\033[0m"
+          "\001\033[1;#{30+value}m\002#{text}\001\033[0m\002"
         end
       end
 
@@ -98,4 +98,3 @@ class Pry
     end
   end
 end
-


### PR DESCRIPTION
Addresses to #493. Fixes the described bug in the situation when you use
helper methods in your Pry prompt like this:

  Pry.prompt = [
    proc { |_, _, _| Pry::Helpers::Text.red("YO > ") },
    proc { |_, _, _| "| "}
  ]