### PR TITLE
Cache all available methods list for expression completion

### DIFF
--- a/lib/pry/helpers.rb
+++ b/lib/pry/helpers.rb
@@ -1,5 +1,6 @@
 require "pry/helpers/base_helpers"
 require "pry/helpers/options_helpers"
 require "pry/helpers/command_helpers"
+require "pry/helpers/completer_helpers"
 require "pry/helpers/text"
 require "pry/helpers/table"

--- a/lib/pry/helpers/completer_helpers.rb
+++ b/lib/pry/helpers/completer_helpers.rb
@@ -1,0 +1,64 @@
+class Pry
+  module Helpers
+    module CompleterHelpers
+      module_function
+
+      # For MRI we simply use RubyVM.stat, for other rubies we count
+      # all defined instance methods. While we still iterate over ObjectSpace
+      # we can have improvements from not sorting methods list.
+      def methods_cache_version
+        return RubyVM.stat if defined?(RubyVM.stat)
+        ObjectSpace.each_object(Module).inject(0) do |s, m|
+          s + (m.respond_to?(:instance_methods) ? m.instance_methods(false).count : 0)
+        end
+      end
+
+      def all_available_methods
+        result = []
+        to_ignore = ignored_modules
+        ObjectSpace.each_object(Module) do |m|
+          # some gems overrides .hash method for their modules,
+          # so we rescue invalid invocations and ignore them
+          next if (to_ignore.include?(m) rescue true)
+
+          # jruby doesn't always provide #instance_methods() on each
+          # object.
+          if m.respond_to?(:instance_methods)
+            result.concat m.instance_methods(false).collect(&:to_s)
+          end
+        end
+        result.uniq!
+        result.sort!
+        result
+      end
+
+      def ignored_modules
+        # We could cache the result, but IRB is not loaded by default.
+        # And this is very fast anyway.
+        # By using this approach, we avoid Module#name calls, which are
+        # relatively slow when there are a lot of anonymous modules defined.
+        s = Set.new
+
+        scanner = lambda do |m|
+          next if s.include?(m) # IRB::ExtendCommandBundle::EXCB recurses.
+          s << m
+          m.constants(false).each do |c|
+            value = m.const_get(c)
+            scanner.call(value) if value.is_a?(Module)
+          end
+        end
+
+        # FIXME: Add Pry here as well?
+        %w(IRB SLex RubyLex RubyToken).each do |module_name|
+          sym = module_name.to_sym
+          next unless Object.const_defined?(sym)
+          scanner.call(Object.const_get(sym))
+        end
+
+        s.delete(IRB::Context) if defined?(IRB::Context)
+
+        s
+      end
+    end
+  end
+end

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -248,7 +248,9 @@ class Pry::InputCompleter
     result = []
     to_ignore = ignored_modules
     ObjectSpace.each_object(Module) do |m|
-      next if to_ignore.include?(m)
+      # some gems overrides .hash method for their modules,
+      # so we rescue invalid invocations and ignore them
+      next if (to_ignore.include?(m) rescue true)
 
       # jruby doesn't always provide #instance_methods() on each
       # object.

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -238,7 +238,7 @@ class Pry::InputCompleter
   # all defined instance methods. While we still iterate over ObjectSpace
   # we can have improvements from not sorting methods list.
   def methods_cache_version
-    RubyVM.stat if defined?(RubyVM.stat)
+    return RubyVM.stat if defined?(RubyVM.stat)
     ObjectSpace.each_object(Module).inject(0) do |s, m|
       s + (m.respond_to?(:instance_methods) ? m.instance_methods(false).count : 0)
     end

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -226,68 +226,11 @@ class Pry::InputCompleter
   private
 
   def all_available_methods_cached
-    current_version = methods_cache_version
+    current_version = Pry::Helpers::CompleterHelpers.methods_cache_version
     unless current_version && @methods_cache_version == current_version
-      @all_available_methods_cached = all_available_methods
+      @all_available_methods_cached = Pry::Helpers::CompleterHelpers.all_available_methods
       @methods_cache_version = current_version
     end
     @all_available_methods_cached
