### PR TITLE
Fix for Ruby 2.4 build failures

### DIFF
--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -31,7 +31,13 @@ class Pry
     end
 
     def pp(obj)
-      super
+      if String === obj
+        # Avoid calling Ruby 2.4+ String#pretty_print that prints multiline
+        # Strings prettier
+        Object.instance_method(:pretty_print).bind(obj).call
+      else
+        super
+      end
     rescue => e
       raise if e.is_a? Pry::Pager::StopPaging
       begin

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -57,8 +57,15 @@ describe "ls" do
   end
 
   describe "immediates" do
-    it "should work on Fixnum" do
-      expect(pry_eval("ls 5")).to match(/Fixnum#methods:.*modulo/m)
+    # Ruby 2.4+
+    if 5.class.name == 'Integer'
+      it "should work on Integer" do
+        expect(pry_eval("ls 5")).to match(/Integer#methods:.*modulo/m)
+      end
+    else
+      it "should work on Fixnum" do
+        expect(pry_eval("ls 5")).to match(/Fixnum#methods:.*modulo/m)
+      end
     end
   end
 


### PR DESCRIPTION
This fixes #1585 and one other build failure due to Ruby 2.4 specification change.

1. Ruby 2.4 introduces `String#pretty_print`, so we need to implicitly call Object's pretty_print where we expect the behavior not to change between Ruby versions
see: https://bugs.ruby-lang.org/issues/12664

2. There's a test case that expects 5.class to be Fixnum, but it's been changed to Integer now
see: https://bugs.ruby-lang.org/issues/12005