### PR TITLE
Adds 'clear' as a supported pry function

### DIFF
--- a/lib/pry/commands/clear.rb
+++ b/lib/pry/commands/clear.rb
@@ -1,0 +1,19 @@
+class Pry
+  class Command::Clear < Pry::ClassCommand
+    match 'clear'
+    group 'Input and Output'
+    description 'Clears the current screen'
+
+    banner <<-'BANNER'
+      Usage: clear
+
+      Clears the screen, ignores any parameters that may be present.
+    BANNER
+
+    def process
+      _pry_.config.system.call(output, 'clear', _pry_)
+    end
+  end
+
+  Pry::Commands.add_command(Pry::Command::Clear)
+end


### PR DESCRIPTION
@kyrylo: Follow up from discussions at #1361 and #1335

`clear` now a supported function to clear screen in a pry session, alternative to `Ctrl + L` shortcut for users using that binding elsewhere.