### PR TITLE
[Solved] warning: instance variable @pager not initialized

### DIFF
--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -185,7 +185,7 @@ class Pry::Pager
     end
 
     def invoked_pager?
-      @pager
+      @pager || nil
     end
 
     def pager


### PR DESCRIPTION
Hello!

This PR gets rid of the following warning:

```
warning: instance variable @pager not initialized
````

Best regards!