### PR TITLE
Fix string literal methods completion

### DIFF
--- a/lib/pry/basic_object.rb
+++ b/lib/pry/basic_object.rb
@@ -1,5 +1,5 @@
 class Pry::BasicObject < BasicObject
-  [:Kernel, :Pry].each do |constant|
+  [:Kernel, :Pry, :ArgumentError].each do |constant|
     const_set constant, ::Object.const_get(constant)
   end
   include Kernel

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -8,4 +8,19 @@ class Pry::Config < Pry::BasicObject
   def self.shortcuts
     Convenience::SHORTCUTS
   end
+
+  READLINE_WORD_ESCAPE_STR = " \t\n`><=;|&{("
+
+  def input=(input)
+    @lookup['input'] = input
+
+    if input.respond_to?(:completer_word_break_characters=)
+      begin
+        input.completer_word_break_characters = READLINE_WORD_ESCAPE_STR
+      rescue ArgumentError
+        # Hi JRuby
+        input.basic_word_break_characters = READLINE_WORD_ESCAPE_STR
+      end
+    end
+  end
 end

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -219,9 +219,11 @@ private
   def __push(key,value)
     unless singleton_class.method_defined? key
       define_singleton_method(key) { self[key] }
+    end
+    unless singleton_class.method_defined? "#{key}="
       define_singleton_method("#{key}=") { |val| @lookup[key] = val }
     end
-    @lookup[key] = value
+    send("#{key}=", value)
   end
 
   def __remove(key)

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -85,6 +85,13 @@ describe Pry::InputCompleter do
 
     # Absolute Constant
     completer_test(o).call('::IndexError')
+
+    # String
+    completer_test(Object.new).call('"".size')
+    completer_test(Object.new).call('abcd".size')
+
+    # Chain of calls starting with a string
+    completer_test(Object.new).call('abcd".size.times')
   end
 
   it 'should complete for target symbols' do

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -138,59 +138,6 @@ describe Pry::InputCompleter do
     completer_test(b, pry).call('/Con')
   end
 
-  it 'should complete for stdlib symbols' do
-
-    o = Object.new
-    # Regexp
-    completer_test(o).call('/foo/.extend')
-
-    # Array
-    completer_test(o).call('[1].push')
-
-    # Hash
-    completer_test(o).call('{"a" => "b"}.keys')
-
-    # Proc
-    completer_test(o).call('{2}.call')
-
-    # Symbol
-    completer_test(o).call(':symbol.to_s')
-
-    # Absolute Constant
-    completer_test(o).call('::IndexError')
-  end
-
-  it 'should complete for target symbols' do
-    o = Object.new
-
-    # Constant
-    module Mod
-      remove_const :Con if defined? Con
-      Con = 'Constant'
-      module Mod2
-      end
-    end
-
-    completer_test(Mod).call('Con')
-
-    # Constants or Class Methods
-    completer_test(o).call('Mod::Con')
-
-    # Symbol
-    _foo = :symbol
-    completer_test(o).call(':symbol')
-
-    # Variables
-    class << o
-      attr_accessor :foo
-    end
-    o.foo = 'bar'
-    completer_test(binding).call('o.foo')
-
-    # trailing slash
-    expect(Pry::InputCompleter.new(Readline).call('Mod2/', :target => Pry.binding_for(Mod)).include?('Mod2/')).to   eq(true)
-  end
-
   it 'should complete for arbitrary scopes' do
     module Bar
       @barvar = :bar

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -239,4 +239,18 @@ describe Pry::Config do
       expect(local['output']).to eq(nil)
     end
   end
+
+  describe "#input=" do
+    it 'assigns a value on the key' do
+      local = Pry::Config.from_hash({})
+      local.input = :foo
+      expect(local.input).to eq(:foo)
+    end
+
+    it 'modifies input itself' do
+      input = OpenStruct.new(completer_word_break_characters: 'asdf')
+      local = Pry::Config.from_hash(input: input)
+      expect(input.completer_word_break_characters).to eq(Pry::Config::READLINE_WORD_ESCAPE_STR)
+    end
+  end
 end


### PR DESCRIPTION
This fixes #1528.

Note: the first time the completer is invoked, `Readline.completer_word_break_characters` hasn't had its effect yet (because its value is set in the completer's constructor), but for now the user shouldn't notice that because completion for inputs like `.abc` doesn't work anymore. They'll just have to press TAB one more time.

Going forward, we should probably move that statement to the top level again, or force the construction of the completer earlier.