### PR TITLE
add Pry::Prompt.add_prompt(), Pry::Prompt.get_prompt() & Pry::Prompt.remove_prompt().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### HEAD
 
+* Add `Pry::Prompt.add_prompt()`, `Pry::Prompt.get_prompt()`, and `Pry::Prompt.remove_prompt()`, for integrating custom prompts with Pry ([#1628](https://github.com/pry/pry/pull/1628))
+* Add text helpers for background colors ([#1624](https://github.com/pry/pry/pull/1624))
 * Fix string literal methods completion. ([#1590](https://github.com/pry/pry/pull/1590))
 * Add alias 'whereami[?!]+' for 'whereami' command. ([#1597](https://github.com/pry/pry/pull/1597))
 * Improve Ruby 2.4 support ([#1611](https://github.com/pry/pry/pull/1611)):

--- a/lib/pry/commands/change_prompt.rb
+++ b/lib/pry/commands/change_prompt.rb
@@ -18,9 +18,9 @@ class Pry::Command::ChangePrompt < Pry::ClassCommand
     end
   end
 
-private
+  private
   def prompt_map
-    Pry::Prompt::MAP
+    Pry::Prompt::PROMPT_MAP
   end
   Pry::Commands.add_command(self)
 end

--- a/lib/pry/commands/list_prompts.rb
+++ b/lib/pry/commands/list_prompts.rb
@@ -19,9 +19,9 @@ class Pry::Command::ListPrompts < Pry::ClassCommand
     end
   end
 
-private
+  private
   def prompt_map
-    Pry::Prompt::MAP
+    Pry::Prompt::PROMPT_MAP
   end
 
   def selected_text

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -1,26 +1,67 @@
-class Pry::Prompt
-  MAP = {
-    "default" => {
-      value: Pry::DEFAULT_PROMPT,
-      description: "The default Pry prompt. Includes information about the\n" \
-                   "current expression number, evaluation context, and nesting\n" \
-                   "level, plus a reminder that you're using Pry."
-    },
+module Pry::Prompt
+  extend self
+  PROMPT_MAP = {}
 
-    "simple" => {
-      value: Pry::SIMPLE_PROMPT,
-      description: "A simple '>>'."
-    },
-
-    "nav" => {
-      value: Pry::NAV_PROMPT,
-      description: "A prompt that displays the binding stack as a path and\n" \
-                   "includes information about _in_ and _out_."
-    },
-
-    "none" => {
-      value: Pry::NO_PROMPT,
-      description: "Wave goodbye to the Pry prompt."
+  #
+  # Integrate a custom prompt with Pry.
+  # The prompt will be visible in the output of the "list-prompts" command, and
+  # it can be used with the "change-prompt"command.
+  #
+  # @param [String] name
+  #   The name of the prompt.
+  #
+  # @param [String] description
+  #   A short description of the prompt.
+  #
+  # @param [Array<Proc,Proc>] value
+  #  A prompt in the form of [proc {}, proc {}].
+  #
+  def add_prompt(name, description, value)
+    PROMPT_MAP[name.to_s] = {
+      value: value,
+      description: description
     }
- }
+  end
+
+  #
+  # @example
+  #
+  #   # .pryrc
+  #   Pry.config.prompt = Pry::Prompt.get_prompt('simple')
+  #
+  # @return [Array<Proc,Proc>]
+  #   Returns a prompt in the form of [proc{}, proc{}]
+  #
+  def get_prompt(name)
+    PROMPT_MAP.key?(name.to_s) and PROMPT_MAP[name.to_s][:value]
+  end
+
+  #
+  # Remove a prompt from Pry.
+  # It will no longer be visible in the output of "list-prompts" or usable with the
+  # "change-prompt" command.
+  #
+  # @param [String] name
+  #   The name of a prompt.
+  #
+  # @return [Object, nil]
+  #   Returns truthy if a prompt was deleted, otherwise nil.
+  #
+  def remove_prompt(name)
+    PROMPT_MAP.delete name.to_s if PROMPT_MAP.key?(name.to_s)
+  end
+
+  add_prompt "default",
+             "The default Pry prompt. Includes information about the\n" \
+             "current expression number, evaluation context, and nesting\n" \
+             "level, plus a reminder that you're using Pry.",
+             Pry::DEFAULT_PROMPT
+
+  add_prompt "nav",
+             "A prompt that displays the binding stack as a path and\n" \
+             "includes information about _in_ and _out_.",
+             Pry::NAV_PROMPT
+
+  add_prompt "simple", "A simple '>>'.", Pry::SIMPLE_PROMPT
+  add_prompt "none", "Wave goodbye to the Pry prompt.", Pry::NO_PROMPT
 end

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -1,5 +1,37 @@
 require_relative 'helper'
 
+RSpec.describe Pry::Prompt do
+  let(:prompt_value) do
+    [proc{},proc{}]
+  end
+
+  before do
+    described_class.add_prompt "prompt-name", "prompt description", prompt_value
+  end
+
+  after do
+    described_class.remove_prompt "prompt-name"
+  end
+
+  describe ".add_prompt" do
+    specify "it adds a new prompt to Pry" do
+      new_prompt = described_class::PROMPT_MAP['prompt-name']
+      expect(new_prompt).to eq(description: "prompt description", value: prompt_value)
+      expect(pry_eval("list-prompts")).to include("prompt-name")
+      expect(pry_eval("list-prompts")).to include("prompt description")
+      expect(pry_eval("change-prompt prompt-name", "_pry_.prompt")).to eq(prompt_value)
+    end
+  end
+
+  describe ".remove_prompt" do
+    specify "it removes a prompt from Pry" do
+      described_class.remove_prompt 'prompt-name'
+      expect(pry_eval("list-prompts")).to_not include("prompt-name")
+      expect(pry_eval("list-prompts")).to_not include("prompt description")
+    end
+  end
+end
+
 describe "Prompts" do
   describe "one-parameter prompt proc" do
     it 'should get full config object' do


### PR DESCRIPTION
A prompt added through Pry::Prompt will be visible in the output of
the "list-prompts" command, and it can be used with the "change-prompt"
command. So, adding a prompt this way integrates with the rest of Pry
and is a good option for plugins who want their prompts to be discoverable
by Pry's built-in commands.