### PR TITLE
Improve completion speed in large applications

### DIFF
--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -252,7 +252,7 @@ class Pry::InputCompleter
     end
 
     # FIXME: Add Pry here as well?
-    %w(IRB SLEX RubyLex RubyToken).each do |module_name|
+    %w(IRB SLex RubyLex RubyToken).each do |module_name|
       sym = module_name.to_sym
       next unless Object.const_defined?(sym)
       scanner.call(Object.const_get(sym))

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -168,8 +168,9 @@ class Pry::InputCompleter
         else
           # func1.func2
           candidates = []
+          to_ignore = ignored_modules
           ObjectSpace.each_object(Module){|m|
-            next if ignored_modules.include?(m)
+            next if to_ignore.include?(m)
 
             # jruby doesn't always provide #instance_methods() on each
             # object.

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -170,7 +170,7 @@ class Pry::InputCompleter
           candidates = []
           to_ignore = ignored_modules
           ObjectSpace.each_object(Module){|m|
-            next if to_ignore.include?(m) rescue true
+            next if (to_ignore.include?(m) rescue true)
 
             # jruby doesn't always provide #instance_methods() on each
             # object.

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -169,13 +169,7 @@ class Pry::InputCompleter
           # func1.func2
           candidates = []
           ObjectSpace.each_object(Module){|m|
-            begin
-              name = m.name.to_s
-            rescue Pry::RescuableException
-              name = ""
-            end
-            next if name != "IRB::Context" and
-            /^(IRB|SLex|RubyLex|RubyToken)/ =~ name
+            next if ignored_modules.include?(m)
 
             # jruby doesn't always provide #instance_methods() on each
             # object.
@@ -238,5 +232,25 @@ class Pry::InputCompleter
       p
     end
     return path, input
+  end
+
+  def ignored_modules
+    @@ignored_modules ||=
+      begin
+        s = Set.new
+
+        ObjectSpace.each_object(Module) do |m|
+          begin
+            name = m.name.to_s
+          rescue Pry::RescuableException
+            next
+          end
+
+          next if name == "IRB::Context" || /^(IRB|SLex|RubyLex|RubyToken)/ !~ name
+          s << m
+        end
+
+        s
+      end
   end
 end

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -178,8 +178,8 @@ class Pry::InputCompleter
               candidates.concat m.instance_methods(false).collect(&:to_s)
             end
           }
-          candidates.sort!
           candidates.uniq!
+          candidates.sort!
         end
         select_message(path, receiver, message, candidates)
       when /^\.([^.]*)$/

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -170,7 +170,7 @@ class Pry::InputCompleter
           candidates = []
           to_ignore = ignored_modules
           ObjectSpace.each_object(Module){|m|
-            next if to_ignore.include?(m)
+            next if to_ignore.include?(m) rescue true
 
             # jruby doesn't always provide #instance_methods() on each
             # object.

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -224,4 +224,16 @@ describe Pry::InputCompleter do
     require 'irb'
     completer_test(self, nil, false).call("[].size.parse_printf_format")
   end
+
+  it 'ignores methods from modules that override Object#hash incompatibly' do
+    _m = Module.new do
+      def self.hash(a, b)
+      end
+
+      def aaaa
+      end
+    end
+
+    completer_test(self, nil, false).call("[].size.aaaa")
+  end
 end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -215,4 +215,13 @@ describe Pry::InputCompleter do
     pry = Pry.new
     expect(Pry::InputCompleter.new(Readline, pry).call("pry.", :target => binding)).not_to include nil
   end
+
+  it 'completes expressions with all available methods' do
+    completer_test(self).call("[].size.chars")
+  end
+
+  it 'does not offer methods from blacklisted modules' do
+    require 'irb'
+    completer_test(self, nil, false).call("[].size.irb_exit")
+  end
 end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -225,15 +225,18 @@ describe Pry::InputCompleter do
     completer_test(self, nil, false).call("[].size.parse_printf_format")
   end
 
-  it 'ignores methods from modules that override Object#hash incompatibly' do
-    _m = Module.new do
-      def self.hash(a, b)
+  if !Pry::Helpers::BaseHelpers.jruby?
+    # Classes that override .hash are still hashable in JRuby, for some reason.
+    it 'ignores methods from modules that override Object#hash incompatibly' do
+      _m = Module.new do
+        def self.hash(a, b)
+        end
+
+        def aaaa
+        end
       end
 
-      def aaaa
-      end
+      completer_test(self, nil, false).call("[].size.aaaa")
     end
-
-    completer_test(self, nil, false).call("[].size.aaaa")
   end
 end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -222,6 +222,6 @@ describe Pry::InputCompleter do
 
   it 'does not offer methods from blacklisted modules' do
     require 'irb'
-    completer_test(self, nil, false).call("[].size.irb_exit")
+    completer_test(self, nil, false).call("[].size.parse_printf_format")
   end
 end


### PR DESCRIPTION
This is another attempt to improve completion speed (e.g. #1540). It's a non-caching solution which improved full scan completion speed in our production app from `5s` to `0.16s`.

Even if we end up adding cache, I'd rather it didn't take long to populate.