### PR TITLE
Issue #1647: Fix String#pp output color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ __Features:__
 
 * Add mac_osx? and linux? utility functions to Pry::Helpers::BaseHelpers. 
 [#1668](https://github.com/pry/pry/pull/1668)
+* Fix String#pp output color. [#1674](https://github.com/pry/pry/pull/1674)
 
 ### 0.11.0
 

--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -32,9 +32,7 @@ class Pry
 
     def pp(obj)
       if String === obj
-        # Avoid calling Ruby 2.4+ String#pretty_print that prints multiline
-        # Strings prettier
-        Object.instance_method(:pretty_print).bind(obj).call
+        text(obj.inspect)
       else
         super
       end

--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -32,6 +32,8 @@ class Pry
 
     def pp(obj)
       if String === obj
+        # Avoid calling Ruby 2.4+ String#pretty_print that prints multiline
+        # Strings prettier
         text(obj.inspect)
       else
         super

--- a/spec/color_printer_spec.rb
+++ b/spec/color_printer_spec.rb
@@ -80,5 +80,21 @@ describe Pry::ColorPrinter do
         expect(str).to match(/\A#<BasicG:0x\w+>\z/)
       end
     end
+
+    describe 'String' do
+      context 'with a single-line string' do
+        it 'pretty prints the string' do
+          Pry::ColorPrinter.pp('hello world', io)
+          expect(str).to eq('"hello world"')
+        end
+      end
+
+      context 'with a multi-line string' do
+        it 'pretty prints the string' do
+          Pry::ColorPrinter.pp("hello\nworld", io)
+          expect(str).to eq('"hello\nworld"')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request fixes https://github.com/pry/pry/issues/1647 and pretty prints strings in red instead of green. This bug was introduced in https://github.com/pry/pry/pull/1586. This pull request will also continue to pretty print multi-line strings without a `'+'` delimiter, per the same pull request.

Here is a screenshot:
![image](https://user-images.githubusercontent.com/13701468/31866196-80a65ace-b741-11e7-9894-b25a90065e9c.png)