### PR TITLE
fix failing specs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ group :development do
 end
 
 group :test do
-  gem 'rspec', '~> 3.0'
+  gem 'rspec', '~> 3.4.0'
 end
 
 group :development, :test do
-  gem 'simplecov', '~> 0.8'
+  gem 'simplecov', '~> 0.8.0'
 end
 
 platform :rbx do


### PR DESCRIPTION
revert to rspec ~> 3.4.0, and simplecov ~> 0.8.0.
rspec 3.5.0 causes random test failures in the test suite.
simplecov 0.12.0 cannot be installed on ruby 1.9 or earlier.