### PR TITLE
⚠ ambiguous first argument; put parentheses or a space even after `/' operator

### DIFF
--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -193,5 +193,5 @@ class Pry
 
   Pry::Commands.add_command(Pry::Command::Whereami)
   Pry::Commands.alias_command '@', 'whereami'
-  Pry::Commands.alias_command /whereami[!?]+/, 'whereami'
+  Pry::Commands.alias_command(/whereami[!?]+/, 'whereami')
 end


### PR DESCRIPTION
Current 0.11.1 gem warns with `-w` option, e.g.
`% ruby -wrpry -e ''`