### PR TITLE
Temporary fix for issue #1557

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
 end
 
 group :test do
-  gem 'rspec', '~> 3.4.0'
+  gem 'rspec', '~> 3.5.0'
 end
 
 group :development, :test do

--- a/Rakefile
+++ b/Rakefile
@@ -21,7 +21,7 @@ task :test do
     if explicit_list = ENV['run']
       explicit_list.split(',')
     else
-      Dir['spec/**/*_spec.rb'].shuffle!
+      Dir['spec/**/*_spec.rb']
     end
   run_specs paths
 end


### PR DESCRIPTION
First off I apologize for the 2 month delay.

I spent time trying to dive into this issue, but had trouble finding a solution. There is a bug that depends on the order the spec files are ran when we go from rspec 3.4.0 -> 3.5.0. So to fix this, I delete the order randomization of the spec files in the Rakefile.

If anyone more experienced with rspec wants to dive into this deeper, please do and let me know of the findings.