### PR TITLE
Fix link to Gaslight's homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [Atomic Object](https://atomicobject.com/)<br/>
 [Hashrocket](https://hashrocket.com/)<br/>
 [Intridea](http://www.intridea.com)<br/>
-[Gaslight](https://teamgaslight.com/home)<br/>
+[Gaslight](https://teamgaslight.com)<br/>
 
 **Other Resources**
 


### PR DESCRIPTION
This tiny change makes a tiny improvement to Pry's README and fixes the link to Gaslight's homepage.