### PR TITLE
Fix warning: Using the raise_error matcher without providing a specific error

### DIFF
--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -15,7 +15,7 @@ describe Pry::Hooks do
     it 'should not allow adding of a hook with a duplicate name' do
       @hooks.add_hook(:test_hook, :my_name) {}
 
-      expect { @hooks.add_hook(:test_hook, :my_name) {} }.to raise_error
+      expect { @hooks.add_hook(:test_hook, :my_name) {} }.to raise_error ArgumentError
     end
 
     it 'should create a new hook with a block' do

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -102,7 +102,7 @@ describe Pry do
 
       # bug fix for https://github.com/pry/pry/issues/93
       it 'should not leak pry constants into Object namespace' do
-        expect { pry_eval(Object.new, "Command") }.to raise_error
+        expect { pry_eval(Object.new, "Command") }.to raise_error NameError
       end
 
       it 'should be able to operate inside the BasicObject class' do


### PR DESCRIPTION
The following warnings is displayed when you execute 'rake test'.
I fix warnings.

```ruby
naiad% rake test
--snip--
Ruby v2.2.2 (ruby), Pry v0.10.1, method_source v0.8.2, CodeRay v1.1.0, Slop v3.6.0
..........................................................................................
..........................................................................................
..........................................................................................
..........................................................................................
..........................................................................................
..........................................................................................
..........................................................................................
..........................................................................................
..................................WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, 
since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, 
potentially allowing the expectation to pass without even executing the method you are intending to call. 
Instead consider providing a specific error class or message. 
This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. 
Called from /Users/takiy33/.ghq/github.com/takiy33/pry/spec/hooks_spec.rb:18:in `block (3 levels) in <top (required)>'.
..........................................................................................
..........................................................................................
............................................................................WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, 
since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, 
potentially allowing the expectation to pass without even executing the method you are intending to call. 
Instead consider providing a specific error class or message. 
This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. 
Called from /Users/takiy33/.ghq/github.com/takiy33/pry/spec/pry_spec.rb:105:in `block (4 levels) in <top (required)>'.
..........................................................................................
..............................................

Finished in 7.97 seconds (files took 1.01 seconds to load)
1146 examples, 0 failures
```