### PR TITLE
Alias whereami to pwd

### DIFF
--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -193,4 +193,5 @@ class Pry
 
   Pry::Commands.add_command(Pry::Command::Whereami)
   Pry::Commands.alias_command '@', 'whereami'
+  Pry::Commands.alias_command 'pwd', 'whereami'
 end


### PR DESCRIPTION
As a UNIX bod, I keep expecting to be able to type pwd to see what scope I'm in. Useful alias?