### PR TITLE
fix #1633

### DIFF
--- a/lib/pry/commands/ls/formatter.rb
+++ b/lib/pry/commands/ls/formatter.rb
@@ -18,14 +18,16 @@ class Pry
       private
 
       def color(type, str)
-        Pry::Helpers::Text.send _pry_.config.ls["#{type}_color"], str
+        # Pass 'Pry' because global state programmers...
+        Pry::Helpers::Text.public_send _pry_.config.ls["#{type}_color"], str, Pry
       end
 
       # Add a new section to the output.
       # Outputs nothing if the section would be empty.
       def output_section(heading, body)
         return '' if body.compact.empty?
-        fancy_heading = Pry::Helpers::Text.bold(color(:heading, heading))
+        # Pass 'Pry' because global state programmers...
+        fancy_heading = Pry::Helpers::Text.bold(color(:heading, heading), Pry)
         Pry::Helpers.tablify_or_one_line(fancy_heading, body)
       end
 

--- a/lib/pry/helpers/colors.rb
+++ b/lib/pry/helpers/colors.rb
@@ -77,11 +77,11 @@ module Pry::Helpers::Colors
   # Executes the block with `Pry.config.color` set to false.
   # @yield
   # @return [void]
-  def no_color(&block)
-    boolean = Pry.config.color
-    Pry.config.color = false
+  def no_color pry=(defined?(_pry_) && _pry_) || Pry, &block
+    boolean = pry.config.color
+    pry.config.color = false
     yield
   ensure
-    Pry.config.color = boolean
+    pry.config.color = boolean
   end
 end

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -45,7 +45,7 @@ class Pry
           r.each_with_index do |e,i|
             next unless e
             item = e.ljust(widths[i])
-            item.sub! e, _recall_color_for(e) if :color_on == style
+            item.sub! e, _recall_color_for(e).to_s if :color_on == style
             padded << item
           end
           padded.join(Pry.config.ls.separator)

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -10,7 +10,7 @@ class Pry
       # Use this instead of "black" or "white" when you mean absence of colour.
       #
       # @deprecated
-      #   Please use {#strip_color} instead.
+      #   Please use {Colors#strip_color} instead.
       #
       # @param [String, #to_s] text
       # @return [String]

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -16,22 +16,26 @@ class Pry
         "white"   => 7
       }
 
+      color_enabled = lambda do |pry|
+        (pry and pry.color) or (defined?(_pry_) and _pry_.color)
+      end
+
       COLORS.each_pair do |color, value|
-        define_method color do |text|
-          "\033[0;#{30+value}m#{text}\033[0m"
+        define_method(color) do |text, pry=nil|
+           instance_exec(pry, &color_enabled) ? "\033[0;#{30+value}m#{text}\033[0m" : text
         end
 
-        define_method "bright_#{color}" do |text|
-          "\033[1;#{30+value}m#{text}\033[0m"
+        define_method("bright_#{color}") do |text, pry=nil|
+           instance_exec(pry, &color_enabled) ? "\033[1;#{30+value}m#{text}\033[0m" : text
         end
 
         COLORS.each_pair do |bg_color, bg_value|
-          define_method "#{color}_on_#{bg_color}" do |text|
-            "\033[0;#{30 + value};#{40 + bg_value}m#{text}\033[0m"
+          define_method "#{color}_on_#{bg_color}" do |text, pry=nil|
+            instance_exec(pry, &color_enabled) ? "\033[0;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
           end
 
-          define_method "bright_#{color}_on_#{bg_color}" do |text|
-            "\033[1;#{30 + value};#{40 + bg_value}m#{text}\033[0m"
+          define_method "bright_#{color}_on_#{bg_color}" do |text, pry=nil|
+            instance_exec(pry, &color_enabled) ? "\033[1;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
           end
         end
       end
@@ -48,8 +52,8 @@ class Pry
       #
       # @param [String, #to_s] text
       # @return [String] _text_
-      def bold(text)
-        "\e[1m#{text}\e[0m"
+      def bold text, pry=defined?(_pry_) && _pry_
+        (pry and pry.color) ? "\e[1m#{text}\e[0m" : text
       end
 
       # Returns `text` in the default foreground colour.
@@ -57,7 +61,7 @@ class Pry
       #
       # @param [String, #to_s] text
       # @return [String]
-      def default(text)
+      def default(text, pry=nil)
         text.to_s
       end
       alias_method :bright_default, :bold
@@ -65,23 +69,23 @@ class Pry
       # Executes the block with `Pry.config.color` set to false.
       # @yield
       # @return [void]
-      def no_color(&block)
-        boolean = Pry.config.color
-        Pry.config.color = false
+      def no_color pry=(defined?(_pry_) && _pry_) || Pry, &block
+        boolean = pry.color
+        pry.config.color = false
         yield
       ensure
-        Pry.config.color = boolean
+        pry.config.color = boolean
       end
 
       # Executes the block with `Pry.config.pager` set to false.
       # @yield
       # @return [void]
-      def no_pager(&block)
-        boolean = Pry.config.pager
-        Pry.config.pager = false
+      def no_pager pry=(defined?(_pry_) && _pry_) || Pry, &block
+        boolean = pry.config.pager
+        pry.config.pager = false
         yield
       ensure
-        Pry.config.pager = boolean
+        pry.config.pager = boolean
       end
 
       # Returns _text_ in a numbered list, beginning at _offset_.
@@ -108,4 +112,3 @@ class Pry
     end
   end
 end
-

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -17,7 +17,7 @@ class Pry
       }
 
       color_enabled = lambda do |pry|
-        (pry and pry.color) or (defined?(_pry_) and _pry_.color)
+        (pry and pry.color) or (defined?(_pry_) and _pry_.color) or Pry.color
       end
 
       COLORS.each_pair do |color, value|

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -52,7 +52,7 @@ class Pry
       #
       # @param [String, #to_s] text
       # @return [String] _text_
-      def bold text, pry=defined?(_pry_) && _pry_
+      def bold text, pry=(defined?(_pry_) && _pry_) || Pry
         (pry and pry.color) ? "\e[1m#{text}\e[0m" : text
       end
 


### PR DESCRIPTION
When calling 'text.black("foo")' and similar methods available on Text,
the called method(black in this case) will look for the presence of '_pry_'
and respect '_pry_.color' before returning a string. If '_pry_' isn't in
scope, a colorised string is always returned.

See also https://github.com/pry/pry/pull/1635