### PR TITLE
Adding fix for ls -l in rails console environment

### DIFF
--- a/lib/pry/commands/ls/local_vars.rb
+++ b/lib/pry/commands/ls/local_vars.rb
@@ -29,7 +29,7 @@ class Pry
 
       def colorized_assignment_style(lhs, rhs, desired_width = 7)
         colorized_lhs = color(:local_var, lhs)
-        color_escape_padding = colorized_lhs.size - lhs.size
+        color_escape_padding = colorized_lhs.to_s.size - lhs.size
         pad = desired_width + color_escape_padding
         "%-#{pad}s = %s" % [color(:local_var, colorized_lhs), rhs]
       end

--- a/lib/pry/commands/ls/local_vars.rb
+++ b/lib/pry/commands/ls/local_vars.rb
@@ -29,7 +29,7 @@ class Pry
 
       def colorized_assignment_style(lhs, rhs, desired_width = 7)
         colorized_lhs = color(:local_var, lhs)
-        color_escape_padding = colorized_lhs.to_s.size - lhs.size
+        color_escape_padding = colorized_lhs.to_s.size - lhs.to_s.size
         pad = desired_width + color_escape_padding
         "%-#{pad}s = %s" % [color(:local_var, colorized_lhs), rhs]
       end

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -138,7 +138,13 @@ describe "ls" do
       expect(pry_eval('ls -l')).not_to match(/_(?:dir|file|ex|pry|out|in)_/)
     end
 
+  end
+
+  describe 'when in rails console environment' do
     it 'should handle symbols' do
+      # remove the size method from symbol class to mirror rails console env
+      Symbol.class_eval { remove_method :size }
+
       result = pry_eval(Object.new, "a = Class.new{def foo; end;}", 'ls -l')
 
       expect(result).to match(/a/)

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -120,7 +120,7 @@ describe "ls" do
     # see: https://travis-ci.org/pry/pry/jobs/5071918
     unless Pry::Helpers::BaseHelpers.rbx?
       it "should handle classes that (pathologically) define .ancestors" do
-        output = pry_eval("ls Class.new{ def self.ancestors; end; def hihi; end }")
+        jutput = pry_eval("ls Class.new{ def self.ancestors; end; def hihi; end }")
         expect(output).to match(/hihi/)
       end
     end
@@ -133,8 +133,15 @@ describe "ls" do
       expect(result).not_to match(/0x\d{5}/)
       expect(result).to match(/asdf.*xyz/m)
     end
+
     it 'should not list pry noise' do
       expect(pry_eval('ls -l')).not_to match(/_(?:dir|file|ex|pry|out|in)_/)
+    end
+
+    it 'should handle symbols' do
+      result = pry_eval(Object.new, "a = Class.new{def foo; end;}", 'ls -l')
+
+      expect(result).to match(/a/)
     end
   end
 

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -120,7 +120,7 @@ describe "ls" do
     # see: https://travis-ci.org/pry/pry/jobs/5071918
     unless Pry::Helpers::BaseHelpers.rbx?
       it "should handle classes that (pathologically) define .ancestors" do
-        jutput = pry_eval("ls Class.new{ def self.ancestors; end; def hihi; end }")
+        output = pry_eval("ls Class.new{ def self.ancestors; end; def hihi; end }")
         expect(output).to match(/hihi/)
       end
     end


### PR DESCRIPTION
While Ruby's Symbol class has a size method, for whatever reason the method doesn't exist within the rails console causing `ls -l` to break with `NoMethodError: undefined method size for :symbol:Size` while parsing local variables pointing at symbols. 

Symbol's size method just calls `.to_s` so felt like it made more sense to add that then conditionally check for type