### PR TITLE
working command for gem install pry-doc hint

### DIFF
--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -484,7 +484,7 @@ class Pry
       else
         fail_msg = "Cannot locate this method: #{name}."
         if mri?
-          fail_msg += " Try 'gem-install pry-doc' to get access to Ruby Core documentation."
+          fail_msg += " Try 'gem install pry-doc' to get access to Ruby Core documentation."
         end
         raise CommandError, fail_msg
       end


### PR DESCRIPTION
The current hint suggests me to run `gem-install pry-doc`, but to just copy it as a working command it would be nicer if it says `gem install pry-doc`.