### PR TITLE
improve ruby 2.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.1
+  - 2.4
   - ruby-head
   - rbx-2
   - jruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 ### HEAD
 
-* Improve Ruby 2.4 support:
+* Improve Ruby 2.4 support ([#1611](https://github.com/pry/pry/pull/1611)):
   * Deprecated constants are hidden from `ls` output by default, use the `-d` switch to see them.
   * Fix warnings that originate in Pry while using the repl.
-* Improve completion speed in large applications. [#1588](https://github.com/pry/pry/pull/1588)
-* Pry::ColorPrinter.pp: add `newline` argument and pass it on to PP. [#1603](https://github.com/pry/pry/pull/1603)
-* Use `less` or system pager pager on MS Windows if it is available. [#1512](https://github.com/pry/pry/pull/1512)
-* Add `Pry.configure` as an alternative to the current way of changing configuration options in `.pryrc` files. [#1502](https://github.com/pry/pry/pull/1502)
-* Add `Pry::Config::Behavior#eager_load!` to add a possible workaround for issues like [#1501](https://github.com/pry/pry/issues/1501)
+* Improve completion speed in large applications. ([#1588](https://github.com/pry/pry/pull/1588))
+* Pry::ColorPrinter.pp: add `newline` argument and pass it on to PP. ([#1603](https://github.com/pry/pry/pull/1603))
+* Use `less` or system pager pager on MS Windows if it is available. ([#1512](https://github.com/pry/pry/pull/1512))
+* Add `Pry.configure` as an alternative to the current way of changing configuration options in `.pryrc` files. ([#1502](https://github.com/pry/pry/pull/1502))
+* Add `Pry::Config::Behavior#eager_load!` to add a possible workaround for issues like ([#1501](https://github.com/pry/pry/issues/1501))
 * Remove Slop as a runtime dependency by vendoring v3.4 as Pry::Slop.
   People can depend on Slop v4 and Pry at the same time without running into version conflicts. ([#1497](https://github.com/pry/pry/issues/1497))
 * Fix auto-indentation of code that uses a single-line rescue ([#1450](https://github.com/pry/pry/issues/1450))
@@ -37,7 +37,7 @@
 * Implemented support for CDPATH for ShellCommand ([#1433](https://github.com/pry/pry/issues/1433), [#1434](https://github.com/pry/pry/issues/1434))
 * `Pry::CLI.parse_options` does not start Pry anymore ([#1393](https://github.com/pry/pry/pull/1393))
 * The gem uses CPU-less platforms for Windows now ([#1410](https://github.com/pry/pry/pull/1410))
-* Add `Pry::Config::Lazy` to make it easier to reimplement `Pry::Config::Default` without knowing its implementation [#1503](https://github.com/pry/pry/pull/1503/)
+* Add `Pry::Config::Lazy` to make it easier to reimplement `Pry::Config::Default` without knowing its implementation ([#1503](https://github.com/pry/pry/pull/1503/))
 * Lazy load the config defaults for `Pry.config.history` and `Pry.config.gist`.
 
 ### 0.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### HEAD
 
+* Improve Ruby 2.4 support:
+  * Deprecated constants are hidden from `ls` output by default, use the `-d` switch to see them.
+  * Fix warnings that originate in Pry while using the repl.
 * Improve completion speed in large applications. [#1588](https://github.com/pry/pry/pull/1588)
 * Pry::ColorPrinter.pp: add `newline` argument and pass it on to PP. [#1603](https://github.com/pry/pry/pull/1603)
 * Use `less` or system pager pager on MS Windows if it is available. [#1512](https://github.com/pry/pry/pull/1512)

--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -2,12 +2,11 @@
 # MIT License
 #
 require 'pp'
-
+require 'pry/forwardable'
 require 'pry/input_lock'
 require 'pry/exceptions'
 require 'pry/helpers/base_helpers'
 require 'pry/hooks'
-require 'forwardable'
 
 class Pry
   # The default hooks - display messages when beginning and ending Pry sessions.

--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -338,7 +338,7 @@ class Pry
     undef =~
 
     # Check whether String responds to missing methods.
-    def respond_to_missing?(name, include_all = false)
+    def respond_to_missing?(name, include_all=false)
       ''.respond_to?(name, include_all)
     end
 

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -157,7 +157,7 @@ class Pry
       case opts[:i]
       when Range
         (_pry_.input_array[opts[:i]] || []).join
-      when Fixnum
+      when 1.class
         _pry_.input_array[opts[:i]] || ""
       else
         raise Pry::CommandError, "Not a valid range: #{opts[:i]}"

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -157,7 +157,7 @@ class Pry
       case opts[:i]
       when Range
         (_pry_.input_array[opts[:i]] || []).join
-      when 1.class
+      when Integer
         _pry_.input_array[opts[:i]] || ""
       else
         raise Pry::CommandError, "Not a valid range: #{opts[:i]}"

--- a/lib/pry/commands/ls.rb
+++ b/lib/pry/commands/ls.rb
@@ -61,7 +61,9 @@ class Pry
       " " * 32 <<            "Constants that are pending autoload? are also shown (in yellow)"
       opt.on :i, :ivars,     "Show instance variables (in blue) and class variables (in bright blue)"
       opt.on :G, :grep,      "Filter output by regular expression", :argument => true
-
+      if Object.respond_to?(:deprecate_constant)
+        opt.on :d, :dconstants, "Show deprecated constants"
+      end
       if jruby?
         opt.on :J, "all-java", "Show all the aliases for methods from java (default is to show only prettiest)"
       end

--- a/lib/pry/commands/ls/constants.rb
+++ b/lib/pry/commands/ls/constants.rb
@@ -3,7 +3,7 @@ require 'pry/commands/ls/interrogatable'
 class Pry
   class Command::Ls < Pry::ClassCommand
     class Constants < Pry::Command::Ls::Formatter
-      DEPRECATED_CONSTANTS = [:Fixnum, :Bignum, :NIL, :FALSE, :TRUE]
+      DEPRECATED_CONSTANTS = [:Fixnum, :Bignum, :TimeoutError, :NIL, :FALSE, :TRUE]
       include Pry::Command::Ls::Interrogatable
 
       def initialize(interrogatee, no_user_opts, opts, _pry_)

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -186,8 +186,8 @@ module Pry::Config::Behavior
     end
   end
 
-  def respond_to_missing?(key, include_private=false)
-    key?(key) or @default.respond_to?(key) or super(key, include_private)
+  def respond_to_missing?(key, include_all=false)
+    key?(key) or @default.respond_to?(key) or super(key, include_all)
   end
 
 private

--- a/lib/pry/forwardable.rb
+++ b/lib/pry/forwardable.rb
@@ -1,0 +1,23 @@
+class Pry
+  module Forwardable
+    require 'forwardable'
+    include ::Forwardable
+
+    #
+    # Since Ruby 2.4, Forwardable will print a warning when
+    # calling a method that is private on a delegate, and
+    # in the future it could be an error: https://bugs.ruby-lang.org/issues/12782#note-3
+    #
+    # That's why we revert to a custom implementation for delegating one
+    # private method to another.
+    #
+    def def_private_delegators(target, *private_delegates)
+      private_delegates.each do |private_delegate|
+        define_method(private_delegate) do |*a, &b|
+          instance_variable_get(target).__send__(private_delegate, *a, &b)
+        end
+      end
+      class_eval { private *private_delegates }
+    end
+  end
+end

--- a/lib/pry/forwardable.rb
+++ b/lib/pry/forwardable.rb
@@ -17,7 +17,7 @@ class Pry
           instance_variable_get(target).__send__(private_delegate, *a, &b)
         end
       end
-      class_eval { private *private_delegates }
+      class_eval { private(*private_delegates) }
     end
   end
 end

--- a/lib/pry/last_exception.rb
+++ b/lib/pry/last_exception.rb
@@ -23,8 +23,8 @@ class Pry::LastException < BasicObject
     end
   end
 
-  def respond_to_missing?(name, include_private = false)
-    @e.respond_to?(name)
+  def respond_to_missing?(name, include_all=false)
+    @e.respond_to?(name, include_all)
   end
 
   #

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -461,8 +461,8 @@ class Pry
 
     # @param [String, Symbol] method_name
     # @return [Boolean]
-    def respond_to?(method_name)
-      super or @method.respond_to?(method_name)
+    def respond_to?(method_name, include_all=false)
+      super or @method.respond_to?(method_name, include_all)
     end
 
     # Delegate any unknown calls to the wrapped method.

--- a/lib/pry/output.rb
+++ b/lib/pry/output.rb
@@ -35,8 +35,8 @@ class Pry::Output
     @boxed_io.__send__(name, *args, &block)
   end
 
-  def respond_to_missing?(*a)
-    @boxed_io.respond_to?(*a)
+  def respond_to_missing?(m, include_all=false)
+    @boxed_io.respond_to?(m, include_all)
   end
 
   def decolorize_maybe(str)

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -5,7 +5,7 @@ class Pry
   LOCAL_RC_FILE = "./.pryrc"
 
   class << self
-    extend Forwardable
+    extend Pry::Forwardable
     attr_accessor :custom_completions
     attr_accessor :current_line
     attr_accessor :line_buffer

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -1,5 +1,3 @@
-require 'forwardable'
-
 class Pry
   class REPL
     extend Pry::Forwardable

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -2,7 +2,7 @@ require 'forwardable'
 
 class Pry
   class REPL
-    extend Forwardable
+    extend Pry::Forwardable
     def_delegators :@pry, :input, :output
 
     # @return [Pry] The instance of {Pry} that the user is controlling.

--- a/lib/pry/slop.rb
+++ b/lib/pry/slop.rb
@@ -332,7 +332,7 @@ class Pry::Slop
   # Override this method so we can check if an option? method exists.
   #
   # Returns true if this option key exists in our list of options.
-  def respond_to_missing?(method_name, include_private = false)
+  def respond_to_missing?(method_name, include_all=false)
     options.any? { |o| o.key == method_name.to_s.chop } || super
   end
 

--- a/lib/pry/test/helper.rb
+++ b/lib/pry/test/helper.rb
@@ -102,7 +102,7 @@ def pry_eval(*eval_strs)
 end
 
 class PryTester
-  extend Forwardable
+  extend Pry::Forwardable
 
   attr_reader :pry, :out
 

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -150,8 +150,8 @@ class Pry
       wrapped.send(method_name, *args, &block)
     end
 
-    def respond_to?(method_name)
-      super || wrapped.respond_to?(method_name)
+    def respond_to?(method_name, include_all=false)
+      super || wrapped.respond_to?(method_name, include_all)
     end
 
     # Retrieve the source location of a module. Return value is in same

--- a/lib/pry/wrapped_module/candidate.rb
+++ b/lib/pry/wrapped_module/candidate.rb
@@ -1,5 +1,4 @@
 require 'pry/helpers/documentation_helpers'
-require 'forwardable'
 
 class Pry
   class WrappedModule
@@ -10,7 +9,7 @@ class Pry
     class Candidate
       include Pry::Helpers::DocumentationHelpers
       include Pry::CodeObject::Helpers
-      extend Forwardable
+      extend Pry::Forwardable
 
       # @return [String] The file where the module definition is located.
       attr_reader :file
@@ -22,15 +21,12 @@ class Pry
 
       # Methods to delegate to associated `Pry::WrappedModule
       # instance`.
-      private_delegates = [:lines_for_file, :method_candidates,
-                           :yard_docs?]
-
-      public_delegates = [:wrapped, :module?, :class?, :name, :nonblank_name,
+      private_delegates = [:lines_for_file, :method_candidates, :yard_docs?, :name]
+      public_delegates = [:wrapped, :module?, :class?, :nonblank_name,
                           :number_of_candidates]
 
-      def_delegators :@wrapper, *(private_delegates + public_delegates)
-      private(*private_delegates)
-      public(*public_delegates)
+      def_delegators :@wrapper, *public_delegates
+      def_private_delegators :@wrapper, *private_delegates
 
       # @raise [Pry::CommandError] If `rank` is out of bounds.
       # @param [Pry::WrappedModule] wrapper The associated

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -388,8 +388,8 @@ describe "edit" do
     end
 
     it "should edit a multi-line expression as it occupies one line of _in_" do
-      pry_eval "class Fixnum\n  def invert; -self; end\nend", "edit -i 1"
-      expect(@contents).to eq "class Fixnum\n  def invert; -self; end\nend\n"
+      pry_eval "class #{1.class}\n  def invert; -self; end\nend", "edit -i 1"
+      expect(@contents).to eq "class #{1.class}\n  def invert; -self; end\nend\n"
     end
 
     it "should not work with a filename" do

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -415,7 +415,8 @@ describe Pry::Method do
       end
 
       it "should not include singleton classes of numbers" do
-        expect(Pry::Method.resolution_order(4)).to eq Pry::Method.instance_resolution_order(Fixnum)
+        target_class = 4.class
+        expect(Pry::Method.resolution_order(4)).to eq Pry::Method.instance_resolution_order(target_class)
       end
 
       it "should include singleton classes for classes" do

--- a/spec/pry_output_spec.rb
+++ b/spec/pry_output_spec.rb
@@ -116,9 +116,8 @@ describe Pry do
   describe "custom non-IO object as $stdout" do
     it "does not crash pry" do
       old_stdout = $stdout
-      custom_io = Class.new { def write(*) end }.new
       pry_eval = PryTester.new(binding)
-      expect(pry_eval.eval("$stdout = custom_io", ":ok")).to eq(:ok)
+      expect(pry_eval.eval("$stdout = Class.new { def write(*) end }.new", ":ok")).to eq(:ok)
       $stdout = old_stdout
     end
   end


### PR DESCRIPTION
Fix warnings and other issues that come up, eg:
```
/home/robert/.rubies/ruby-2.4.1/lib/ruby/2.4.0/forwardable.rb:225: warning: Pry::WrappedModule#respond_to?(:respond_to_missing?) uses the deprecated method signature, which takes one parameter
/home/robert/pry/lib/pry/wrapped_module.rb:153: warning: respond_to? is defined here
```