### PR TITLE
Bring version up to date

### DIFF
--- a/lib/pry/version.rb
+++ b/lib/pry/version.rb
@@ -1,3 +1,3 @@
 class Pry
-  VERSION = "0.10.1"
+  VERSION = "0.10.3"
 end


### PR DESCRIPTION
Otherwise, bundler gets understandably confused when pointing to master

```
$ bundle outdated 
Fetching git://github.com/pry/pry.git
Fetching gem metadata from https://rubygems.org/.........
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Resolving dependencies...

Outdated gems included in the bundle:
  * pry (newest 0.10.3, installed 0.10.1 b07e3f8) in group "default"
```