### PR TITLE
display an error message when cat is invoked without arguments.

### DIFF
--- a/lib/pry/commands/cat/file_formatter.rb
+++ b/lib/pry/commands/cat/file_formatter.rb
@@ -6,6 +6,8 @@ class Pry
       attr_reader :_pry_
 
       def initialize(file_with_embedded_line, _pry_, opts)
+        raise CommandError, "Must provide a filename, --in, or --ex." if !file_with_embedded_line
+
         @file_with_embedded_line = file_with_embedded_line
         @opts = opts
         @_pry_ = _pry_
@@ -13,8 +15,6 @@ class Pry
       end
 
       def format
-        raise CommandError, "Must provide a filename, --in, or --ex." if !file_with_embedded_line
-
         set_file_and_dir_locals(file_name, _pry_, _pry_.current_context)
         decorate(@code_from_file)
       end

--- a/spec/commands/cat_spec.rb
+++ b/spec/commands/cat_spec.rb
@@ -15,6 +15,12 @@ describe "cat" do
     end
   end
 
+  describe "when invoked without arguments" do
+    it 'should display an error message' do
+      expect { @t.eval 'cat' }.to raise_error(Pry::CommandError, /Must provide a filename/)
+    end
+  end
+
   describe "on receiving a file that does not exist" do
     it 'should display an error message' do
       expect { @t.eval 'cat supercalifragilicious66' }.to raise_error(StandardError, /Cannot open/)


### PR DESCRIPTION
When cat is invoked without arguments it raises a `NoMethodError` instead of displaying an error message.

    [1] pry(main)> cat
    NoMethodError: undefined method `split' for nil:NilClass
    from .../pry/lib/pry/commands/cat/file_formatter.rb:23:in `file_and_line'
