### PR TITLE
Changes deprecated ‘File.exists’ to ‘File.exist’

### DIFF
--- a/lib/pry/commands/gem_readme.rb
+++ b/lib/pry/commands/gem_readme.rb
@@ -12,7 +12,7 @@ class Pry::Command::GemReadme < Pry::ClassCommand
     spec = Gem::Specification.find_by_name(name)
     glob = File.join(spec.full_gem_path, 'README*')
     readme = Dir[glob][0]
-    if File.exists?(readme.to_s)
+    if File.exist?(readme.to_s)
       _pry_.pager.page File.read(readme)
     else
       raise Pry::CommandError, "Gem '#{name}' doesn't appear to have a README"

--- a/lib/pry/commands/play.rb
+++ b/lib/pry/commands/play.rb
@@ -91,7 +91,7 @@ class Pry
     end
 
     def file_content
-      if default_file && File.exists?(default_file)
+      if default_file && File.exist?(default_file)
         @cc.restrict_to_lines(File.read(default_file), @cc.line_range)
       else
         raise CommandError, "File does not exist! File was: #{default_file.inspect}"

--- a/lib/pry/repl_file_loader.rb
+++ b/lib/pry/repl_file_loader.rb
@@ -13,7 +13,7 @@ class Pry
   class REPLFileLoader
     def initialize(file_name)
       full_name = File.expand_path(file_name)
-      raise RuntimeError, "No such file: #{full_name}" if !File.exists?(full_name)
+      raise RuntimeError, "No such file: #{full_name}" if !File.exist?(full_name)
 
       define_additional_commands
       @content = File.read(full_name)


### PR DESCRIPTION
According to the ruby docs [File.exists](http://ruby-doc.org/core-2.2.0/File.html#method-c-exists-3F) is being deprecated.

![image](https://cloud.githubusercontent.com/assets/6809782/7557511/d7efd008-f74f-11e4-8ce4-46568aa307c8.png)