### PR TITLE
Syntax highlight <tt> tags in documentation output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 
+* Syntax highlight <tt> tags in documentation output.
 * Add support for BasicObject subclasses who implement their own #inspect (#1341)
 * Fix 'include RSpec::Matchers' at the top-level (#1277)
 * Add 'gem-readme' command, prints the README file bundled with a rubygem

--- a/lib/pry/helpers/documentation_helpers.rb
+++ b/lib/pry/helpers/documentation_helpers.rb
@@ -12,6 +12,7 @@ class Pry
         comment.gsub(/<code>(?:\s*\n)?(.*?)\s*<\/code>/m) { CodeRay.scan($1, :ruby).term }.
           gsub(/<em>(?:\s*\n)?(.*?)\s*<\/em>/m) { "\e[1m#{$1}\e[0m" }.
           gsub(/<i>(?:\s*\n)?(.*?)\s*<\/i>/m) { "\e[1m#{$1}\e[0m" }.
+          gsub(/<tt>(?:\s*\n)?(.*?)\s*<\/tt>/m) { CodeRay.scan($1, :ruby).term }.
           gsub(/\B\+(\w+?)\+\B/)  { "\e[32m#{$1}\e[0m" }.
           gsub(/((?:^[ \t]+.+(?:\n+|\Z))+)/)  { CodeRay.scan($1, :ruby).term }.
           gsub(/`(?:\s*\n)?([^\e]*?)\s*`/) { "`#{CodeRay.scan($1, :ruby).term}`" }

--- a/spec/documentation_helper_spec.rb
+++ b/spec/documentation_helper_spec.rb
@@ -56,6 +56,10 @@ describe Pry::Helpers::DocumentationHelpers do
       expect(@helper.process_rdoc("for <code>Example</code>")).to match(/for \e.*Example\e.*/)
     end
 
+    it "should syntax highlight code in <tt>" do
+      expect(@helper.process_rdoc("for <tt>Example</tt>")).to match(/for \e.*Example\e.*/)
+    end
+
     it "should not double-highlight backticks inside indented code" do
       expect(@helper.process_rdoc("  `echo 5`")).to match(/echo 5/)
     end


### PR DESCRIPTION
\<tt> tags appear in documentation like CSV.foreach