### PR TITLE
Test case and fix for terminal no longer echoing commands

### DIFF
--- a/spec/regression/readline_spec.rb
+++ b/spec/regression/readline_spec.rb
@@ -36,7 +36,7 @@ describe "Readline" do
       puts Process.pid
       binding.pry
     RUBY
-    tty_state_before = `stty -g`
+    tty_state_before = `stty -f /dev/tty -a`
     pid_that_will_eat_your_echo = fork do
       `#@ruby -I #@pry_dir -e '#{code}'`.chomp
     end
@@ -44,7 +44,7 @@ describe "Readline" do
     at_exit do
       is_dev_tty_still_there = !open("/dev/tty", "w").closed?
       expect(is_dev_tty_still_there).to eq(true)
-      tty_state_after = `stty -g`
+      tty_state_after = `stty -f /dev/tty -a`
       expect(tty_state_after).to eq(tty_state_before)
     end
   end

--- a/spec/regression/readline_spec.rb
+++ b/spec/regression/readline_spec.rb
@@ -27,6 +27,20 @@ describe "Readline" do
     expect(`#@ruby -I #@pry_dir -e '#{code}'`.end_with?("constant\n")).to eq(true)
   end
 
+  it "causes the terminal to no longer echo commands" do
+    skip "tty not present" unless $stdout.respond_to?(:tty?)
+    skip "cannot fork" if RUBY_PLATFORM =~ /java/
+    code = <<-RUBY
+      require "pry"
+      puts Process.pid
+      binding.pry
+    RUBY
+    pid_that_will_eat_your_echo = fork do
+      `#@ruby -I #@pry_dir -e '#{code}'`.chomp
+    end
+    Process.kill 'INT', pid_that_will_eat_your_echo
+  end
+
   it "is not loaded on invoking 'pry' if Pry.input is set" do
     code = <<-RUBY
       require "pry"

--- a/spec/regression/readline_spec.rb
+++ b/spec/regression/readline_spec.rb
@@ -30,15 +30,23 @@ describe "Readline" do
   it "causes the terminal to no longer echo commands" do
     skip "tty not present" unless $stdout.respond_to?(:tty?)
     skip "cannot fork" if RUBY_PLATFORM =~ /java/
+
     code = <<-RUBY
       require "pry"
       puts Process.pid
       binding.pry
     RUBY
+    tty_state_before = `stty -g`
     pid_that_will_eat_your_echo = fork do
       `#@ruby -I #@pry_dir -e '#{code}'`.chomp
     end
     Process.kill 'INT', pid_that_will_eat_your_echo
+    at_exit do
+      is_dev_tty_still_there = !open("/dev/tty", "w").closed?
+      expect(is_dev_tty_still_there).to eq(true)
+      tty_state_after = `stty -g`
+      expect(tty_state_after).to eq(tty_state_before)
+    end
   end
 
   it "is not loaded on invoking 'pry' if Pry.input is set" do


### PR DESCRIPTION
Test case for https://github.com/pry/pry/issues/1275 . Issue is required reading to understand this PR.

in my console:

``` ruby
p [Pry.config.input, Pry.config.output]
#=> [Readline, #<IO:0x007f8dc10c64e8>]
```

## Solution


1. Ignore the interrupt signal, convert to a throw, then restore the original signal
1. Distinguish between pry's interrupt lock exception and Ruby's Interrupt

See https://github.com/pry/pry/pull/1576/files#r86923754

## Debugging

I've tried 

``` ruby
    File.write("stty.before.#{$$}.#{Time.now.to_i}.txt", `stty -a`.chomp)
    at_exit {
      File.write("stty.after.#{$$}.#{Time.now.to_i}.txt", `stty -a`.chomp)
    }
```

And got:

| command | before | after |
| --- | --- | --- |
| `stty -g` (machine format) | `iflag=6306:lflag=5cf` | `iflag=6206:lflag=4c7` |
| `stty -a` (human format) | `lflags: icanon echo`<br>`iflags: icrnl`<br>`cchars: lnext = ^V;` | `lflags: -icanon -echo`<br>`iflags: -icrnl`<br>`cchars: lnext = <undef>` |

