### PR TITLE
Explicitly set arch to 'universal' for mingw and mswin

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -86,7 +86,7 @@ end
   namespace platform do
     spec = modify_base_gemspec do |s|
       s.add_dependency('win32console', '~> 1.3')
-      s.platform = Gem::Platform.new [nil, platform, nil]
+      s.platform = Gem::Platform.new ['universal', platform, nil]
     end
 
     Gem::PackageTask.new(spec) do |pkg|


### PR DESCRIPTION
Using an explicit nil like Gem::Platform.new [nil, 'mingw32'] is causing issues like https://github.com/rubygems/rubygems/issues/1120.

When pushing out new gems going forward, there shouldn't be any issues with gem platform matching.