-  end
-
-  # For MRI we simply use RubyVM.stat, for other rubies we count
-  # all defined instance methods. While we still iterate over ObjectSpace
-  # we can have improvements from not sorting methods list.
-  def methods_cache_version
-    return RubyVM.stat if defined?(RubyVM.stat)
-    ObjectSpace.each_object(Module).inject(0) do |s, m|
-      s + (m.respond_to?(:instance_methods) ? m.instance_methods(false).count : 0)
-    end
-  end
-
-  def all_available_methods
-    result = []
-    to_ignore = ignored_modules
-    ObjectSpace.each_object(Module) do |m|
-      # some gems overrides .hash method for their modules,
-      # so we rescue invalid invocations and ignore them
-      next if (to_ignore.include?(m) rescue true)
-
-      # jruby doesn't always provide #instance_methods() on each
-      # object.
-      if m.respond_to?(:instance_methods)
-        result.concat m.instance_methods(false).collect(&:to_s)
-      end
-    end
-    result.uniq!
-    result.sort!
-    result
-  end
-
-  def ignored_modules
-    # We could cache the result, but IRB is not loaded by default.
-    # And this is very fast anyway.
-    # By using this approach, we avoid Module#name calls, which are
-    # relatively slow when there are a lot of anonymous modules defined.
-    s = Set.new
-
-    scanner = lambda do |m|
-      next if s.include?(m) # IRB::ExtendCommandBundle::EXCB recurses.
-      s << m
-      m.constants(false).each do |c|
-        value = m.const_get(c)
-        scanner.call(value) if value.is_a?(Module)
-      end
-    end
-
-    # FIXME: Add Pry here as well?
-    %w(IRB SLex RubyLex RubyToken).each do |module_name|
-      sym = module_name.to_sym
-      next unless Object.const_defined?(sym)
-      scanner.call(Object.const_get(sym))
-    end
-
-    s.delete(IRB::Context) if defined?(IRB::Context)
-
-    s
   end
 end

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -59,7 +59,7 @@ class Pry::InputCompleter
     # all defined instance methods. While we still iterate over ObjectSpace
     # we can have improvements from not sorting methods list.
     def methods_cache_version
-      RubyVM.stat if defined?(RubyVM)
+      RubyVM.stat if defined?(RubyVM.stat)
       ObjectSpace.each_object(Module).inject(0) do |s, m|
         s + (m.respond_to?(:instance_methods) ? m.instance_methods(false).count : 0)
       end

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -41,20 +41,7 @@ class Pry::InputCompleter
 
   WORD_ESCAPE_STR = " \t\n\"\\'`><=;|&{("
 
-  Mutex = ::Mutex.new
-
   class << self
-    def all_available_methods_cached
-      Mutex.synchronize do
-        current_version = methods_cache_version
-        unless current_version && @methods_cache_version == current_version
-          @all_available_methods_cached = all_available_methods
-          @methods_cache_version = current_version
-        end
-        @all_available_methods_cached
-      end
-    end
-
     # For MRI we simply use RubyVM.stat, for other rubies we count
     # all defined instance methods. While we still iterate over ObjectSpace
     # we can have improvements from not sorting methods list.
@@ -214,7 +201,7 @@ class Pry::InputCompleter
           end
         else
           # func1.func2
-          self.class.all_available_methods_cached
+          all_available_methods
         end
         select_message(path, receiver, message, candidates)
       when /^\.([^.]*)$/
@@ -268,5 +255,16 @@ class Pry::InputCompleter
       p
     end
     return path, input
+  end
+
+  private
+
+  def all_available_methods
+    current_version = self.class.methods_cache_version
+    unless current_version && @methods_cache_version == current_version
+      @all_available_methods = self.class.all_available_methods
+      @methods_cache_version = current_version
+    end
+    @all_available_methods
   end
 end

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -246,14 +246,9 @@ class Pry::InputCompleter
 
   def all_available_methods
     result = []
+    to_ignore = ignored_modules
     ObjectSpace.each_object(Module) do |m|
-      begin
-        name = m.name.to_s
-      rescue Pry::RescuableException
-        name = ""
-      end
-      next if name != "IRB::Context" and
-      /^(IRB|SLex|RubyLex|RubyToken)/ =~ name
+      next if to_ignore.include?(m)
 
       # jruby doesn't always provide #instance_methods() on each
       # object.
@@ -261,8 +256,36 @@ class Pry::InputCompleter
         result.concat m.instance_methods(false).collect(&:to_s)
       end
     end
-    result.sort!
     result.uniq!
+    result.sort!
     result
+  end
+
+  def ignored_modules
+    # We could cache the result, but IRB is not loaded by default.
+    # And this is very fast anyway.
+    # By using this approach, we avoid Module#name calls, which are
+    # relatively slow when there are a lot of anonymous modules defined.
+    s = Set.new
+
+    scanner = lambda do |m|
+      next if s.include?(m) # IRB::ExtendCommandBundle::EXCB recurses.
+      s << m
+      m.constants(false).each do |c|
+        value = m.const_get(c)
+        scanner.call(value) if value.is_a?(Module)
+      end
+    end
+
+    # FIXME: Add Pry here as well?
+    %w(IRB SLex RubyLex RubyToken).each do |module_name|
+      sym = module_name.to_sym
+      next unless Object.const_defined?(sym)
+      scanner.call(Object.const_get(sym))
+    end
+
+    s.delete(IRB::Context) if defined?(IRB::Context)
+
+    s
   end
 end

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -133,8 +133,8 @@ class Pry
   def complete(str)
     return EMPTY_COMPLETIONS unless config.completer
     Pry.critical_section do
