### PR TITLE
Refactor command hooks so they could use Pry::Hooks (newer API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Secured usage of colours with special characters (RL_PROMPT_START_IGNORE and RL_PROMPT_END_IGNORE) in Pry::Helpers::Text ([#493](https://github.com/pry/pry/issues/493#issuecomment-39232771))
 * Fixed regression with `pry -e` when it messes the terminal ([#1387](https://github.com/pry/pry/issues/1387))
 * Fixed regression with space prefixes of expressions ([#1369](https://github.com/pry/pry/issues/1369))
+* Introduced the new way to define hooks for commands (with `Pry.hooks.add_hook("{before,after}_commandName")). The old way is deprecated, but still supported (with `Pry.commands.{before,after}_command) ([#651](https://github.com/pry/pry/issues/651))
+
 
 ### 0.10.1
 

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -125,9 +125,10 @@ class Pry
     #   Pry.config.commands.before_command("whereami") do |n|
     #     output.puts "parameter passed was #{n}"
     #   end
+    # @deprecated Use {Pry::Hooks#add_hook} instead.
     def before_command(search, &block)
       cmd = find_command_by_match_or_listing(search)
-      cmd.hooks[:before].unshift block
+      cmd.hooks.add_hook("before_#{cmd.command_name}", random_hook_name, block)
     end
 
     # Execute a block of code after a command is invoked. The block also
@@ -139,10 +140,16 @@ class Pry
     #   Pry.config.commands.after_command("whereami") do |n|
     #     output.puts "command complete!"
     #   end
+    # @deprecated Use {Pry::Hooks#add_hook} instead.
     def after_command(search, &block)
       cmd = find_command_by_match_or_listing(search)
-      cmd.hooks[:after] << block
+      cmd.hooks.add_hook("after_#{cmd.command_name}", random_hook_name, block)
     end
+
+    def random_hook_name
+      (0...8).map { ('a'..'z').to_a[rand(26)] }.join
+    end
+    private :random_hook_name
 
     def each(&block)
       @commands.each(&block)

--- a/lib/pry/hooks.rb
+++ b/lib/pry/hooks.rb
@@ -96,6 +96,7 @@ class Pry
     # @example
     #   Pry::Hooks.new.add_hook(:before_session, :say_hi) { puts "hi!" }
     def add_hook(event_name, hook_name, callable=nil, &block)
+      event_name = event_name.to_s
       @hooks[event_name] ||= []
 
       # do not allow duplicates, but allow multiple `nil` hooks
@@ -128,6 +129,7 @@ class Pry
     #   my_hooks = Pry::Hooks.new.add_hook(:before_session, :say_hi) { puts "hi!" }
     #   my_hooks.exec_hook(:before_session) #=> OUTPUT: "hi!"
     def exec_hook(event_name, *args, &block)
+      event_name = event_name.to_s
       @hooks[event_name] ||= []
 
       @hooks[event_name].map do |hook_name, callable|
@@ -147,6 +149,7 @@ class Pry
     #   my_hooks = Pry::Hooks.new.add_hook(:before_session, :say_hi) { puts "hi!" }
     #   my_hooks.count(:before_session) #=> 1
     def hook_count(event_name)
+      event_name = event_name.to_s
       @hooks[event_name] ||= []
       @hooks[event_name].size
     end
@@ -159,6 +162,7 @@ class Pry
     #   my_hooks = Pry::Hooks.new.add_hook(:before_session, :say_hi) { puts "hi!" }
     #   my_hooks.get_hook(:before_session, :say_hi).call #=> "hi!"
     def get_hook(event_name, hook_name)
+      event_name = event_name.to_s
       @hooks[event_name] ||= []
       hook = @hooks[event_name].find { |current_hook_name, callable| current_hook_name == hook_name }
       hook.last if hook
@@ -173,6 +177,7 @@ class Pry
     #   my_hooks = Pry::Hooks.new.add_hook(:before_session, :say_hi) { puts "hi!" }
     #   my_hooks.get_hooks(:before_session) #=> {:say_hi=>#<Proc:0x00000101645e18@(pry):9>}
     def get_hooks(event_name)
+      event_name = event_name.to_s
       @hooks[event_name] ||= []
       Hash[@hooks[event_name]]
     end
@@ -186,6 +191,7 @@ class Pry
     #   my_hooks = Pry::Hooks.new.add_hook(:before_session, :say_hi) { puts "hi!" }
     #   my_hooks.delete_hook(:before_session, :say_hi)
     def delete_hook(event_name, hook_name)
+      event_name = event_name.to_s
       @hooks[event_name] ||= []
       deleted_callable = nil
 
@@ -206,6 +212,7 @@ class Pry
     #   my_hooks = Pry::Hooks.new.add_hook(:before_session, :say_hi) { puts "hi!" }
     #   my_hooks.delete_hook(:before_session)
     def delete_hooks(event_name)
+      event_name = event_name.to_s
       @hooks[event_name] = []
     end
 
@@ -224,6 +231,7 @@ class Pry
     # @param [Symbol] hook_name Name of the hook.
     # @return [Boolean] Whether the hook by the name `hook_name`
     def hook_exists?(event_name, hook_name)
+      event_name = event_name.to_s
       !!(@hooks[event_name] && @hooks[event_name].find { |name, _| name == hook_name })
     end
   end

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -406,7 +406,8 @@ class Pry
       :target => current_binding,
       :output => output,
       :eval_string => @eval_string,
-      :pry_instance => self
+      :pry_instance => self,
+      :hooks => hooks
     )
 
     # set a temporary (just so we can inject the value we want into eval_string)

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -428,7 +428,7 @@ describe Pry::CommandSet do
         @set.before_command('foo') { foo << 4 }
         @set.run_command(@ctx, 'foo')
 
-        expect(foo).to eq [4, 3, 2, 1]
+        expect(foo).to eq [2, 3, 4, 1]
       end
 
     end


### PR DESCRIPTION
Fixes #651 ({after,before}_command hooks should be unified with
Pry::Hooks system)

* The support for the `Pry.commands.{after,before}_command` API was kept
* Hooks defined via the older API use random names
* The order of hooks execution was changed from LIFO to FIFO