### PR TITLE
Fix warning

### DIFF
--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -23,6 +23,8 @@ class Pry
       @pry    = pry
       @indent = Pry::Indent.new
 
+      @readline_output = nil
+
       if options[:target]
         @pry.push_binding options[:target]
       end


### PR DESCRIPTION
```
warning: instance variable @readline_output not initialized
```