### PR TITLE
Pry configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### HEAD
-* Add `Pry.configure` as an alternative to the current way of changing configuration options in `.pryrc` files.
+* Add `Pry.configure` as an alternative to the current way of changing configuration options in `.pryrc` files. [#1502](https://github.com/pry/pry/pull/1502)
 * Add `Pry::Config::Behavior#eager_load!` to add a possible workaround for issues like [#1501](https://github.com/pry/pry/issues/1501)
 * Remove Slop as a runtime dependency by vendoring v3.4 as Pry::Slop.
   People can depend on Slop v4 and Pry at the same time without running into version conflicts. ([#1497](https://github.com/pry/pry/issues/1497))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### HEAD
+* Add `Pry.configure` as an alternative to the current way of changing configuration options in `.pryrc` files.
 * Remove Slop as a runtime dependency by vendoring v3.4 as Pry::Slop.
   People can depend on Slop v4 and Pry at the same time without running into version conflicts. ([#1497](https://github.com/pry/pry/issues/1497))
 * Fix auto-indentation of code that uses a single-line rescue ([#1450](https://github.com/pry/pry/issues/1450))

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -32,6 +32,14 @@ class Pry
     def history
       @history ||= History.new
     end
+
+    #
+    # @return [void]
+    #   Yields a block with {Pry.config} as its argument.
+    #
+    def configure
+      yield config
+    end
   end
 
   #

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -34,7 +34,14 @@ class Pry
     end
 
     #
-    # @return [void]
+    # @example
+    #  Pry.configure do |config|
+    #     config.eager_load! # optional
+    #     config.input =     # ..
+    #     config.foo = 2
+    #  end
+    #
+    # @yield [config]
     #   Yields a block with {Pry.config} as its argument.
     #
     def configure

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -5,8 +5,9 @@ describe Pry do
     @str_output = StringIO.new
   end
 
-  describe "Pry.configure" do
+  describe ".configure" do
     it "yields a block with Pry.config as its argument" do
+      Pry.config.foo = nil
       Pry.configure do |config|
         config.foo = "bar"
       end

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -5,6 +5,15 @@ describe Pry do
     @str_output = StringIO.new
   end
 
+  describe "Pry.configure" do
+    it "yields a block with Pry.config as its argument" do
+      Pry.configure do |config|
+        config.foo = "bar"
+      end
+      expect(Pry.config.foo).to eq("bar")
+    end
+  end
+
   describe "Exotic object support" do
     # regression test for exotic object support
     it "Should not error when return value is a BasicObject instance" do


### PR DESCRIPTION
adds an alternative way to the current way of setting configuration options from a pryrc file. i think its useful because it can  be used to separate modifications to `Pry.config` and other custom configurations.

```ruby
Pry.configure do |config|
  config.eager_load! # optional
  config.input =     # ...
  config.foo = 1
end
```