### PR TITLE
workaround JRuby CI issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ sudo: false
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: jruby
     - rvm: jruby-head
     - rvm: rbx-2
     - rvm: 2.4.1 # because of https://bugs.ruby-lang.org/issues/13537


### PR DESCRIPTION
'jruby' as a catch-all often fails (not always) but pinning to a specific
version seems to at least be able to run the test suite. Tracking JRuby
development may be best, and then pinning to a new version of JRuby when
a new version is released. It's not ideal, but at least it doesn't cause
false red flags.