### PR TITLE
Feature/add histignore

### DIFF
--- a/lib/pry/commands/hist.rb
+++ b/lib/pry/commands/hist.rb
@@ -170,8 +170,9 @@ class Pry
           else
             Pry.history.to_a.last(Pry.history.session_line_count)
           end
-      # The last value in history will be the 'hist' command itself.
-      Pry::Code(h[0..-2])
+
+      # The last value in history will be the 'hist' command itself
+      Pry::Code(Pry.history.filter(h[0..-2]))
     end
   end
 

--- a/lib/pry/commands/hist.rb
+++ b/lib/pry/commands/hist.rb
@@ -171,7 +171,6 @@ class Pry
             Pry.history.to_a.last(Pry.history.session_line_count)
           end
 
-      # The last value in history will be the 'hist' command itself
       Pry::Code(Pry.history.filter(h[0..-2]))
     end
   end

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -47,7 +47,7 @@ class Pry
       unless line.empty? || (@history.last && line == @history.last)
         @pusher.call(line)
         @history << line
-        unless exist_in_histignore?(line)
+        unless should_ignore?(line)
           @saver.call(line) if Pry.config.history.should_save
         end
       end
@@ -84,18 +84,18 @@ class Pry
     # @return [Array<String>] An array containing all the lines that are not included
     # in the histignore.
     def filter(history)
-      history.select { |l| l unless exist_in_histignore?(l) }
+      history.select { |l| l unless should_ignore?(l) }
     end
 
     private
 
     # Check if the line match any option in the histignore [Pry.config.history.histignore]
     # @return [Boolean] a boolean that notifies if the line was found in the histignore array.
-    def exist_in_histignore?(line)
-      hi = Pry.config.history.histignore
-      return false if hi.nil? || hi.empty?
+    def should_ignore?(line)
+      hist_ignore = Pry.config.history.histignore
+      return false if hist_ignore.nil? || hist_ignore.empty?
 
-      strings, regex = hi.partition { |w| w.class == String }
+      strings, regex = hist_ignore.partition { |w| w.is_a?(String) }
 
       regex.any? { |r| line =~ r } || strings.include?(line)
     end

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -56,7 +56,7 @@ class Pry
     alias << push
 
     # Clear this session's history. This won't affect the contents of the
-    #   history file.
+    # history file.
     def clear
       @clearer.call
       @original_lines = 0
@@ -90,15 +90,14 @@ class Pry
     private
 
     # Check if the line match any option in the histignore
-    #   [Pry.config.history.histignore]
+    # [Pry.config.history.histignore]
     # @return [Boolean] a boolean that notifies if the line was found in the
     #   histignore array.
     def should_ignore?(line)
       hist_ignore = Pry.config.history.histignore
       return false if hist_ignore.nil? || hist_ignore.empty?
 
-      strings, regex = hist_ignore.partition { |w| w.is_a?(String) }
-      regex.any? { |r| line.to_s.match(r) } || strings.include?(line)
+      hist_ignore.any? { |p| line.to_s.match(p) }
     end
 
     # The default loader. Yields lines from `Pry.history.config.file`.

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -56,7 +56,7 @@ class Pry
     alias << push
 
     # Clear this session's history. This won't affect the contents of the
-    # history file.
+    #   history file.
     def clear
       @clearer.call
       @original_lines = 0
@@ -81,16 +81,18 @@ class Pry
     end
 
     # Filter the history with the histignore options
-    # @return [Array<String>] An array containing all the lines that are not included
-    # in the histignore.
+    # @return [Array<String>] An array containing all the lines that are not
+    #   included in the histignore.
     def filter(history)
       history.select { |l| l unless should_ignore?(l) }
     end
 
     private
 
-    # Check if the line match any option in the histignore [Pry.config.history.histignore]
-    # @return [Boolean] a boolean that notifies if the line was found in the histignore array.
+    # Check if the line match any option in the histignore
+    #   [Pry.config.history.histignore]
+    # @return [Boolean] a boolean that notifies if the line was found in the
+    #   histignore array.
     def should_ignore?(line)
       hist_ignore = Pry.config.history.histignore
       return false if hist_ignore.nil? || hist_ignore.empty?

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -47,8 +47,8 @@ class Pry
       unless line.empty? || (@history.last && line == @history.last)
         @pusher.call(line)
         @history << line
-        unless should_ignore?(line)
-          @saver.call(line) if Pry.config.history.should_save
+        if !should_ignore?(line) && Pry.config.history.should_save
+          @saver.call(line)
         end
       end
       line
@@ -96,8 +96,7 @@ class Pry
       return false if hist_ignore.nil? || hist_ignore.empty?
 
       strings, regex = hist_ignore.partition { |w| w.is_a?(String) }
-
-      regex.any? { |r| line =~ r } || strings.include?(line)
+      regex.any? { |r| line.to_s.match(r) } || strings.include?(line)
     end
 
     # The default loader. Yields lines from `Pry.history.config.file`.

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -196,5 +196,27 @@ describe "hist" do
       expect(output).to match(/1:\s:athos\n2:\s:porthos\n3:\s:aramis\n/)
       expect(output).to match(/4:\sgoodbye\n5:\sworld/)
     end
+
+    it "should not display histignore words in history" do
+      Pry.config.history.histignore = [
+        "well",
+        "hello",
+        "beautiful",
+        /show*/,
+        "exit"
+      ]
+
+      @hist.push("well")
+      @hist.push("hello")
+      @hist.push("beautiful")
+      @hist.push("why")
+      @hist.push("so")
+      @hist.push("serious?")
+      @hist.push("show-method")
+      @hist.push("exit")
+
+      output = @t.eval("hist")
+      expect(output).to match(/1:\swhy\n2:\sso\n3:\sserious\?\n/)
+    end
   end
 end

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -160,6 +160,7 @@ describe Pry do
       @history.push "exit"
 
       expect(File.open(@histfile.path).entries.size).to eq 1
+      expect(IO.readlines(@histfile.path).first).to eq "kakaroto\n"
     end
   end
 

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -151,6 +151,16 @@ describe Pry do
 
       expect(File.read(@histfile.path)).to eq "5\n6\n7\n"
     end
+
+    it "should not write histignore words to the history file" do
+      Pry.config.history.histignore = [ "ls", /hist*/, 'exit' ]
+      @history.push "ls"
+      @history.push "hist"
+      @history.push "kakaroto"
+      @history.push "exit"
+
+      expect(File.open(@histfile.path).entries.size).to eq 1
+    end
   end
 
   describe "expanding the history file path" do


### PR DESCRIPTION
Adding HISTIGNORE like functionality, e.g:

in .pryrc
<pre>
<code>
Pry.config.history.histignore = [
   /hist*/,
   "ls",
   "exit"
]
</code>
</pre>

every line that matches the options will not be written to the history file or show in the session history.
https://github.com/pry/pry/issues/1463