Per [stty](http://pubs.opengroup.org/onlinepubs/009696799/utilities/stty.html): [ref 1](http://www.real-world-systems.com/docs/stty.1.html), [ref 2](http://www.in-ulm.de/~mascheck/various/ascii-tty/)

`icanon  (-icanon)`

> Enable (disable) canonical input (ERASE and KILL processing). This shall have the effect of setting (not setting) ICANON in the termios c_lflag field, as defined in the Base Definitions volume of IEEE Std 1003.1-2001, Chapter 11, General Terminal Interface.

`echo  (-echo)`

> Echo back (do not echo back) every character typed. This shall have the effect of setting (not setting) ECHO in the termios c_lflag field, as defined in the Base Definitions volume of IEEE Std 1003.1-2001, Chapter 11, General Terminal Interface.

`icrnl  (-icrnl)`

> Map (do not map) CR to NL on input. This shall have the effect of setting (not setting) ICRNL in the termios c_iflag field, as defined in the Base Definitions volume of IEEE Std 1003.1-2001, Chapter 11, General Terminal Interface.

`lnext`

>   lnext  enter the next character quoted(literly)

```
^C - SIGINT, the interrupt character

Special characters:
   intr  send an interrupt signal

Input settings:
   [-]brkint     breaks cause an interrupt signal

Local settings:
  [-]echoprt    echo erased characters backward, between `\' and '/'
   [-]icanon     enable erase, kill, werase, and rprnt special characters
   [-]iexten     enable non-POSIX special characters
   [-]isig       enable interrupt, quit, and suspend special characters
   [-]noflsh     disable flushing after interrupt and quit special characters
```

More references:
- https://blog.nelhage.com/2009/12/a-brief-introduction-to-termios-termios3-and-stty/
- https://github.com/xonsh/xonsh/issues/78
- https://github.com/ruby/ruby/blob/32674b167bddc0d737c38f84722986b0f228b44b/ext/readline/README.ja
- https://github.com/ruby/ruby/blob/32674b167bddc0d737c38f84722986b0f228b44b/ext/readline/readline.c#L409
- https://github.com/ruby/ruby/blob/e78beed4994b7db355a06b80b1b06026d991d38c/ext/io/console/console.c#L45
- https://github.com/ruby/ruby/blob/32674b167bddc0d737c38f84722986b0f228b44b/sample/pty/script.rb
- https://github.com/ruby/ruby/blob/32674b167bddc0d737c38f84722986b0f228b44b/sample/pty/shl.rb
- https://github.com/pry/pry/blob/90d127778f3f4e9581d9dfb5c17851af48867186/lib/pry/commands/exit_program.rb
- https://github.com/guard/guard/blob/v2.13.0/lib/guard/jobs/pry_wrapper.rb#90 `:in 'handle_interrupt': Interrupt (Interrupt)` 
- http://www.real-world-systems.com/docs/bashBuiltins.html#trap
  - `trap-p displays commands associated with each signal.`
  - `trap - sig[, sig …   specified signals are reset to the values they had when the shell was started.`
## Discussion

Yeah, it looks like the tests pass, because there's no assertion, but if you run it locally, your terminal will disappear.

I've tried various solutions for this but haven't found one yet. Am taking a break. _Anyone can pick up_.  

I've noticed that if I raise an exception in an `at_exit` that the tty echoes, but not sure if that's helpful.
### Likely location of fix
- [repl#handle_read_errors](https://github.com/pry/pry/blob/67c0b7fcd7ee81dede7d50d028afbb592ab83cbe/lib/pry/repl.rb#L142-L146)
-  [pry instance](https://github.com/pry/pry/blob/67c0b7fcd7ee81dede7d50d028afbb592ab83cbe/lib/pry/pry_instance.rb)

``` ruby
   def repl
      loop do
        case val = read
        when :control_c
          output.puts ""
          pry.reset_eval_string   # <------  should probably restore tty here if readline see https://github.com/pry/pry/blob/67c0b7fcd7ee81dede7d50d028afbb592ab83cbe/lib/pry/pry_instance.rb
          # <snip>
        end
      end
    end
   def read_line(current_prompt)
      handle_read_errors do
        # <snip>
        if readline_available?
          set_readline_output
          input_readline(current_prompt, false) # false since we'll add it manually
          # <snip>
        end
      end
    end

    def handle_read_errors
      # <snip>

      # Handle <Ctrl+C> like Bash: empty the current input buffer, but don't
      # quit.  This is only for MRI 1.9; other versions of Ruby don't let you
      # send Interrupt from within Readline.
      rescue Interrupt # <----- this might not be the global interrupt, but the pry-specific one
        return :control_c

      # <snip>
    end

   def readline_available?
      defined?(Readline) && input == Readline
    end
```

pry-specific interrupts
- [global trap](https://github.com/pry/pry/blob/67c0b7fcd7ee81dede7d50d028afbb592ab83cbe/lib/pry/pry_class.rb#L110-L114)
- [input lock](https://github.com/pry/pry/blob/67c0b7fcd7ee81dede7d50d028afbb592ab83cbe/lib/pry/input_lock.rb#L3-L9)
  - [interruptible sleep](https://github.com/pry/pry/blob/67c0b7fcd7ee81dede7d50d028afbb592ab83cbe/lib/pry/input_lock.rb#L109-L130)
- [rescuable exception](https://github.com/pry/pry/blob/67c0b7fcd7ee81dede7d50d028afbb592ab83cbe/lib/pry/exceptions.rb#L6-L13)
### Interesting: https://gist.github.com/garybernhardt/d496c69bf9e7cc03ddbd

``` ruby
# This is a stripped-down example based on Selecta's TTY handling. We store the
# TTY state in `tty_state`, then go into an infinite loop. When the loop is
# terminated by a ^C, we try to restore the TTY state. It's important that this
# work, but it doesn't in some subtle situations, and I don't know why.
#
# Save this file as test.rb and run it via this command, where `stty` should
# successfully restore the TTY state:
#   bash -c 'echo | ruby test.rb'
#
# Next, run it via this command, where `stty` should fail to restore the TTY
# state:
#   bash -c 'echo $(echo | ruby test.rb)'
#
# Clearly, the command substitution matters, but I don't know why. Initially, I
# thought that the TTY file might be gone by the time the SIGINT is sent,
# meaning there would be nothing for `stty` to see. However, you can see that
# in both commands the TTY file is still there.
#
# Here's what I get when I run those two commands and ^C them (on OS X 10.10,
# but this problem was originally observed in Linux):
#
# $ bash -c 'echo | ruby test.rb'
# ^C
# Did stty succeed?: true
# Is /dev/tty still there?: true
# 
# $ bash -c 'echo $(echo | ruby test.rb)'
# ^C
# stty: tcsetattr: Input/output error
# 
# Did stty succeed?: false
# Is /dev/tty still there?: true

tty_state = `stty -f /dev/tty -g` # -F with "stty (GNU coreutils) 8.23"
begin
  loop do end
rescue Interrupt
  # Swallow the exception
ensure
  $stderr.puts `stty -f /dev/tty #{tty_state}` # -F with "stty (GNU coreutils) 8.23"
  $stderr.puts "Did stty succeed?: #{$?.success?}"
  $stderr.puts "Is /dev/tty still there?: #{!open("/dev/tty", "w").closed?}"
end
```
