### PR TITLE
Fix regression with respect to space prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fixed the "uninitialized constant Pry::ObjectPath::StringScanner" exception during autocomplete ([#1330](https://github.com/pry/pry/issues/1330))
 * Secured usage of colours with special characters (RL_PROMPT_START_IGNORE and RL_PROMPT_END_IGNORE) in Pry::Helpers::Text ([#493](https://github.com/pry/pry/issues/493#issuecomment-39232771))
 * Fixed regression with `pry -e` when it messes the terminal ([#1387](https://github.com/pry/pry/issues/1387))
+* Fixed regression with space prefixes of expressions ([#1369](https://github.com/pry/pry/issues/1369))
 
 ### 0.10.1
 

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -269,7 +269,7 @@ class Pry
     @suppress_output = false
     inject_sticky_locals!
     begin
-      if !process_command_safely(line.lstrip)
+      if !process_command_safely(line)
         @eval_string << "#{line.chomp}\n" if !line.empty? || !@eval_string.empty?
       end
     rescue RescuableException => e
@@ -400,6 +400,7 @@ class Pry
   # @param [String] val The line to process.
   # @return [Boolean] `true` if `val` is a command, `false` otherwise
   def process_command(val)
+    val = val.lstrip if /^\s\S/ !~ val
     val = val.chomp
     result = commands.process_line(val,
       :target => current_binding,

--- a/lib/pry/test/helper.rb
+++ b/lib/pry/test/helper.rb
@@ -121,7 +121,10 @@ class PryTester
     result = nil
 
     strs.flatten.each do |str|
-      str = "#{str.strip}\n"
+      # Check for space prefix. See #1369.
+      if str !~ /^\s\S/
+        str = "#{str.strip}\n"
+      end
       @history.push str if @history
 
       if @pry.process_command(str)

--- a/spec/pry_repl_spec.rb
+++ b/spec/pry_repl_spec.rb
@@ -99,4 +99,17 @@ describe "The whole thing" do
     end
   end
 
+  describe "space prefix" do
+    describe "with 1 space" do
+      it "it prioritizes variables over commands" do
+        expect(pry_eval(' ls = 2+2', ' ls')).to eq(4)
+      end
+    end
+
+    describe "with more than 1 space" do
+      it "prioritizes commands over variables" do
+        expect(mock_pry('    ls = 2+2')).to match(/SyntaxError.+unexpected '='/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1369 (Prefixing commands with a space is not working)

The regression was introduced by this commit:

  68bcca22a0c0f5f1e501e6316e3d51d95677542a

Since then the main logic for the REPL was hugely refactored. This
refactoring morphed the error into this commit:

  e020f8cecd32fe3498790c888cc873d0f323c518

Sorry about this hacky solution.