### PR TITLE
Use --no-document option instead of --no-rdoc and --no-ri option

### DIFF
--- a/multi_test_inside_docker.sh
+++ b/multi_test_inside_docker.sh
@@ -11,7 +11,7 @@ function test {
   export RUBY_ROOT=/opt/rubies/$version
 
   if [ ! -f $GEM_HOME/bin/bundle ]; then
-    gem install bundler --no-rdoc --no-ri
+    gem install bundler --no-document
   fi
 
   bundle install --quiet


### PR DESCRIPTION
## Reason

* --no-rdoc and --no-ri option is deprecated.

## See also

* [gem install(command reference)](http://guides.rubygems.org/command-reference/#gem-install)