### PR TITLE
Add alias 'whereami?' => 'whereami'

### DIFF
--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -193,4 +193,5 @@ class Pry
 
   Pry::Commands.add_command(Pry::Command::Whereami)
   Pry::Commands.alias_command '@', 'whereami'
+  Pry::Commands.alias_command 'whereami?', 'whereami'
 end


### PR DESCRIPTION
I spent a minute wondering why "wtf?" was working but "whereami?" wasn't.  That frustration led me to this.