### PR TITLE
Find configuration file in XDG Base Directory

### DIFF
--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -1,7 +1,18 @@
 require 'pry/config'
 class Pry
 
-  HOME_RC_FILE = ENV["PRYRC"] || "~/.pryrc"
+  HOME_RC_FILE =
+    if ENV.key?('PRYRC')
+      ENV['PRYRC']
+    elsif File.exist?(File.expand_path('~/.pryrc'))
+      '~/.pryrc'
+    elsif ENV.key?('XDG_CONFIG_HOME') && ENV['XDG_CONFIG_HOME'] != ''
+      # See XDG Base Directory Specification at
+      # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
+      ENV['XDG_CONFIG_HOME'] + '/pry/pryrc'
+    else
+      '~/.config/pry/config'
+    end
   LOCAL_RC_FILE = "./.pryrc"
 
   class << self


### PR DESCRIPTION
Note that cache file directory is not yet modified, because I don't know what to do if neither `~/.pry_history` nor `$~/.config/pry/history` is created, and `$XDG_CACHE_HOME` is not set. I'm open to discussion about that.

In addition, the specification is not fully implemented, such as this

> If an implementation encounters a relative path in any of these variables it should consider the path invalid and ignore it.

I don't think we need it that far, though.

Note: no idea what happened to the Travis failure.

Fixes #1316.