### PR TITLE
Allow pry commands to work even when #call is defined on Symbol.

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -427,8 +427,18 @@ class Pry
         raise CommandError, "The command '#{command_name}' requires an argument."
       end
 
-      ret = call_with_hooks(*args)
+      ret = use_unpatched_symbol do
+        call_with_hooks(*args)
+      end
       command_options[:keep_retval] ? ret : void
+    end
+
+    def use_unpatched_symbol
+      call_method = Symbol.method_defined?(:call) && Symbol.instance_method(:call)
+      Symbol.class_eval { undef :call } if call_method
+      yield
+    ensure
+      Symbol.instance_eval { define_method(:call, call_method) } if call_method
     end
 
     # Are all the gems required to use this command installed?

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -14,6 +14,17 @@ describe "show-doc" do
 
   end
 
+  after do
+    if Symbol.method_defined? :call
+      Symbol.class_eval { undef :call }
+    end
+  end
+
+  it 'should work even if #call is defined on Symbol' do
+    class Symbol ; def call ; 5 ; end ; end
+    expect(pry_eval(binding, "show-doc @o.sample_method")).to match(/sample doc/)
+  end
+
   it 'should output a method\'s documentation' do
     expect(pry_eval(binding, "show-doc @o.sample_method")).to match(/sample doc/)
   end


### PR DESCRIPTION
When #call is defined on Symbol, Slop (3.6.0) fails. #use_unpatched_symbol is used to execute code with Symbol having its #call undefined thus preventing Slop from failing. This also fixes #1356 for facets 3.0.0