### PR TITLE
Bug with module#prepend in ruby 2.0.0

### DIFF
--- a/lib/pry/method/weird_method_locator.rb
+++ b/lib/pry/method/weird_method_locator.rb
@@ -104,8 +104,10 @@ class Pry
           # TODO: Fix up the exception handling so we don't need a bare rescue
           if normal_method?(guess)
             return guess
-          else
+          elsif guess != guess.super
             guess = guess.super
+          else
+            break
           end
         end
 

--- a/spec/commands/whereami_spec.rb
+++ b/spec/commands/whereami_spec.rb
@@ -41,6 +41,27 @@ describe "whereami" do
     Object.remove_const(:Cor)
   end
 
+  if RUBY_VERSION > "2.0.0"
+    it 'should work with prepended methods' do
+      module Cor2
+        def blimey!
+          super
+        end
+      end
+      class Cor
+        prepend Cor2
+        def blimey!
+          pry_eval(binding, 'whereami').should =~ /Cor2[#]blimey!/
+        end
+      end
+
+      Cor.new.blimey!
+
+      Object.remove_const(:Cor)
+      Object.remove_const(:Cor2)
+    end
+  end
+
   it 'should work in BasicObjects' do
     cor = Class.new(BasicObject) do
       def blimey!
@@ -230,4 +251,5 @@ describe "whereami" do
   it "should work inside an object" do
     expect(pry_eval(Object.new, 'whereami')).to match(/Inside #<Object/)
   end
+
 end


### PR DESCRIPTION
Hi, I found a bug when using `binding.pry` inside a method that is wrapped with a prepended method.

I'm not sure if the obtained behaviour is correct (the whereami title ends up being the module instead of the class instance), but at least fixes the infinite loop bug and provides a the minimum case to reproduce the loop.

Please let me know, if there's another way to fix it, and I can give it a try at doing it.

Thanks!