### PR TITLE
Pry::Command::Ri requires an argument

### DIFF
--- a/lib/pry/commands/ri.rb
+++ b/lib/pry/commands/ri.rb
@@ -14,6 +14,10 @@ class Pry
     BANNER
 
     def process(spec)
+      unless spec
+        return output.puts "Enter the method name you want to look up."
+      end
+
       # Lazily load RI
       require 'rdoc/ri/driver'
 


### PR DESCRIPTION
When the ri command is called within a pry session, it will prompt
you to supply an argument if none is passed.

Before:
```pry
[1] pry(main)> ri
NoMethodError: undefined method `split' for nil:NilClass
from /Users/dalizard/.rubies/2.2.2/lib/ruby/2.2.0/rdoc/ri/driver.rb:1320:in `parse_name'
[1] pry(main)>
```

After:
```pry
[1] pry(main)> ri
Enter the method name you want to look up.
[2] pry(main)> 
```