### PR TITLE
[FIX] wery long execution on fatty apps

### DIFF
--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -234,7 +234,7 @@ class Pry::InputCompleter
     (self.obj_space_mutex ||= Mutex.new).synchronize do
       all_modules = ObjectSpace.each_object(Module)
       count = all_modules.inject(0) do |a,e|
-        #we have a memory leak with Pry::Config, Class generates every time on autocomplete
+        # we have a memory leak with Pry::Config, Class generates every time on autocomplete
         # this checks are here for stubbing it.
           a+= e.is_a?(Class) && e.superclass == Pry::Config ? 0 : e.instance_methods(false).count
         end

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -251,6 +251,6 @@ class Pry::InputCompleter
           m.instance_methods(false).each{|method| buffer[method] = nil }
         end
         self.obj_space_collection = buffer.keys.map(&:to_s).sort
-      end
+      end.count
     end
 end


### PR DESCRIPTION
When ObjectSpase become to be huge, autocomplete with double tab press beginning to work weeery slow (up to 20 seconds for act), and main core of it is going throw ObjectSpace & sort vs uniq after (at the end I have 40k records). I made hack, which will do it only if count of object changes, so, if you debug, you'll need to wait only once ( sad, but it is  inevitably), and then you'll use saved collection.

Also I improved selection function, so it will work faster too. so you'll wait ~3 second first time and then it will work instantly. 

I can not test in jruby, in MRI all works perfect.

Also, may me you'll find useful this idea like an option with external updater for methods and put this option as a settings. If you like this Idea, i can rewrite this chunk.
