### PR TITLE
cherrypick commits to fix install of pry on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.10.3
+
+* cherry-pick 0d1d72b and e0e5c75 to fix the install of Pry on Windows.
+
 ### 0.10.2
 
 * cherry-pick c2ed9ec135bd791a32c70fbe05cc0508ea17c4040e from master (fix inf. loop with prepended methods source retrieval)

--- a/Rakefile
+++ b/Rakefile
@@ -82,11 +82,11 @@ namespace :jruby do
 end
 
 
-['i386-mingw32', 'i386-mswin32', 'x64-mingw32'].each do |platform|
+['mswin32', 'mingw32'].each do |platform|
   namespace platform do
     spec = modify_base_gemspec do |s|
       s.add_dependency('win32console', '~> 1.3')
-      s.platform = platform
+      s.platform = Gem::Platform.new [nil, platform, nil]
     end
 
     Gem::PackageTask.new(spec) do |pkg|
@@ -94,10 +94,12 @@ end
       pkg.need_tar = false
     end
   end
+
+  task gems: "#{platform}:gem"
 end
 
 desc "build all platform gems at once"
-task :gems => [:clean, :rmgems, 'ruby:gem', 'i386-mswin32:gem', 'i386-mingw32:gem', 'x64-mingw32:gem', 'jruby:gem']
+task :gems => [:clean, :rmgems, 'ruby:gem', 'jruby:gem']
 
 desc "remove all platform gems"
 task :rmgems => ['ruby:clobber_package']

--- a/Rakefile
+++ b/Rakefile
@@ -86,7 +86,7 @@ end
   namespace platform do
     spec = modify_base_gemspec do |s|
       s.add_dependency('win32console', '~> 1.3')
-      s.platform = Gem::Platform.new [nil, platform, nil]
+      s.platform = Gem::Platform.new ['universal', platform, nil]
     end
 
     Gem::PackageTask.new(spec) do |pkg|

--- a/lib/pry/version.rb
+++ b/lib/pry/version.rb
@@ -1,3 +1,3 @@
 class Pry
-  VERSION = "0.10.2"
+  VERSION = "0.10.3"
 end


### PR DESCRIPTION
@banister could you check this out and merge/release if its okay? PR is against 0-10-stable branch. Windows users can't install pry, see https://github.com/rubygems/rubygems/pull/1058 and https://github.com/rubygems/rubygems/issues/1120
