### PR TITLE
make 'Pry::Config::Default' less of a special case by adding Pry::Config::Lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Implemented support for CDPATH for ShellCommand ([#1433](https://github.com/pry/pry/issues/1433), [#1434](https://github.com/pry/pry/issues/1434))
 * `Pry::CLI.parse_options` does not start Pry anymore ([#1393](https://github.com/pry/pry/pull/1393))
 * The gem uses CPU-less platforms for Windows now ([#1410](https://github.com/pry/pry/pull/1410))
+* Add `Pry::Config::Lazy` to make it easier to reimplement `Pry::Config::Default` without knowing its implementation [#1503](https://github.com/pry/pry/pull/1503/)
 
 ### 0.10.1
 

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -1,6 +1,7 @@
 require_relative 'basic_object'
 class Pry::Config < Pry::BasicObject
   require_relative 'config/behavior'
+  require_relative 'config/lazy'
   require_relative 'config/default'
   require_relative 'config/convenience'
   include Pry::Config::Behavior

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -142,7 +142,7 @@ module Pry::Config::Behavior
 
   def eager_load!
     local_last_default = last_default
-    local_last_default.default_keys.each do |key|
+    local_last_default.lazy_keys.each do |key|
       self[key] = local_last_default.public_send(key)
     end
   end

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -1,5 +1,6 @@
 class Pry::Config::Default
   include Pry::Config::Behavior
+  include Pry::Config::Lazy
 
   default = {
     input: proc {
@@ -121,19 +122,9 @@ class Pry::Config::Default
     configure_gist
     configure_history
   end
+  lazy_implement(default)
 
-  default.each do |key, value|
-    define_method(key) do
-      if default[key].equal?(value)
-        default[key] = instance_eval(&value)
-      end
-      default[key]
-    end
-  end
-
-  define_method(:default_keys) { default.keys }
-
-private
+  private
   # TODO:
   # all of this configure_* stuff is a relic of old code.
   # we should try move this code to being command-local.

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -2,7 +2,7 @@ class Pry::Config::Default
   include Pry::Config::Behavior
   include Pry::Config::Lazy
 
-  default = {
+  lazy_implement({
     input: proc {
       lazy_readline
     },
@@ -115,14 +115,13 @@ class Pry::Config::Default
     exec_string: proc {
       ""
     }
-  }
+  })
 
   def initialize
     super(nil)
     configure_gist
     configure_history
   end
-  lazy_implement(default)
 
   private
   # TODO:

--- a/lib/pry/config/lazy.rb
+++ b/lib/pry/config/lazy.rb
@@ -1,6 +1,5 @@
 module Pry::Config::Lazy
-  LAZY_KEYS = {}
-  LAZY_KEYS.default_proc = lambda {|h,k| h[k] = [] }
+  LAZY_KEYS = Hash.new {|h,k| h[k] = [] }
 
   module ExtendModule
     def lazy_implement(method_name_to_func)

--- a/lib/pry/config/lazy.rb
+++ b/lib/pry/config/lazy.rb
@@ -1,0 +1,26 @@
+module Pry::Config::Lazy
+  LAZY_KEYS = {}
+  LAZY_KEYS.default_proc = lambda {|h,k| h[k] = [] }
+
+  module ExtendModule
+    def lazy_implement(method_name_to_func)
+      method_name_to_func.each do |method_name, func|
+        define_method(method_name) do
+          if method_name_to_func[method_name].equal?(func)
+            method_name_to_func[method_name] = instance_eval(&func)
+            LAZY_KEYS[self.class] |= method_name_to_func.keys
+          end
+          method_name_to_func[method_name]
+        end
+      end
+    end
+  end
+
+  def self.included(includer)
+    includer.extend(ExtendModule)
+  end
+
+  def lazy_keys
+    LAZY_KEYS[self.class]
+  end
+end

--- a/lib/pry/config/lazy.rb
+++ b/lib/pry/config/lazy.rb
@@ -7,8 +7,8 @@ module Pry::Config::Lazy
       method_name_to_func.each do |method_name, func|
         define_method(method_name) do
           if method_name_to_func[method_name].equal?(func)
-            method_name_to_func[method_name] = instance_eval(&func)
             LAZY_KEYS[self.class] |= method_name_to_func.keys
+            method_name_to_func[method_name] = instance_eval(&func)
           end
           method_name_to_func[method_name]
         end

--- a/lib/pry/config/lazy.rb
+++ b/lib/pry/config/lazy.rb
@@ -1,7 +1,7 @@
 module Pry::Config::Lazy
   LAZY_KEYS = Hash.new {|h,k| h[k] = [] }
 
-  module ExtendModule
+  module ClassMethods
     def lazy_implement(method_name_to_func)
       method_name_to_func.each do |method_name, func|
         define_method(method_name) do
@@ -16,7 +16,7 @@ module Pry::Config::Lazy
   end
 
   def self.included(includer)
-    includer.extend(ExtendModule)
+    includer.extend(ClassMethods)
   end
 
   def lazy_keys

--- a/spec/config/behavior_spec.rb
+++ b/spec/config/behavior_spec.rb
@@ -1,0 +1,16 @@
+require 'helper'
+RSpec.describe Pry::Config::Behavior do
+  let(:behavior) do
+    Class.new do
+      include Pry::Config::Behavior
+    end
+  end
+  
+  describe "#last_default" do
+    it "returns the last default in a list of defaults" do
+      last = behavior.from_hash({}, nil)
+      middle = behavior.from_hash({}, last)
+      expect(behavior.from_hash({}, middle).last_default).to be(last)
+    end
+  end
+end

--- a/spec/config/lazy_spec.rb
+++ b/spec/config/lazy_spec.rb
@@ -1,0 +1,13 @@
+require 'helper'
+RSpec.describe Pry::Config::Lazy do
+  let(:lazyobject) do
+    Class.new do
+      include Pry::Config::Lazy
+      lazy_implement({foo: proc {"bar"}})
+    end.new
+  end
+
+  it 'memorizes value after first call' do
+    expect(lazyobject.foo).to equal(lazyobject.foo)
+  end
+end

--- a/spec/config/lazy_spec.rb
+++ b/spec/config/lazy_spec.rb
@@ -1,13 +1,22 @@
 require 'helper'
 RSpec.describe Pry::Config::Lazy do
-  let(:lazyobject) do
+  let(:lazyobj) do
     Class.new do
       include Pry::Config::Lazy
-      lazy_implement({foo: proc {"bar"}})
+      lazy_implement({foo: proc {"foo"}, bar: proc {"bar"}})
     end.new
   end
 
-  it 'memorizes value after first call' do
-    expect(lazyobject.foo).to equal(lazyobject.foo)
+  describe "on call of a lazy method" do
+    it "memoizes the return value" do
+      expect(lazyobj.foo).to be(lazyobj.foo)
+    end
+  end
+
+  describe "#lazy_keys" do
+    it "tracks a list of lazy keys" do
+      lazyobj.foo # at least one lazy method has to be called before #lazy_keys could return a non-empty array.
+      expect(lazyobj.lazy_keys).to eq([:foo, :bar])
+    end
   end
 end


### PR DESCRIPTION
adds "Pry::Config::Lazy" to make "Pry::Config::Default" less of a special case and easier to implement your own default without knowing that much internal workings.