### PR TITLE
Pager: Condition to use where.exe in Windows, instead of 'which'.

### DIFF
--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -138,7 +138,11 @@ class Pry::Pager
       if @system_pager.nil?
         @system_pager = begin
           pager_executable = default_pager.split(' ').first
-          `which #{pager_executable}`
+          if Pry::Helpers::BaseHelpers.windows? || Pry::Helpers::BaseHelpers.windows_ansi?
+            `where #{pager_executable}`
+          else
+            `which #{pager_executable}`
+          end
           $?.success?
         rescue
           false


### PR DESCRIPTION
This commit solves https://github.com/pry/pry/issues/1328 (Pager support broken on windows).