### PR TITLE
add Pry::Platform.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ### HEAD
 
 #### Features
+
+* Add a new category module: "Pry::Platform". Loosely related to #1668 below.
+[#1670](https://github.com/pry/pry/pull/1670)
+
 * Add `mac_osx?` and `linux?` utility functions to Pry::Helpers::BaseHelpers.
 [#1668](https://github.com/pry/pry/pull/1668)
 
@@ -8,7 +12,9 @@
 [#1673](https://github.com/pry/pry/pull/1673)
 
 #### Bug fixes
-* Fix `String#pp` output color. [#1674](https://github.com/pry/pry/pull/1674)
+
+* Fix `String#pp` output color.
+[#1674](https://github.com/pry/pry/pull/1674)
 
 ### 0.11.0
 

--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -5,6 +5,7 @@ require 'pp'
 require 'pry/forwardable'
 require 'pry/input_lock'
 require 'pry/exceptions'
+require 'pry/platform'
 require 'pry/helpers/base_helpers'
 require 'pry/hooks'
 

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -58,8 +58,8 @@ class Pry::Config::Default
       true
     },
     should_trap_interrupts: proc {
-      Pry::Helpers::BaseHelpers.jruby?
-    }, # TODO: Pry::Platform.jruby?
+      Pry::Platform.jruby?
+    },
     disable_auto_reload: proc {
       false
     },

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -1,138 +1,71 @@
-class Pry
-  module Helpers
+module Pry::Helpers; end
+module Pry::Helpers::BaseHelpers
+  include Pry::Platform
+  extend self
 
-    module BaseHelpers
+  def silence_warnings
+    old_verbose = $VERBOSE
+    $VERBOSE = nil
+    begin
+      yield
+    ensure
+      $VERBOSE = old_verbose
+    end
+  end
 
-      module_function
+  # Acts like send but ignores any methods defined below Object or Class in the
+  # inheritance hierarchy.
+  # This is required to introspect methods on objects like Net::HTTP::Get that
+  # have overridden the `method` method.
+  def safe_send(obj, method, *args, &block)
+    (Module === obj ? Module : Object).instance_method(method).bind(obj).call(*args, &block)
+  end
+  public :safe_send
 
-      def silence_warnings
-        old_verbose = $VERBOSE
-        $VERBOSE = nil
-        begin
-          yield
-        ensure
-          $VERBOSE = old_verbose
-        end
-      end
+  def find_command(name, set = Pry::Commands)
+    command_match = set.find do |_, command|
+      (listing = command.options[:listing]) == name && listing != nil
+    end
+    command_match.last if command_match
+  end
 
-      # Acts like send but ignores any methods defined below Object or Class in the
-      # inheritance hierarchy.
-      # This is required to introspect methods on objects like Net::HTTP::Get that
-      # have overridden the `method` method.
-      def safe_send(obj, method, *args, &block)
-        (Module === obj ? Module : Object).instance_method(method).bind(obj).call(*args, &block)
-      end
-      public :safe_send
+  def not_a_real_file?(file)
+    file =~ /^(\(.*\))$|^<.*>$/ || file =~ /__unknown__/ || file == "" || file == "-e"
+  end
 
-      def find_command(name, set = Pry::Commands)
-        command_match = set.find do |_, command|
-          (listing = command.options[:listing]) == name && listing != nil
-        end
-        command_match.last if command_match
-      end
+  def command_dependencies_met?(options)
+    return true if !options[:requires_gem]
+    Array(options[:requires_gem]).all? do |g|
+      Pry::Rubygem.installed?(g)
+    end
+  end
 
-      def not_a_real_file?(file)
-        file =~ /^(\(.*\))$|^<.*>$/ || file =~ /__unknown__/ || file == "" || file == "-e"
-      end
+  def use_ansi_codes?
+    windows_ansi? || ENV['TERM'] && ENV['TERM'] != "dumb"
+  end
 
-      def command_dependencies_met?(options)
-        return true if !options[:requires_gem]
-        Array(options[:requires_gem]).all? do |g|
-          Rubygem.installed?(g)
-        end
-      end
+  def colorize_code(code)
+    CodeRay.scan(code, :ruby).term
+  end
 
-      def use_ansi_codes?
-        windows_ansi? || ENV['TERM'] && ENV['TERM'] != "dumb"
-      end
+  def highlight(string, regexp, highlight_color=:bright_yellow)
+    string.gsub(regexp) { |match| "<#{highlight_color}>#{match}</#{highlight_color}>" }
+  end
 
-      def colorize_code(code)
-        CodeRay.scan(code, :ruby).term
-      end
+  # formatting
+  def heading(text)
+    text = "#{text}\n--"
+    "\e[1m#{text}\e[0m"
+  end
 
-      def highlight(string, regexp, highlight_color=:bright_yellow)
-        string.gsub(regexp) { |match| "<#{highlight_color}>#{match}</#{highlight_color}>" }
-      end
-
-      # formatting
-      def heading(text)
-        text = "#{text}\n--"
-        "\e[1m#{text}\e[0m"
-      end
-
-      #
-      # @return [Boolean]
-      #  Returns true if Pry is running on Mac OSX.
-      #
-      # @note
-      #   Queries RbConfig::CONFIG['host_os'] with a best guess.
-      #
-      def mac_osx?
-        !!(RbConfig::CONFIG['host_os'] =~ /\Adarwin/i)
-      end
-
-      #
-      # @return [Boolean]
-      #   Returns true if Pry is running on Linux.
-      #
-      # @note
-      #   Queries RbConfig::CONFIG['host_os'] with a best guess.
-      #
-      #
-      def linux?
-        !!(RbConfig::CONFIG['host_os'] =~ /linux/i)
-      end
-
-      #
-      # @return [Boolean]
-      #   Returns true if Pry is running on Windows.
-      #
-      # @note
-      #   Queries RbConfig::CONFIG['host_os'] with a best guess.
-      #
-      def windows?
-        !!(RbConfig::CONFIG['host_os'] =~ /mswin|mingw/)
-      end
-
-      # are we able to use ansi on windows?
-      def windows_ansi?
-        defined?(Win32::Console) || ENV['ANSICON'] || (windows? && mri_2?)
-      end
-
-      def jruby?
-        RbConfig::CONFIG['ruby_install_name'] == 'jruby'
-      end
-
-      def jruby_19?
-        jruby? && RbConfig::CONFIG['ruby_version'] == '1.9'
-      end
-
-      def rbx?
-        RbConfig::CONFIG['ruby_install_name'] == 'rbx'
-      end
-
-      def mri?
-        RbConfig::CONFIG['ruby_install_name'] == 'ruby'
-      end
-
-      def mri_19?
-        mri? && RUBY_VERSION =~ /^1\.9/
-      end
-
-      def mri_2?
-        mri? && RUBY_VERSION =~ /^2/
-      end
-
-      # Send the given text through the best available pager (if Pry.config.pager is
-      # enabled). Infers where to send the output if used as a mixin.
-      # DEPRECATED.
-      def stagger_output(text, out = nil)
-        if defined?(_pry_) && _pry_
-          _pry_.pager.page text
-        else
-          Pry.new.pager.page text
-        end
-      end
+  # Send the given text through the best available pager (if Pry.config.pager is
+  # enabled). Infers where to send the output if used as a mixin.
+  # DEPRECATED.
+  def stagger_output(text, out = nil)
+    if defined?(_pry_) && _pry_
+      _pry_.pager.page text
+    else
+      Pry.new.pager.page text
     end
   end
 end

--- a/lib/pry/platform.rb
+++ b/lib/pry/platform.rb
@@ -1,0 +1,93 @@
+module Pry::Platform
+  extend self
+
+  #
+  # @return [Boolean]
+  #  Returns true if Pry is running on Mac OSX.
+  #
+  # @note
+  #   Queries RbConfig::CONFIG['host_os'] with a best guess.
+  #
+  def mac_osx?
+    !!(RbConfig::CONFIG['host_os'] =~ /\Adarwin/i)
+  end
+
+  #
+  # @return [Boolean]
+  #   Returns true if Pry is running on Linux.
+  #
+  # @note
+  #   Queries RbConfig::CONFIG['host_os'] with a best guess.
+  #
+  def linux?
+    !!(RbConfig::CONFIG['host_os'] =~ /linux/i)
+  end
+
+  #
+  # @return [Boolean]
+  #   Returns true if Pry is running on Windows.
+  #
+  # @note
+  #   Queries RbConfig::CONFIG['host_os'] with a best guess.
+  #
+  def windows?
+    !!(RbConfig::CONFIG['host_os'] =~ /mswin|mingw/)
+  end
+
+  #
+  # @return [Boolean]
+  #   Returns true when Pry is running on Windows with ANSI support.
+  #
+  def windows_ansi?
+    return false if not windows?
+    !!(defined?(Win32::Console) or ENV['ANSICON'] or mri_2?)
+  end
+
+  #
+  # @return [Boolean]
+  #   Returns true when Pry is being run from JRuby.
+  #
+  def jruby?
+    RbConfig::CONFIG['ruby_install_name'] == 'jruby'
+  end
+
+  #
+  # @return [Boolean]
+  #   Returns true when Pry is being run from JRuby in 1.9 mode.
+  #
+  def jruby_19?
+    jruby? and RbConfig::CONFIG['ruby_version'] == '1.9'
+  end
+
+  #
+  # @return [Boolean]
+  #   Returns true when Pry is being run from Rubinius.
+  #
+  def rbx?
+    RbConfig::CONFIG['ruby_install_name'] == 'rbx'
+  end
+
+  #
+  # @return [Boolean]
+  #   Returns true when Pry is being run from MRI (CRuby).
+  #
+  def mri?
+    RbConfig::CONFIG['ruby_install_name'] == 'ruby'
+  end
+
+  #
+  # @return [Boolean]
+  #   Returns true when Pry is being run from MRI v1.9+ (CRuby).
+  #
+  def mri_19?
+    !!(mri? and RUBY_VERSION =~ /\A1\.9/)
+  end
+
+  #
+  # @return [Boolean]
+  #   Returns true when Pry is being run from MRI v2+ (CRuby).
+  #
+  def mri_2?
+    !!(mri? and RUBY_VERSION =~ /\A2/)
+  end
+end


### PR DESCRIPTION
Platform is a category module that adds utility functions for querying
platform information relating to Pry.

Some methods are moved from BaseHelpers, and for backwards compatibility
included via 'include Pry::Platform'.

module_function is not used by BaseHelpers anymore, in favour of
include/extend being used in its place.

There is also less indentation noise in BaseHelpers module.
With `_pry_.h` (available on the backup master branch) these methods
exist on a single module that doesn't pollute the command scope, although
for backwards compatibility we still include the functions as top-level
command functions.