### PR TITLE
Support after_breakout hook

### DIFF
--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -246,6 +246,7 @@ class Pry
         # then popping all the bindings) we still exit immediately.
         return !@stopped
       end
+      exec_hook(:after_breakout, exit_value, self)
       exception = false
     end
 

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -249,6 +249,7 @@ class Pry
       exec_hook(:after_breakout, exit_value, self)
       exception = false
     end
+    exec_hook(:after_raise_up, exception, self) if exception
 
     @stopped = true
     @exit_value = exit_value

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -456,6 +456,20 @@ describe Pry::Hooks do
         expect(hook_executed).to eq(true)
       end
     end
+
+    describe "after_raise_up hook" do
+      it "should run after raise_up" do
+        raised_exception = nil
+        hooks = Pry::Hooks.new.add_hook(:after_raise_up, :raised_exception) { |exception, pry| raised_exception = exception }
+        begin
+          redirect_pry_io(InputTester.new("raise-up Exception"), out = StringIO.new) do
+            Pry.start(self, :hooks => hooks)
+          end
+        rescue Exception
+          expect(raised_exception).to be_a_kind_of(Exception)
+        end
+      end
+    end
   end
 
   describe "anonymous hooks" do

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -445,6 +445,17 @@ describe Pry::Hooks do
         end
       end
     end
+
+    describe "after_breakout hook" do
+      it "should run after exit-all" do
+        hook_executed = false
+        hooks = Pry::Hooks.new.add_hook(:after_breakout, :hook_executed) { |exit_value, pry| hook_executed = true }
+        redirect_pry_io(InputTester.new("exit-all"), out = StringIO.new) do
+          Pry.start(self, :hooks => hooks)
+        end
+        expect(hook_executed).to eq(true)
+      end
+    end
   end
 
   describe "anonymous hooks" do


### PR DESCRIPTION
I want to execute a hook after execution of `exit` or `quit` (not all `:after_session`). Since `exit` command throws `:breakout` in `exit-all`, `Pry::Command#call_with_hooks` doesn't call `instance_exec` for `after_hooks`.

Is there any way to do it without this patch?
