### PR TITLE
Split out session standup

### DIFF
--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -81,6 +81,8 @@ class Pry
           exit
         end
 
+        Pry.final_session_setup
+
         # Option processors are optional.
         if option_processors
           option_processors.each { |processor| processor.call(opts) }

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -101,6 +101,7 @@ class Pry
         if opts[:context]
           Pry.initial_session_setup
           context = Pry.binding_for(eval(opts[:context]))
+          Pry.final_session_setup
         else
           context = Pry.toplevel_binding
         end

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -156,6 +156,7 @@ you can add "Pry.config.windows_console_warning = false" to your .pryrc.
 
     options[:target] = Pry.binding_for(target || toplevel_binding)
     initial_session_setup
+    final_session_setup
 
     # Unless we were given a backtrace, save the current one
     if options[:backtrace].nil?

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -124,6 +124,9 @@ you can add "Pry.config.windows_console_warning = false" to your .pryrc.
     # note these have to be loaded here rather than in pry_instance as
     # we only want them loaded once per entire Pry lifetime.
     load_rc_files
+  end
+
+  def self.final_session_setup
     load_plugins if Pry.config.should_load_plugins
     load_requires if Pry.config.should_load_requires
     load_history if Pry.config.history.should_load

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -127,6 +127,8 @@ you can add "Pry.config.windows_console_warning = false" to your .pryrc.
   end
 
   def self.final_session_setup
+    return if @session_finalized
+    @session_finalized = true
     load_plugins if Pry.config.should_load_plugins
     load_requires if Pry.config.should_load_requires
     load_history if Pry.config.history.should_load

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -312,6 +312,8 @@ Readline version #{Readline::VERSION} detected - will not auto_resize! correctly
   # Set all the configurable options back to their default values
   def self.reset_defaults
     @initial_session = true
+    @session_finalized = nil
+
     self.config = Pry::Config.new Pry::Config::Default.new
     self.cli = false
     self.current_line = 1


### PR DESCRIPTION
cc @kyrylo 

I tracked down the bug, it's that loading rc files and actually processing the impact of (rc files + flags) were linked.

This fixes that. I kinda poked around trying to work out how to get some tests for this, but came up blank. Let me know if it looks obvious. I did some regression testing in a shell and in an internal project that uses pry, and it looked ok.