### PR TITLE
include Pry::Helpers::Text into Pry::Command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 
+* Include Pry::Helpers::Text into Pry::Command, and deprecate `Pry::Command#text`. ([#1629](https://github.com/pry/pry/pull/1629))
 * Fix string literal methods completion. ([#1590](https://github.com/pry/pry/pull/1590))
 * Add alias 'whereami[?!]+' for 'whereami' command. ([#1597](https://github.com/pry/pry/pull/1597))
 * Improve Ruby 2.4 support ([#1611](https://github.com/pry/pry/pull/1611)):

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -254,6 +254,14 @@ class Pry
       command_set.to_hash
     end
 
+    #
+    # @deprecated {Pry::Helpers::Text} is included into {Pry::Command}.
+    # This method is no longer neccessary, as 'text.black("foo")' can be written as
+    # 'black("foo")' instead.
+    #
+    # @return [Module]
+    #   returns Pry::Helpers::Text
+    #
     def text
       Pry::Helpers::Text
     end
@@ -264,6 +272,7 @@ class Pry
 
     include Pry::Helpers::BaseHelpers
     include Pry::Helpers::CommandHelpers
+    include Pry::Helpers::Text
 
     # Instantiate a command, in preparation for calling it.
     # @param [Hash] context The runtime context to use with this command.


### PR DESCRIPTION
Requiring `text.yellow()` was always at odds with how other helper
methods are available to commands. Now commands can be written the
more convient:

```ruby
_pry_.pager.puts yellow("snowman")
```