### PR TITLE
exception cause support

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -46,6 +46,15 @@ class Pry
     else
       output.puts "#{exception.class}: #{exception.message}"
       output.puts "from #{exception.backtrace.first}"
+
+      if exception.respond_to? :cause
+        cause = exception.cause
+        while cause
+          output.puts "Caused by #{cause.class}: #{cause}\n"
+          output.puts "from #{cause.backtrace.first}"
+          cause = cause.cause
+        end
+      end
     end
   end
 

--- a/lib/pry/commands/wtf.rb
+++ b/lib/pry/commands/wtf.rb
@@ -32,6 +32,19 @@ class Pry
       else
         output.puts with_line_numbers(backtrace.first(size_of_backtrace))
       end
+
+      if exception.respond_to? :cause
+        cause = exception.cause
+        while cause
+          output.puts "#{text.bold('Caused by:')} #{cause.class}: #{cause}\n--"
+          if opts.verbose?
+            output.puts with_line_numbers(cause.backtrace)
+          else
+            output.puts with_line_numbers(cause.backtrace.first(size_of_backtrace))
+          end
+          cause = cause.cause
+        end
+      end
     end
 
     private


### PR DESCRIPTION
This fixes #1449. I believe this way the user will receive vital info about
any exceptions with cause as most often than not the actual error is
the `cause`.

Here's example output (empty lines inserted by me below for clarity):

```
[1] pry(main)> raise "gaga" rescue raise "gogo"
RuntimeError: gogo
from (pry):1:in `rescue in __pry__'
Caused by RuntimeError: gaga
from (pry):1:in `__pry__'



[2] pry(main)> wtf
Exception: RuntimeError: gogo
--
0: (pry):1:in `rescue in __pry__'
1: (pry):1:in `__pry__'
2: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `eval'
3: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `evaluate_ruby'
4: /home/avalon/pry/lib/pry/pry_instance.rb:323:in `handle_line'
Caused by: RuntimeError: gaga
--
0: (pry):1:in `__pry__'
1: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `eval'
2: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `evaluate_ruby'
3: /home/avalon/pry/lib/pry/pry_instance.rb:323:in `handle_line'
4: /home/avalon/pry/lib/pry/pry_instance.rb:243:in `block (2 levels) in eval'



[3] pry(main)> wtf -v
Exception: RuntimeError: gogo
--
 0: (pry):1:in `rescue in __pry__'
 1: (pry):1:in `__pry__'
 2: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `eval'
 3: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `evaluate_ruby'
 4: /home/avalon/pry/lib/pry/pry_instance.rb:323:in `handle_line'
 5: /home/avalon/pry/lib/pry/pry_instance.rb:243:in `block (2 levels) in eval'
 6: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `catch'
 7: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `block in eval'
 8: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `catch'
 9: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `eval'
10: /home/avalon/pry/lib/pry/repl.rb:79:in `block in repl'
11: /home/avalon/pry/lib/pry/repl.rb:69:in `loop'
12: /home/avalon/pry/lib/pry/repl.rb:69:in `repl'
13: /home/avalon/pry/lib/pry/repl.rb:40:in `block in start'
14: /home/avalon/pry/lib/pry/input_lock.rb:61:in `call'
15: /home/avalon/pry/lib/pry/input_lock.rb:61:in `__with_ownership'
16: /home/avalon/pry/lib/pry/input_lock.rb:79:in `with_ownership'
17: /home/avalon/pry/lib/pry/repl.rb:40:in `start'
18: /home/avalon/pry/lib/pry/repl.rb:15:in `start'
19: /home/avalon/pry/lib/pry/pry_class.rb:189:in `start'
20: /home/avalon/pry/lib/pry/cli.rb:116:in `start'
21: /home/avalon/pry/bin/pry:12:in `<top (required)>'
22: /home/avalon/.gem/ruby/bin/pry:23:in `load'
23: /home/avalon/.gem/ruby/bin/pry:23:in `<main>'
Caused by: RuntimeError: gaga
--
 0: (pry):1:in `__pry__'
 1: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `eval'
 2: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `evaluate_ruby'
 3: /home/avalon/pry/lib/pry/pry_instance.rb:323:in `handle_line'
 4: /home/avalon/pry/lib/pry/pry_instance.rb:243:in `block (2 levels) in eval'
 5: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `catch'
 6: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `block in eval'
 7: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `catch'
 8: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `eval'
 9: /home/avalon/pry/lib/pry/repl.rb:79:in `block in repl'
10: /home/avalon/pry/lib/pry/repl.rb:69:in `loop'
11: /home/avalon/pry/lib/pry/repl.rb:69:in `repl'
12: /home/avalon/pry/lib/pry/repl.rb:40:in `block in start'
13: /home/avalon/pry/lib/pry/input_lock.rb:61:in `call'
14: /home/avalon/pry/lib/pry/input_lock.rb:61:in `__with_ownership'
15: /home/avalon/pry/lib/pry/input_lock.rb:79:in `with_ownership'
16: /home/avalon/pry/lib/pry/repl.rb:40:in `start'
17: /home/avalon/pry/lib/pry/repl.rb:15:in `start'
18: /home/avalon/pry/lib/pry/pry_class.rb:189:in `start'
19: /home/avalon/pry/lib/pry/cli.rb:116:in `start'
20: /home/avalon/pry/bin/pry:12:in `<top (required)>'
21: /home/avalon/.gem/ruby/bin/pry:23:in `load'
22: /home/avalon/.gem/ruby/bin/pry:23:in `<main>'




