### PR TITLE
Check rc files for should_load_plugins before loading the plugin options

### DIFF
--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -122,6 +122,15 @@ class Pry
   end
 end
 
+# RC files may disable loading of plugins, so load before trying to bring in options from plugins
+Slop.new do
+  on :f, "Suppress loading of ~/.pryrc and ./.pryrc" do
+    Pry.config.should_load_rc = false
+    Pry.config.should_load_local_rc = false
+  end
+end
+
+Pry.load_rc_files
 
 # Bring in options defined by plugins
 Slop.new do
@@ -157,11 +166,6 @@ Copyright (c) 2015 John Mair (banisterfiend)
 
   on "no-color", "Disable syntax highlighting for session" do
     Pry.config.color = false
-  end
-
-  on :f, "Suppress loading of ~/.pryrc and ./.pryrc" do
-    Pry.config.should_load_rc = false
-    Pry.config.should_load_local_rc = false
   end
 
   on :s, "select-plugin=", "Only load specified plugin (and no others)." do |plugin_name|


### PR DESCRIPTION
Our team is hitting an where it's not possible to fully disable plugins when using pry in conjunction with Rails.  As background, we have some developers using pry-byebug as a debugger, and other using rdebug. Using these two simultaneously conflict, so the rdebug developers need a way to disable pry-byebug.

Right now, the following occurs:
  1) Pry.rb requires 'pry/cli'
  2) Cli.rb executes `Pry::CLI.add_plugin_options` (conditionally, if `Pry.config.should_load_plugins` is true)
  3) add_plugin_options `require`s the pry-byebug gem, which is where it initializes itself and creates conflicts.

At first glance, it seems the way to disable loading plugins would be to flag off `Pry.config.should_load_plugins` to hit the false on the conditional at 2.  However, at this point, the only way to do this is with a command-line argument -- and adding an additional "no-plugins" parameter causes many complaints that this is an unknown argument when running rails console, rspec, etc.

Applying this same configuration option through the .pryrc file seems like a reasonable way to do it, but the RC files aren't loaded at the #2 where Pry.config.should_load_plugins in checked.  This PR pre-loads the RC file before checking this option. 

A downside is that I believe this can cause a double-loading of the RC file.  We could add a check to Pry.load_rc_files to see if they're already loaded, or remove this from initial_session_setup if the cli.rb file is always hit?  Open to other suggestions on this fix...