### PR TITLE
add environment variable to skip Pry.init

### DIFF
--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -398,4 +398,4 @@ Readline version #{Readline::VERSION} detected - will not auto_resize! correctly
   end
 end
 
-Pry.init
+Pry.init unless ENV['INIT_PRY_ON_LOAD'] == 'false'


### PR DESCRIPTION
`Pry.init` is normally called by default when pry loads. This means
`require 'pry'` will load all of our pry plugins without giving us a
chance to disable ones that might cause issues in some cases (e.g.
pry-byebug).

This change gives us a point where we can disable sporadic plugins
before initializing pry