[4] pry(main)> wtf!??!
Exception: RuntimeError: gogo
--
 0: (pry):1:in `rescue in __pry__'
 1: (pry):1:in `__pry__'
 2: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `eval'
 3: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `evaluate_ruby'
 4: /home/avalon/pry/lib/pry/pry_instance.rb:323:in `handle_line'
 5: /home/avalon/pry/lib/pry/pry_instance.rb:243:in `block (2 levels) in eval'
 6: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `catch'
 7: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `block in eval'
 8: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `catch'
 9: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `eval'
10: /home/avalon/pry/lib/pry/repl.rb:79:in `block in repl'
11: /home/avalon/pry/lib/pry/repl.rb:69:in `loop'
12: /home/avalon/pry/lib/pry/repl.rb:69:in `repl'
13: /home/avalon/pry/lib/pry/repl.rb:40:in `block in start'
14: /home/avalon/pry/lib/pry/input_lock.rb:61:in `call'
15: /home/avalon/pry/lib/pry/input_lock.rb:61:in `__with_ownership'
16: /home/avalon/pry/lib/pry/input_lock.rb:79:in `with_ownership'
17: /home/avalon/pry/lib/pry/repl.rb:40:in `start'
18: /home/avalon/pry/lib/pry/repl.rb:15:in `start'
19: /home/avalon/pry/lib/pry/pry_class.rb:189:in `start'
20: /home/avalon/pry/lib/pry/cli.rb:116:in `start'
21: /home/avalon/pry/bin/pry:12:in `<top (required)>'
22: /home/avalon/.gem/ruby/bin/pry:23:in `load'
23: /home/avalon/.gem/ruby/bin/pry:23:in `<main>'
Caused by: RuntimeError: gaga
--
 0: (pry):1:in `__pry__'
 1: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `eval'
 2: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `evaluate_ruby'
 3: /home/avalon/pry/lib/pry/pry_instance.rb:323:in `handle_line'
 4: /home/avalon/pry/lib/pry/pry_instance.rb:243:in `block (2 levels) in eval'
 5: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `catch'
 6: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `block in eval'
 7: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `catch'
 8: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `eval'
 9: /home/avalon/pry/lib/pry/repl.rb:79:in `block in repl'
10: /home/avalon/pry/lib/pry/repl.rb:69:in `loop'
11: /home/avalon/pry/lib/pry/repl.rb:69:in `repl'
12: /home/avalon/pry/lib/pry/repl.rb:40:in `block in start'
13: /home/avalon/pry/lib/pry/input_lock.rb:61:in `call'
14: /home/avalon/pry/lib/pry/input_lock.rb:61:in `__with_ownership'
15: /home/avalon/pry/lib/pry/input_lock.rb:79:in `with_ownership'
16: /home/avalon/pry/lib/pry/repl.rb:40:in `start'
17: /home/avalon/pry/lib/pry/repl.rb:15:in `start'
18: /home/avalon/pry/lib/pry/pry_class.rb:189:in `start'
19: /home/avalon/pry/lib/pry/cli.rb:116:in `start'
20: /home/avalon/pry/bin/pry:12:in `<top (required)>'
21: /home/avalon/.gem/ruby/bin/pry:23:in `load'
22: /home/avalon/.gem/ruby/bin/pry:23:in `<main>'


[2] pry(main)> wtf!
Exception: RuntimeError: gogo
--
0: (pry):1:in `rescue in __pry__'
1: (pry):1:in `__pry__'
2: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `eval'
3: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `evaluate_ruby'
4: /home/avalon/pry/lib/pry/pry_instance.rb:323:in `handle_line'
5: /home/avalon/pry/lib/pry/pry_instance.rb:243:in `block (2 levels) in eval'
6: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `catch'
7: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `block in eval'
8: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `catch'
9: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `eval'
Caused by: RuntimeError: gaga
--
0: (pry):1:in `__pry__'
1: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `eval'
2: /home/avalon/pry/lib/pry/pry_instance.rb:355:in `evaluate_ruby'
3: /home/avalon/pry/lib/pry/pry_instance.rb:323:in `handle_line'
4: /home/avalon/pry/lib/pry/pry_instance.rb:243:in `block (2 levels) in eval'
5: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `catch'
6: /home/avalon/pry/lib/pry/pry_instance.rb:242:in `block in eval'
7: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `catch'
8: /home/avalon/pry/lib/pry/pry_instance.rb:241:in `eval'
9: /home/avalon/pry/lib/pry/repl.rb:79:in `block in repl'
```
