### PR TITLE
Travis: make jruby jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.4.1
   - ruby-head
   - rbx-2
-  - jruby
+  - jruby-9.1.13.0
   - jruby-head
 
 script:


### PR DESCRIPTION
This PR tries to fix the build on JRuby.

The CI matrix name `jruby` expanded that name to jruby-9.1.13.0200 which was not found, leading to a failure.

