### PR TITLE
Pry::ColorPrinter.pp: add `newline` argument and pass it on to PP

### DIFF
--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -12,8 +12,8 @@ class Pry
 
     CodeRay::Encoders::Terminal::TOKEN_COLORS[:comment][:self] = "\e[1;34m"
 
-    def self.pp(obj, out = $>, width = 79)
-      q = ColorPrinter.new(out, width)
+    def self.pp(obj, out = $>, width = 79, newline = "\n")
+      q = ColorPrinter.new(out, width, newline)
       q.guard_inspect_key { q.pp obj }
       q.flush
       out << "\n"


### PR DESCRIPTION
[`Pry::DEFAULT_PRINT` ](https://github.com/pry/pry/blob/1f64463184e0a160d0b41d1a1f92b8e2f230278c/lib/pry.rb#L20) does a great job coloring and paging the output, but I kind of dislike the fact that it sometimes prints many short lines when it could print fewer, longer lines.

For instance, printing `(1..100).to_a` will print each number on its own line, like this:

```
[1, 
2, 
3, 
4, 
5, 
6, 
7, 
8, 
9, 
10,
11,
12,
13,
14,
15,
16,
17,
18,
19,
20,
...
90, 
91, 
92, 
93, 
94, 
95, 
96, 
97, 
98, 
99, 
100]

```

instead of just

```
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60
, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100]
```

And I just feel this is a waste of terminal columns :)

I'd like to remove these newlines without losing the other Pry's capabilities (coloring, paging), and I found that the simplest way would be for the `Pry::ColorPrinter.pp` method to accept a `newline` parameter, which can then be passed on to the [PP initializer](https://github.com/ruby/ruby/blob/trunk/lib/prettyprint.rb#L82) along with the current `width` and `out` parameters.

Then, the desired output could be achieved using this custom print object:

```ruby
Pry.config.print = proc do |output, value, _pry_|
  _pry_.pager.open do |pager|
    pager.print _pry_.config.output_prefix
    Pry::ColorPrinter.pp(value, pager, Pry::Terminal.width! - 1, '')
  end
end
```
