### PR TITLE
add "snowman" prompt to Pry.

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,1 @@
+Pry.config.prompt = Pry::Prompt['☃']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### HEAD
 
+* Add snowman prompt ([#1632](https://github.com/pry/pry/pull/1632))
 * Add 'alias-prompt' command.
 * Add `Pry::Prompt.add_prompt()`, `Pry::Prompt.get_prompt()`, `Pry::Prompt.alias_prompt` and
   `Pry::Prompt.remove_prompt()`, for integrating custom prompts with Pry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * Add `Pry::Helpers::Colors`, and a new `#paint` function.
 * Add clear-screen command ([#1630](https://github.com/pry/pry/pull/1630))
 * Fix [#1636](https://github.com/pry/pry/issues/1636)
->>>>>>> pry/master
 * Add 'alias-prompt' command.
 
 * Add `Pry::Prompt.[]`, `Pry::Prompt.add_prompt()`, `Pry::Prompt.alias_prompt()` and

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -1,5 +1,7 @@
+# coding: utf-8
 require 'set'
 module Pry::Prompt
+  require_relative "prompt/snowman"
   extend self
   PROMPT_MAP = {}
   private_constant :PROMPT_MAP
@@ -84,7 +86,7 @@ module Pry::Prompt
   #
   #   # .pryrc
   #   Pry.configure do |config|
-  #     config.prompt = Pry::Prompt['simple'].proc_array
+  #     config.prompt = Pry::Prompt['☃']
   #   end
   #
   # @return [PromptInfo]
@@ -157,6 +159,18 @@ module Pry::Prompt
              "A prompt that displays the binding stack as a path and\n" \
              "includes information about _in_ and _out_.",
              Pry::NAV_PROMPT
+
+  add_prompt "snowman",
+             "First Pry prompt to use unicode characters. It includes\n" \
+             "the same information as the default prompt, plus Ruby \n" \
+             "platform information. Originally authored by \n" \
+             "https://github.com/SaladFork as a Powerline-like prompt \n" \
+             "then adapted to Pry.",
+             [
+               proc{|*args| "%s " % Snowman.prompt(*args, false) },
+               proc{|*args| "%s " % Snowman.prompt(*args, true) }
+             ]
+  alias_prompt "snowman", "☃"
 
   add_prompt "simple", "A simple '>>'.", Pry::SIMPLE_PROMPT
   add_prompt "none", "Wave goodbye to the Pry prompt.", Pry::NO_PROMPT

--- a/lib/pry/prompt/snowman.rb
+++ b/lib/pry/prompt/snowman.rb
@@ -17,7 +17,7 @@ module Pry::Prompt::Snowman
     e = wait ? "*" : ">"
     input_size = pry.input_array.size
     [
-      h.bright_yellow(" #{input_size} "),
+      h.paint(" #{input_size} ", :bright_yellow),
       " #{ruby_info(pry, h)} ",
       "#{PICK} (#{h.bold(Pry.view_clip(obj))})#{':%s' % nest_level if not nest_level.zero?}#{e}",
     ].compact.join
@@ -27,10 +27,10 @@ module Pry::Prompt::Snowman
     case
     when h.jruby?
       str = " #{COFFEE}  #{RUBY_ENGINE}-#{RUBY_VERSION} "
-      h.bright_white_on_red(str)
+      h.paint(str, :bright_white_on_red)
     else
       str = " #{GEM_STONE}  #{RUBY_ENGINE}-#{RUBY_VERSION} "
-      h.bright_white_on_red(str)
+      h.paint(str, :bright_white_on_red)
     end
   end
   private :ruby_info

--- a/lib/pry/prompt/snowman.rb
+++ b/lib/pry/prompt/snowman.rb
@@ -1,8 +1,6 @@
 # coding: utf-8
 module Pry::Prompt::Snowman
   extend self
-  extend Pry::Helpers::Text
-  extend Pry::Helpers::BaseHelpers
 
   # https://unicode-table.com/en/1F48E/
   GEM_STONE = "💎"
@@ -15,10 +13,11 @@ module Pry::Prompt::Snowman
   COFFEE = "☕"
 
   def prompt(obj, nest_level, pry, wait)
+    extend pry.helpers
     e = wait ? "*" : ">"
     input_size = pry.input_array.size
     [
-      pry.color ? bright_yellow(" #{input_size} ") : input_size,
+      bright_yellow(" #{input_size} "),
       " #{ruby_info(pry)} ",
       "#{PICK} (#{bold(Pry.view_clip(obj))})#{':%s' % nest_level if not nest_level.zero?}#{e}",
     ].compact.join
@@ -28,10 +27,10 @@ module Pry::Prompt::Snowman
     case
     when jruby?
       str = " #{COFFEE}  #{RUBY_ENGINE}-#{RUBY_VERSION} "
-      pry.color ? bright_white_on_red(str) : str
+      bright_white_on_red(str)
     else
       str = " #{GEM_STONE}  #{RUBY_ENGINE}-#{RUBY_VERSION} "
-      pry.color ? bright_white_on_red(str) : str
+      bright_white_on_red(str)
     end
   end
   private :ruby_info

--- a/lib/pry/prompt/snowman.rb
+++ b/lib/pry/prompt/snowman.rb
@@ -1,0 +1,38 @@
+# coding: utf-8
+module Pry::Prompt::Snowman
+  extend self
+  extend Pry::Helpers::Text
+  extend Pry::Helpers::BaseHelpers
+
+  # https://unicode-table.com/en/1F48E/
+  GEM_STONE = "💎"
+
+  # Pry-like symbol.
+  # https://unicode-table.com/en/26CF/
+  PICK = "⛏"
+
+  # https://unicode-table.com/en/2615/
+  COFFEE = "☕"
+
+  def prompt(obj, nest_level, pry, wait)
+    e = wait ? "*" : ">"
+    input_size = pry.input_array.size
+    [
+      pry.color ? bright_yellow(" #{input_size} ") : input_size,
+      " #{ruby_info(pry)} ",
+      "#{PICK} (#{bold(Pry.view_clip(obj))})#{':%s' % nest_level if not nest_level.zero?}#{e}",
+    ].compact.join
+  end
+
+  def ruby_info(pry)
+    case
+    when jruby?
+      str = " #{COFFEE}  #{RUBY_ENGINE}-#{RUBY_VERSION} "
+      pry.color ? bright_white_on_red(str) : str
+    else
+      str = " #{GEM_STONE}  #{RUBY_ENGINE}-#{RUBY_VERSION} "
+      pry.color ? bright_white_on_red(str) : str
+    end
+  end
+  private :ruby_info
+end

--- a/lib/pry/prompt/snowman.rb
+++ b/lib/pry/prompt/snowman.rb
@@ -13,7 +13,7 @@ module Pry::Prompt::Snowman
   COFFEE = "☕"
 
   def prompt(obj, nest_level, pry, wait)
-    extend pry.helpers
+    extend pry.helpers if not pry.helpers === self
     e = wait ? "*" : ">"
     input_size = pry.input_array.size
     [

--- a/lib/pry/prompt/snowman.rb
+++ b/lib/pry/prompt/snowman.rb
@@ -13,24 +13,24 @@ module Pry::Prompt::Snowman
   COFFEE = "☕"
 
   def prompt(obj, nest_level, pry, wait)
-    extend pry.helpers if not pry.helpers === self
+    h = pry.helpers
     e = wait ? "*" : ">"
     input_size = pry.input_array.size
     [
-      bright_yellow(" #{input_size} "),
-      " #{ruby_info(pry)} ",
-      "#{PICK} (#{bold(Pry.view_clip(obj))})#{':%s' % nest_level if not nest_level.zero?}#{e}",
+      h.bright_yellow(" #{input_size} "),
+      " #{ruby_info(pry, h)} ",
+      "#{PICK} (#{h.bold(Pry.view_clip(obj))})#{':%s' % nest_level if not nest_level.zero?}#{e}",
     ].compact.join
   end
 
-  def ruby_info(pry)
+  def ruby_info(pry, h)
     case
-    when jruby?
+    when h.jruby?
       str = " #{COFFEE}  #{RUBY_ENGINE}-#{RUBY_VERSION} "
-      bright_white_on_red(str)
+      h.bright_white_on_red(str)
     else
       str = " #{GEM_STONE}  #{RUBY_ENGINE}-#{RUBY_VERSION} "
-      bright_white_on_red(str)
+      h.bright_white_on_red(str)
     end
   end
   private :ruby_info

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -100,6 +100,8 @@ class Pry
         include Pry::Helpers::BaseHelpers
         define_method(:_pry_) { this }
         extend self
+        public_class_method *Pry::Helpers::BaseHelpers.methods(false)
+        public *Pry::Helpers::BaseHelpers.methods(false)
       end
     }.call
   end


### PR DESCRIPTION
First Pry prompt to use unicode characters. It includes the same information
as the default prompt, plus Ruby version. Originally authored by
https://github.com/SaladFork as a Powerline-like prompt, then adapted to Pry.

cc @SaladFork 