### PR TITLE
Multiline History

### DIFF
--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -264,7 +264,6 @@ class Pry
     end
 
     ensure_correct_encoding!(line)
-    Pry.history << line unless options[:generated]
 
     @suppress_output = false
     inject_sticky_locals!
@@ -294,6 +293,8 @@ class Pry
     end
 
     if complete_expr
+      Pry.history << @eval_string.chomp unless options[:generated]
+
       if @eval_string =~ /;\Z/ || @eval_string.empty? || @eval_string =~ /\A *#.*\n\z/
         @suppress_output = true
       end

--- a/spec/pry_repl_spec.rb
+++ b/spec/pry_repl_spec.rb
@@ -97,6 +97,15 @@ describe "The whole thing" do
         prompt(/> $/)
       end
     end
+
+    it "should push to history only complete commands" do
+      ReplTester.start do
+        input  'class Foo'
+        input  'end'
+      end
+
+      expect(Pry.history.to_a.last).to eq("class Foo\nend")
+    end
   end
 
   describe "space prefix" do


### PR DESCRIPTION
Hey. We've discussed this issue on IRC a while ago, and as far as I remember you agreed it's a good feature.

When a REPL command occupies multiple lines, currently each line is added to the history separately, which makes history navigation and editing such commands not the most pleasant experience.

This pull requests changes the behaviour to append to the history only complete expressions.