-      completer = config.completer.new(config.input, self)
-      completer.call str, target: current_binding, custom_completions: custom_completions.call.push(*sticky_locals.keys)
+      @completer ||= config.completer.new(config.input, self)
+      @completer.call str, target: current_binding, custom_completions: custom_completions.call.push(*sticky_locals.keys)
     end
   end
 

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -257,5 +257,21 @@ describe Pry::InputCompleter do
       require 'irb'
       completer_test(self, nil, false).call("[].size.parse_printf_format")
     end
+
+    context 'when some module overrides .hash method' do
+      let(:method_3) { :custom_method_for_test_from_invalid_module }
+      let!(:custom_module_3) do
+        method = method_3
+        Module.new do
+          attr_reader method
+          def self.hash(x); end
+        end
+      end
+
+      it 'ignores this module' do
+        completer_test(self).call("[].size.#{method_1}")
+        completer_test(self, nil, false).call("[].size.#{method_3}")
+      end
+    end
   end
 end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -270,9 +270,12 @@ describe Pry::InputCompleter do
         end
       end
 
-      it 'ignores this module' do
-        completer_test(self).call("[].size.#{method_1}")
-        completer_test(self, nil, false).call("[].size.#{method_3}")
+      # jruby seems to not use .hash for lookup in the Set
+      unless Pry::Helpers::BaseHelpers.jruby?
+        it 'ignores this module' do
+          completer_test(self).call("[].size.#{method_1}")
+          completer_test(self, nil, false).call("[].size.#{method_3}")
+        end
       end
     end
   end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -244,11 +244,11 @@ describe Pry::InputCompleter do
     end
 
     it 'uses cached list of methods' do
-      expect(described_class).to receive(:all_available_methods).and_call_original
+      expect(instance).to receive(:all_available_methods).and_call_original
       completer_test(self).call("[].size.#{method_1}")
       completer_test(self, nil, false).call("[].size.#{method_2}")
       custom_module_2
-      expect(described_class).to receive(:all_available_methods).and_call_original
+      expect(instance).to receive(:all_available_methods).and_call_original
       completer_test(self).call("[].size.#{method_1}")
       completer_test(self).call("[].size.#{method_2}")
     end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -244,11 +244,13 @@ describe Pry::InputCompleter do
     end
 
     it 'uses cached list of methods' do
-      expect(instance).to receive(:all_available_methods).and_call_original
+      expect(Pry::Helpers::CompleterHelpers).
+        to receive(:all_available_methods).and_call_original
       completer_test(self).call("[].size.#{method_1}")
       completer_test(self, nil, false).call("[].size.#{method_2}")
       custom_module_2
-      expect(instance).to receive(:all_available_methods).and_call_original
+      expect(Pry::Helpers::CompleterHelpers).
+        to receive(:all_available_methods).and_call_original
       completer_test(self).call("[].size.#{method_1}")
       completer_test(self).call("[].size.#{method_2}")
     end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -252,5 +252,10 @@ describe Pry::InputCompleter do
       completer_test(self).call("[].size.#{method_1}")
       completer_test(self).call("[].size.#{method_2}")
     end
+
+    it 'does not offer methods from blacklisted modules' do
+      require 'irb'
+      completer_test(self, nil, false).call("[].size.parse_printf_format")
+    end
   end
 end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -224,17 +224,20 @@ describe Pry::InputCompleter do
   context 'for expressions' do
     let(:method_1) { :custom_method_for_test }
     let(:method_2) { :custom_method_for_test_other }
-    let!(:custom_module) do
-      described_class.all_available_methods_cached
+    let(:custom_module) do
       method = method_1
       Module.new { attr_reader method }
     end
     let(:custom_module_2) do
       method = method_2
-      # For jruby we must add more methods than in custom_module.
-      # Because module from previous example can  be gc'ed and we won't see
-      # any new methods.
       Module.new { attr_accessor method }
+    end
+    before do
+      # gc to reset method_cache_version in old rubies and jruby
+      GC.start
+      described_class.all_available_methods_cached
+      # preload module after clean-up
+      custom_module
     end
 
     it 'completes expressions with all all available methods' do


### PR DESCRIPTION
Idea from #1548 with specs and jruby support.

For MRI we simply use RubyVM.stat as cache version, for other rubies we count
all defined instance methods. While we still iterates over ObjectSpace
we can have improvements from not sorting methods list.

However, counting instance methods for jruby may give errors (on module has been gc'ed, and other was defined with same methods count, and we won't see this methods) it seems to be not related to the most of real apps.