### PR TITLE
Introduce Pry.mod_name

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -108,7 +108,8 @@ class Pry
 
     class << self
       def name
-        super.to_s == "" ? "#<class(Pry::Command #{match.inspect})>" : super
+        orig = Pry.mod_name(self)
+        orig.nil? ? "#<class(Pry::Command #{match.inspect})>" : orig
       end
 
       def inspect

--- a/lib/pry/commands/find_method.rb
+++ b/lib/pry/commands/find_method.rb
@@ -79,7 +79,7 @@ class Pry
     # @param [Array<Method>] matches
     def print_matches(matches)
       grouped = matches.group_by(&:owner)
-      order = grouped.keys.sort_by{ |x| x.name || x.to_s }
+      order = grouped.keys.sort_by{ |x| Pry.mod_name(x) || x.to_s }
 
       order.each do |klass|
         print_matches_for_class(klass, grouped)
@@ -88,7 +88,7 @@ class Pry
 
     # Print matched methods for a class
     def print_matches_for_class(klass, grouped)
-      output.puts text.bold(klass.name)
+      output.puts text.bold(Pry.mod_name(klass))
       grouped[klass].each do |method|
         header = method.name_with_owner
         output.puts header + additional_info(header, method)

--- a/lib/pry/commands/show_source.rb
+++ b/lib/pry/commands/show_source.rb
@@ -32,7 +32,7 @@ class Pry
     def process
       if opts.present?(:e)
         obj = target.eval(args.first)
-        self.args = Array.new(1) { Module === obj ? obj.name : obj.class.name }
+        self.args = Array.new(1) { Module === obj ? Pry.mod_name(obj) : Pry.mod_name(obj.class) }
       end
       super
     end

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -170,7 +170,7 @@ class Pry::InputCompleter
           candidates = []
           ObjectSpace.each_object(Module){|m|
             begin
-              name = m.name.to_s
+              name = Pry.mod_name(m).to_s
             rescue Pry::RescuableException
               name = ""
             end

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -206,8 +206,8 @@ you can add "Pry.config.windows_console_warning = false" to your .pryrc.
   def self.view_clip(obj, options = {})
     max = options.fetch :max_length, 60
     id = options.fetch :id, false
-    if obj.kind_of?(Module) && obj.name.to_s != "" && obj.name.to_s.length <= max
-      obj.name.to_s
+    if obj.kind_of?(Module) && (mod_name = Pry.mod_name(obj)) && mod_name.length <= max
+      mod_name
     elsif Pry.main == obj
       # special-case to support jruby.
       # fixed as of https://github.com/jruby/jruby/commit/d365ebd309cf9df3dde28f5eb36ea97056e0c039
@@ -377,6 +377,11 @@ Readline version #{Readline::VERSION} detected - will not auto_resize! correctly
     yield
   ensure
     Thread.current[:pry_critical_section] -= 1
+  end
+
+  def self.mod_name(mod)
+    @mod_name_method ||= ::Module.instance_method(:name)
+    @mod_name_method.bind(mod).call
   end
 end
 

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -93,11 +93,19 @@ class Pry
       end
     end
 
-    # The name of the Module if it has one, otherwise #<Class:0xf00>.
+    # The name of the Module if it has one
     #
     # @return [String]
+    def name
+      Pry.mod_name(wrapped)
+    end
+
+    # The name of the Module if it has one, otherwise #<Class:0xf00>.
+    #
+    # @return String
     def nonblank_name
-      if name.to_s == ""
+      name = self.name
+      unless name
         wrapped.inspect
       else
         name

--- a/lib/pry/wrapped_module/candidate.rb
+++ b/lib/pry/wrapped_module/candidate.rb
@@ -101,9 +101,10 @@ class Pry
 
       def class_regexes
         mod_type_string = wrapped.class.to_s.downcase
-        [/^\s*#{mod_type_string}\s+(?:(?:\w*)::)*?#{wrapped.name.split(/::/).last}/,
-         /^\s*(::)?#{wrapped.name.split(/::/).last}\s*?=\s*?#{wrapped.class}/,
-         /^\s*(::)?#{wrapped.name.split(/::/).last}\.(class|instance)_eval/]
+        name = @wrapper.name.split(/::/).last
+        [/^\s*#{mod_type_string}\s+(?:(?:\w*)::)*?#{name}/,
+         /^\s*(::)?#{name}\s*?=\s*?#{wrapped.class}/,
+         /^\s*(::)?#{name}\.(class|instance)_eval/]
       end
 
       # This method is used by `Candidate#source_location` as a

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -326,12 +326,16 @@ describe "test Pry defaults" do
         describe "with a #name shorter than or equal to the maximum specified" do
           it "returns a string of the #<class name:object idish> format" do
             c, m = Class.new, Module.new
+            c_name, m_name = 'C' * MAX_LENGTH, 'M' * MAX_LENGTH
 
-            def c.name; "a" * MAX_LENGTH; end
-            def m.name; "a" * MAX_LENGTH; end
+            Object.const_set(c_name, c)
+            Object.const_set(m_name, m)
 
-            expect(Pry.view_clip(c, DEFAULT_OPTIONS)).to eq c.name
-            expect(Pry.view_clip(m, DEFAULT_OPTIONS)).to eq m.name
+            expect(Pry.view_clip(c, DEFAULT_OPTIONS)).to eq c_name
+            expect(Pry.view_clip(m, DEFAULT_OPTIONS)).to eq m_name
+
+            Object.remove_const(c_name)
+            Object.remove_const(m_name)
           end
         end
 


### PR DESCRIPTION
This patch adds `Pry.mod_name` that correctly determines the module/class name even if its singleton method `name` is overriden.

Modules and classes are free to define their own `name` singleton method that does not necessary mean *a class name*. Sooo...

Motivating example:

![lol](https://pbs.twimg.com/media/CUrwmDkWUAIvwBN.png:large)