### PR TITLE
Use CPU-less platforms for windows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -82,11 +82,11 @@ namespace :jruby do
 end
 
 
-['i386-mingw32', 'i386-mswin32', 'x64-mingw32'].each do |platform|
+['mswin32', 'mingw32'].each do |platform|
   namespace platform do
     spec = modify_base_gemspec do |s|
       s.add_dependency('win32console', '~> 1.3')
-      s.platform = platform
+      s.platform = Gem::Platform.new [nil, platform, nil]
     end
 
     Gem::PackageTask.new(spec) do |pkg|
@@ -94,10 +94,12 @@ end
       pkg.need_tar = false
     end
   end
+
+  task gems: "#{platform}:gem"
 end
 
 desc "build all platform gems at once"
-task :gems => [:clean, :rmgems, 'ruby:gem', 'i386-mswin32:gem', 'i386-mingw32:gem', 'x64-mingw32:gem', 'jruby:gem']
+task :gems => [:clean, :rmgems, 'ruby:gem', 'jruby:gem']
 
 desc "remove all platform gems"
 task :rmgems => ['ruby:clobber_package']


### PR DESCRIPTION
There is no need to include the CPU in the platform string as there is
no compiled code shipped in the pry gems.  The only difference is the
dependency.

Pry became a victim of rubygems/rubygems#1058 which will be fixed in
rubygems/rubygems#1120.  I would also like to raise awareness of proper
use of platform parts while I'm fixing the bug in RubyGems.