### PR TITLE
cli: parse_opts should not actually spin off a repl

### DIFF
--- a/bin/pry
+++ b/bin/pry
@@ -13,4 +13,5 @@ rescue LoadError
 end
 
 # Process command line options and run Pry
-Pry::CLI.parse_options
+opts = Pry::CLI.parse_options
+Pry::CLI.start(opts)

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -137,7 +137,8 @@ Copyright (c) 2013 John Mair (banisterfiend)
 --
 }
   on :e, :exec=, "A line of code to execute in context before the session starts" do |input|
-    Pry.config.exec_string += input + "\n"
+    Pry.config.exec_string += "\n" if Pry.config.exec_string.length > 0
+    Pry.config.exec_string += input
   end
 
   on "no-pager", "Disable pager for long output" do

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -62,6 +62,9 @@ class Pry
           raise NoOptionsError, "No command line options defined! Use Pry::CLI.add_options to add command line options."
         end
 
+        # Load config files etc first, ensuring that cli options will take precedence.
+        Pry.initial_session_setup
+
         self.input_args = args
 
         begin

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -110,6 +110,9 @@ class Pry::Config::Default
     completer: proc {
       require "pry/input_completer"
       Pry::InputCompleter
+    },
+    exec_string: proc {
+      ""
     }
   }
 


### PR DESCRIPTION
While consuming pry programmatically in an internal project, I was surprised to discover that `parse_options` actually starts a pry session unless you mangle some internal state (clearing `option_processors`).

This patch breaks some APIs that I have no idea if there are meant to be guarantees around, so I can refactor if that's a problem, but in general causes `parse_options` to return the parsed options, which can then be passed to `start`.