### PR TITLE
Add text helpers for background colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 
+* Add text helpers for background colors ([#1624](https://github.com/pry/pry/pull/1624))
 * Fix string literal methods completion. ([#1590](https://github.com/pry/pry/pull/1590))
 * Add alias 'whereami[?!]+' for 'whereami' command. ([#1597](https://github.com/pry/pry/pull/1597))
 * Improve Ruby 2.4 support ([#1611](https://github.com/pry/pry/pull/1611)):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 
+* Add text helpers for background colors ([#1624](https://github.com/pry/pry/pull/1624))
 * Add alias 'whereami[?!]+' for 'whereami' command. ([#1597](https://github.com/pry/pry/pull/1597))
 * Improve Ruby 2.4 support ([#1611](https://github.com/pry/pry/pull/1611)):
   * Deprecated constants are hidden from `ls` output by default, use the `-d` switch to see them.

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -24,6 +24,16 @@ class Pry
         define_method "bright_#{color}" do |text|
           "\033[1;#{30+value}m#{text}\033[0m"
         end
+
+        COLORS.each_pair do |bg_color, bg_value|
+          define_method "#{color}_on_#{bg_color}" do |text|
+            "\033[0;#{30 + value};#{40 + bg_value}m#{text}\033[0m"
+          end
+
+          define_method "bright_#{color}_on_#{bg_color}" do |text|
+            "\033[1;#{30 + value};#{40 + bg_value}m#{text}\033[0m"
+          end
+        end
       end
 
       # Remove any color codes from _text_.


### PR DESCRIPTION
`Pry::Helpers::Text` defines useful methods for coloring text, but it does not offer similarly for coloring the background. This PR adds that ability through methods such as `black_on_green` and `bright_cyan_on_yellow`.

I originally tried to implement it in an additive way (similar to how you can combine the `bold` helper with `red` to get text that is both bold and red), but unfortunately foreground and background colors must be defined together.

I used this approach to create [a Powerline-like Pry prompt](https://gist.github.com/SaladFork/6845b69539e06e68a3a731d1f280a777).