### PR TITLE
Update Pry.run_command to return the command's return value

### DIFF
--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -257,6 +257,8 @@ you can add "Pry.config.windows_console_warning = false" to your .pryrc.
 
     pry = Pry.new(:output   => output, :target   => target, :commands => options[:commands])
     pry.eval command_string
+    result = Pry.current[:pry_cmd_result].retval
+    result == Pry::Command::VOID_VALUE ? nil : result
   end
 
   def self.default_editor_for_platform

--- a/spec/run_command_spec.rb
+++ b/spec/run_command_spec.rb
@@ -1,6 +1,19 @@
 require_relative 'helper'
 
 describe "Pry.run_command" do
+  before(:all) do
+    command_proc = proc do
+      def process
+        args.first
+      end
+    end
+
+    Pry.commands.instance_eval do
+      create_command("command-with-return-value", { :keep_retval => true }, &command_proc)
+      create_command("command-without-return-value", &command_proc)
+    end
+  end
+
   before do
     o = Object.new
     def o.drum
@@ -19,5 +32,18 @@ describe "Pry.run_command" do
   it 'can perform a show-source' do
     Pry.run_command "show-source drum", :context => @context, :output => out = StringIO.new
     expect(out.string).to match(/roken is dodelijk/)
+  end
+
+  context "return value" do
+    it "returns the return value of a command that keeps its return value" do
+      expected_value = "command_result"
+      result = Pry.run_command("command-with-return-value #{expected_value}", :show_output => false)
+      expect(result).to eq(expected_value)
+    end
+
+    it "returns nil for a command that does not keep its return value" do
+      result = Pry.run_command("command-without-return-value unexpected_value", :show_output => false)
+      expect(result).to be_nil
+    end
   end
 end


### PR DESCRIPTION
Not sure if this is the right way to go about this, but the docs for [`Pry.run_command`](https://github.com/pry/pry/blob/master/lib/pry/pry_class.rb#L235) say that the return value of `run_command` should be '[the] return value of the Pry command." Presently, the result is the result of [`Pry#eval`](https://github.com/pry/pry/blob/master/lib/pry/pry_class.rb#L259), which is only ever true or false. Maybe updating the docs is the way to go, but I chose this approach because I think returning the value of the command is a valuable behavior.

Let me know if there are better ways to do any of what I have here or if I'm way off the mark.