### PR TITLE
Fix repetitive suffix for helper modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 #### Bug fixes
 * Fix `String#pp` output color. [#1674](https://github.com/pry/pry/pull/1674)
 
+#### Dev-facing changes
+* Fix repetitive helper module suffix ([#1682](https://github.com/pry/pry/pull/1682))
+
 ### 0.11.0
 
 * Add alias 'whereami[?!]+' for 'whereami' command. ([#1597](https://github.com/pry/pry/pull/1597))

--- a/lib/pry/code/loc.rb
+++ b/lib/pry/code/loc.rb
@@ -61,7 +61,7 @@ class Pry
       # @return [void]
       def add_line_number(max_width = 0, color = false)
         padded = lineno.to_s.rjust(max_width)
-        colorized_lineno = color ? Pry::Helpers::BaseHelpers.colorize_code(padded) : padded
+        colorized_lineno = color ? Pry::Helpers::Base.colorize_code(padded) : padded
         tuple[0] = "#{ colorized_lineno }: #{ line }"
       end
 

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -61,7 +61,7 @@ class Pry
       end
     end
 
-    include Pry::Helpers::CommandHelpers
+    include Pry::Helpers::Command
 
     class << self
       def lookup(str, _pry_, options={})

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -7,7 +7,7 @@ class Pry
   # {Pry::CommandSet#command} which creates a BlockCommand or {Pry::CommandSet#create_command}
   # which creates a ClassCommand. Please don't use this class directly.
   class Command
-    extend Helpers::DocumentationHelpers
+    extend Helpers::Documentation
     extend CodeObject::Helpers
 
     # represents a void return value for a command
@@ -262,8 +262,8 @@ class Pry
       VOID_VALUE
     end
 
-    include Pry::Helpers::BaseHelpers
-    include Pry::Helpers::CommandHelpers
+    include Pry::Helpers::Base
+    include Pry::Helpers::Command
 
     # Instantiate a command, in preparation for calling it.
     # @param [Hash] context The runtime context to use with this command.

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -9,7 +9,7 @@ class Pry
   # different sets, aliased, removed, etc.
   class CommandSet
     include Enumerable
-    include Pry::Helpers::BaseHelpers
+    include Pry::Helpers::Base
     attr_reader :helper_module
 
     # @param [Array<Commandset>] imported_sets
@@ -194,7 +194,7 @@ class Pry
     # @return [Command] The command object matched.
     def find_command_by_match_or_listing(match_or_listing)
       cmd = (@commands[match_or_listing] ||
-        Pry::Helpers::BaseHelpers.find_command(match_or_listing, @commands))
+        Pry::Helpers::Base.find_command(match_or_listing, @commands))
       cmd or raise ArgumentError, "Cannot find a command: '#{match_or_listing}'!"
     end
 

--- a/lib/pry/commands/cat/abstract_formatter.rb
+++ b/lib/pry/commands/cat/abstract_formatter.rb
@@ -1,8 +1,8 @@
 class Pry
   class Command::Cat
     class AbstractFormatter
-      include Pry::Helpers::CommandHelpers
-      include Pry::Helpers::BaseHelpers
+      include Pry::Helpers::Command
+      include Pry::Helpers::Base
 
       private
       def decorate(content)

--- a/lib/pry/commands/code_collector.rb
+++ b/lib/pry/commands/code_collector.rb
@@ -1,6 +1,6 @@
 class Pry
   class Command::CodeCollector
-    include Helpers::CommandHelpers
+    include Helpers::Command
 
     attr_reader :args
     attr_reader :opts

--- a/lib/pry/commands/find_method.rb
+++ b/lib/pry/commands/find_method.rb
@@ -1,6 +1,6 @@
 class Pry
   class Command::FindMethod < Pry::ClassCommand
-    extend Pry::Helpers::BaseHelpers
+    extend Pry::Helpers::Base
 
     match 'find-method'
     group 'Context'

--- a/lib/pry/commands/ls/constants.rb
+++ b/lib/pry/commands/ls/constants.rb
@@ -4,7 +4,7 @@ class Pry
   class Command::Ls < Pry::ClassCommand
     class Constants < Pry::Command::Ls::Formatter
       DEPRECATED_CONSTANTS = [:Fixnum, :Bignum, :TimeoutError, :NIL, :FALSE, :TRUE]
-      DEPRECATED_CONSTANTS << :JavaPackageModuleTemplate if Pry::Helpers::BaseHelpers.jruby?
+      DEPRECATED_CONSTANTS << :JavaPackageModuleTemplate if Pry::Helpers::Base.jruby?
       include Pry::Command::Ls::Interrogatable
 
       def initialize(interrogatee, no_user_opts, opts, _pry_)

--- a/lib/pry/commands/ls/methods_helper.rb
+++ b/lib/pry/commands/ls/methods_helper.rb
@@ -14,7 +14,7 @@ module Pry::Command::Ls::MethodsHelper
                 Pry::Method.all_from_obj(@interrogatee)
               end
 
-    if Pry::Helpers::BaseHelpers.jruby? && !@jruby_switch
+    if Pry::Helpers::Base.jruby? && !@jruby_switch
       methods = trim_jruby_aliases(methods)
     end
 

--- a/lib/pry/commands/show_doc.rb
+++ b/lib/pry/commands/show_doc.rb
@@ -2,7 +2,7 @@ require 'pry/commands/show_info'
 
 class Pry
   class Command::ShowDoc < Command::ShowInfo
-    include Pry::Helpers::DocumentationHelpers
+    include Pry::Helpers::Documentation
 
     match 'show-doc'
     group 'Introspection'

--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -1,6 +1,6 @@
 class Pry
   class Command::ShowInfo < Pry::ClassCommand
-    extend Pry::Helpers::BaseHelpers
+    extend Pry::Helpers::Base
 
     command_options :shellwords => false, :interpolate => false
 

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -43,7 +43,7 @@ class Pry::Config::Default
       Pry::DEFAULT_SYSTEM
     },
     color: proc {
-      Pry::Helpers::BaseHelpers.use_ansi_codes?
+      Pry::Helpers::Base.use_ansi_codes?
     },
     default_window_size: proc {
       5
@@ -58,7 +58,7 @@ class Pry::Config::Default
       true
     },
     should_trap_interrupts: proc {
-      Pry::Helpers::BaseHelpers.jruby?
+      Pry::Helpers::Base.jruby?
     }, # TODO: Pry::Platform.jruby?
     disable_auto_reload: proc {
       false
@@ -67,7 +67,7 @@ class Pry::Config::Default
       ""
     },
     auto_indent: proc {
-      Pry::Helpers::BaseHelpers.use_ansi_codes?
+      Pry::Helpers::Base.use_ansi_codes?
     },
     correct_indent: proc {
       true

--- a/lib/pry/core_extensions.rb
+++ b/lib/pry/core_extensions.rb
@@ -81,7 +81,7 @@ class Object
       # This fixes the following two spec failures, at https://travis-ci.org/pry/pry/jobs/274470002
       # 1) ./spec/pry_spec.rb:360:in `block in (root)'
       # 2) ./spec/pry_spec.rb:366:in `block in (root)'
-      return class_eval {binding} if Pry::Helpers::BaseHelpers.jruby? and self.name == nil
+      return class_eval {binding} if Pry::Helpers::Base.jruby? and self.name == nil
       # class_eval sets both self and the default definee to this class.
       return class_eval("binding")
     end

--- a/lib/pry/editor.rb
+++ b/lib/pry/editor.rb
@@ -1,7 +1,7 @@
 class Pry
   class Editor
-    include Pry::Helpers::BaseHelpers
-    include Pry::Helpers::CommandHelpers
+    include Pry::Helpers::Base
+    include Pry::Helpers::Command
 
     attr_reader :_pry_
 

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -1,7 +1,7 @@
 class Pry
   module Helpers
 
-    module BaseHelpers
+    module Base
 
       module_function
 

--- a/lib/pry/helpers/command_helpers.rb
+++ b/lib/pry/helpers/command_helpers.rb
@@ -1,8 +1,8 @@
 class Pry
   module Helpers
 
-    module CommandHelpers
-      include OptionsHelpers
+    module Command
+      include Options
 
       module_function
 

--- a/lib/pry/helpers/documentation_helpers.rb
+++ b/lib/pry/helpers/documentation_helpers.rb
@@ -69,7 +69,7 @@ class Pry
       # @param [String] text
       # @return [String]
       def strip_leading_whitespace(text)
-        Pry::Helpers::CommandHelpers.unindent(text)
+        Pry::Helpers::Command.unindent(text)
       end
     end
   end

--- a/lib/pry/helpers/documentation_helpers.rb
+++ b/lib/pry/helpers/documentation_helpers.rb
@@ -3,7 +3,7 @@ class Pry
 
     # This class contains methods useful for extracting
     # documentation from methods and classes.
-    module DocumentationHelpers
+    module Documentation
 
       module_function
 

--- a/lib/pry/helpers/options_helpers.rb
+++ b/lib/pry/helpers/options_helpers.rb
@@ -1,6 +1,6 @@
 class Pry
   module Helpers
-    module OptionsHelpers
+    module Options
       module_function
 
       # Add method options to the Pry::Slop instance

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -9,7 +9,7 @@ class Pry
   # will be indented or un-indented by correctly.
   #
   class Indent
-    include Helpers::BaseHelpers
+    include Helpers::Base
 
     # Raised if {#module_nesting} would not work.
     class UnparseableNestingError < StandardError; end
@@ -396,7 +396,7 @@ class Pry
       cols = cols.to_i
       lines = (cols != 0 ? (line_to_measure.length / cols + 1) : 1).to_i
 
-      if Pry::Helpers::BaseHelpers.windows_ansi?
+      if Pry::Helpers::Base.windows_ansi?
         move_up   = "\e[#{lines}F"
         move_down = "\e[#{lines}E"
       else

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -20,9 +20,9 @@ class Pry
     require 'pry/method/disowned'
     require 'pry/method/patcher'
 
-    extend Helpers::BaseHelpers
-    include Helpers::BaseHelpers
-    include Helpers::DocumentationHelpers
+    extend Helpers::Base
+    include Helpers::Base
+    include Helpers::Documentation
     include CodeObject::Helpers
 
     class << self

--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -51,7 +51,7 @@ class Pry::Pager
   def best_available
     if !_pry_.config.pager
       NullPager.new(_pry_.output)
-    elsif !SystemPager.available? || Pry::Helpers::BaseHelpers.jruby?
+    elsif !SystemPager.available? || Pry::Helpers::Base.jruby?
       SimplePager.new(_pry_.output)
     else
       SystemPager.new(_pry_.output)
@@ -138,7 +138,7 @@ class Pry::Pager
       if @system_pager.nil?
         @system_pager = begin
           pager_executable = default_pager.split(' ').first
-          if Pry::Helpers::BaseHelpers.windows? || Pry::Helpers::BaseHelpers.windows_ansi?
+          if Pry::Helpers::Base.windows? || Pry::Helpers::Base.windows_ansi?
             `where #{pager_executable}`
           else
             `which #{pager_executable}`

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -148,7 +148,7 @@ you can add "Pry.config.windows_console_warning = false" to your .pryrc.
     load_requires if Pry.config.should_load_requires
     load_history if Pry.config.history.should_load
     load_traps if Pry.config.should_trap_interrupts
-    load_win32console if Pry::Helpers::BaseHelpers.windows? && !Pry::Helpers::BaseHelpers.windows_ansi?
+    load_win32console if Pry::Helpers::Base.windows? && !Pry::Helpers::Base.windows_ansi?
   end
 
   # Start a Pry REPL.
@@ -287,7 +287,7 @@ you can add "Pry.config.windows_console_warning = false" to your .pryrc.
   def self.default_editor_for_platform
     return ENV['VISUAL'] if ENV['VISUAL'] and not ENV['VISUAL'].empty?
     return ENV['EDITOR'] if ENV['EDITOR'] and not ENV['EDITOR'].empty?
-    if Helpers::BaseHelpers.windows?
+    if Helpers::Base.windows?
       'notepad'
     else
       %w(editor nano vi).detect do |editor|

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -310,7 +310,7 @@ class Pry
       # This workaround has a side effect: java exceptions specified
       # in `Pry.config.exception_whitelist` are ignored.
       jruby_exceptions = []
-      if Pry::Helpers::BaseHelpers.jruby?
+      if Pry::Helpers::Base.jruby?
         jruby_exceptions << Java::JavaLang::Exception
       end
 
@@ -325,7 +325,7 @@ class Pry
         # Eliminate following warning:
         # warning: singleton on non-persistent Java type X
         # (http://wiki.jruby.org/Persistence)
-        if Pry::Helpers::BaseHelpers.jruby? && e.class.respond_to?('__persistent__')
+        if Pry::Helpers::Base.jruby? && e.class.respond_to?('__persistent__')
           e.class.__persistent__ = true
         end
         self.last_exception = e

--- a/lib/pry/rbx_path.rb
+++ b/lib/pry/rbx_path.rb
@@ -2,7 +2,7 @@ class Pry
   module RbxPath
     module_function
     def is_core_path?(path)
-      Pry::Helpers::BaseHelpers.rbx? && (path.start_with?("kernel") || path.start_with?("lib")) && File.exist?(convert_path_to_full(path))
+      Pry::Helpers::Base.rbx? && (path.start_with?("kernel") || path.start_with?("lib")) && File.exist?(convert_path_to_full(path))
     end
 
     def convert_path_to_full(path)

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -49,7 +49,7 @@ class Pry
 
       # Clear the line before starting Pry. This fixes issue #566.
       if pry.config.correct_indent
-        Kernel.print Pry::Helpers::BaseHelpers.windows_ansi? ? "\e[0F" : "\e[0G"
+        Kernel.print Pry::Helpers::Base.windows_ansi? ? "\e[0F" : "\e[0G"
       end
     end
 
@@ -104,7 +104,7 @@ class Pry
         original_val = "#{indentation}#{val}"
         indented_val = @indent.indent(val)
 
-        if output.tty? && pry.config.correct_indent && Pry::Helpers::BaseHelpers.use_ansi_codes?
+        if output.tty? && pry.config.correct_indent && Pry::Helpers::Base.use_ansi_codes?
           output.print @indent.correct_indentation(
             current_prompt, indented_val,
             original_val.length - indented_val.length
@@ -218,7 +218,7 @@ class Pry
     #   % pry | tee log
     def piping?
       return false unless $stdout.respond_to?(:tty?)
-      !$stdout.tty? && $stdin.tty? && !Pry::Helpers::BaseHelpers.windows?
+      !$stdout.tty? && $stdin.tty? && !Pry::Helpers::Base.windows?
     end
 
     # @return [void]

--- a/lib/pry/terminal.rb
+++ b/lib/pry/terminal.rb
@@ -41,7 +41,7 @@ class Pry::Terminal
     end
 
     def screen_size_according_to_io_console
-      return if Pry::Helpers::BaseHelpers.jruby?
+      return if Pry::Helpers::Base.jruby?
 
       begin
         require 'io/console'

--- a/lib/pry/test/helper.rb
+++ b/lib/pry/test/helper.rb
@@ -58,7 +58,7 @@ module PryTestHelpers
   end
 
   def unindent(*args)
-    Pry::Helpers::CommandHelpers.unindent(*args)
+    Pry::Helpers::Command.unindent(*args)
   end
 
   def mock_command(cmd, args=[], opts={})

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -14,7 +14,7 @@ class Pry
   end
 
   class WrappedModule
-    include Helpers::BaseHelpers
+    include Helpers::Base
     include CodeObject::Helpers
 
     attr_reader :wrapped
@@ -138,7 +138,7 @@ class Pry
     def singleton_instance
       raise ArgumentError, "tried to get instance of non singleton class" unless singleton_class?
 
-      if Helpers::BaseHelpers.jruby?
+      if Helpers::Base.jruby?
         wrapped.to_java.attached
       else
         @singleton_instance ||= ObjectSpace.each_object(wrapped).detect{ |x| (class << x; self; end) == wrapped }
@@ -253,7 +253,7 @@ class Pry
                  y.yield candidate(num)
                end
              end
-      Pry::Helpers::BaseHelpers.jruby_19? ? enum.to_a : enum
+      Pry::Helpers::Base.jruby_19? ? enum.to_a : enum
     end
 
     # @return [Boolean] Whether YARD docs are available for this module.

--- a/lib/pry/wrapped_module/candidate.rb
+++ b/lib/pry/wrapped_module/candidate.rb
@@ -7,7 +7,7 @@ class Pry
     # It provides access to the source, documentation, line and file
     # for a monkeypatch (reopening) of a class/module.
     class Candidate
-      include Pry::Helpers::DocumentationHelpers
+      include Pry::Helpers::Documentation
       include Pry::CodeObject::Helpers
       extend Pry::Forwardable
 

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -95,7 +95,7 @@ describe Pry::Code do
 
   describe '#initialize' do
     before do
-      @str = Pry::Helpers::CommandHelpers.unindent <<-CODE
+      @str = Pry::Helpers::Command.unindent <<-CODE
         def hay
           :guys
         end
@@ -119,7 +119,7 @@ describe Pry::Code do
 
   describe 'filters and formatters' do
     before do
-      @code = Pry::Code(Pry::Helpers::CommandHelpers.unindent <<-STR)
+      @code = Pry::Code(Pry::Helpers::Command.unindent <<-STR)
         class MyProgram
           def self.main
             puts 'Hello, world!'

--- a/spec/command_helpers_spec.rb
+++ b/spec/command_helpers_spec.rb
@@ -1,8 +1,8 @@
 require_relative 'helper'
 
-describe Pry::Helpers::CommandHelpers do
+describe Pry::Helpers::Command do
   before do
-    @helper = Pry::Helpers::CommandHelpers
+    @helper = Pry::Helpers::Command
   end
 
   describe "unindent" do

--- a/spec/commands/cat_spec.rb
+++ b/spec/commands/cat_spec.rb
@@ -77,7 +77,7 @@ describe "cat" do
       end
     end
 
-    if !Pry::Helpers::BaseHelpers.rbx?
+    if !Pry::Helpers::Base.rbx?
       it 'cat --ex should display repl code that generated exception' do
         @t.eval unindent(<<-EOS)
           begin

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -20,7 +20,7 @@ describe "edit" do
       # OS-specific tempdir name. For GNU/Linux it's "tmp", for Windows it's
       # something "Temp".
       @tf_dir =
-        if Pry::Helpers::BaseHelpers.mri_19?
+        if Pry::Helpers::Base.mri_19?
           Pathname.new(Dir::Tmpname.tmpdir)
         else
           Pathname.new(Dir.tmpdir)

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -118,7 +118,7 @@ describe "ls" do
 
 
     # see: https://travis-ci.org/pry/pry/jobs/5071918
-    unless Pry::Helpers::BaseHelpers.rbx?
+    unless Pry::Helpers::Base.rbx?
       it "should handle classes that (pathologically) define .ancestors" do
         output = pry_eval("ls Class.new{ def self.ancestors; end; def hihi; end }")
         expect(output).to match(/hihi/)
@@ -212,7 +212,7 @@ describe "ls" do
   describe "when no arguments given" do
     describe "when at the top-level" do
       # rubinius has a bug that means local_variables of "main" aren't reported inside eval()
-      unless Pry::Helpers::BaseHelpers.rbx?
+      unless Pry::Helpers::Base.rbx?
         it "should show local variables" do
           expect(pry_eval("ls")).to match(/_pry_/)
           expect(pry_eval("arbitrar = 1", "ls")).to match(/arbitrar/)
@@ -245,7 +245,7 @@ describe "ls" do
     end
   end
 
-  if Pry::Helpers::BaseHelpers.jruby?
+  if Pry::Helpers::Base.jruby?
     describe 'on java objects' do
       it 'should omit java-esque aliases by default' do
         expect(pry_eval('ls java.lang.Thread.current_thread')).to match(/\bthread_group\b/)

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -467,7 +467,7 @@ describe "show-doc" do
     end
   end
 
-  unless Pry::Helpers::BaseHelpers.rbx?
+  unless Pry::Helpers::Base.rbx?
     describe "can't find class docs" do
       describe "for classes" do
         before do

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -744,7 +744,7 @@ describe "show-source" do
     end
   end
 
-  unless Pry::Helpers::BaseHelpers.rbx?
+  unless Pry::Helpers::Base.rbx?
     describe "can't find class/module code" do
       describe "for classes" do
         before do

--- a/spec/commands/whereami_spec.rb
+++ b/spec/commands/whereami_spec.rb
@@ -196,7 +196,7 @@ describe "whereami" do
     end
 
     # https://github.com/rubinius/rubinius/pull/2247
-    unless Pry::Helpers::BaseHelpers.rbx?
+    unless Pry::Helpers::Base.rbx?
       it 'should show class when -c option used, and binding is outside a method' do
         class Cor
           def blimey;end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -28,7 +28,7 @@ describe Pry::InputCompleter do
   end
 
   # another jruby hack :((
-  if !Pry::Helpers::BaseHelpers.jruby?
+  if !Pry::Helpers::Base.jruby?
     it "should not crash if there's a Module that has a symbolic name." do
       expect { Pry::InputCompleter.new(Readline).call "a.to_s.", :target => Pry.binding_for(Object.new) }.not_to raise_error
     end
@@ -225,7 +225,7 @@ describe Pry::InputCompleter do
     completer_test(self, nil, false).call("[].size.parse_printf_format")
   end
 
-  if !Pry::Helpers::BaseHelpers.jruby?
+  if !Pry::Helpers::Base.jruby?
     # Classes that override .hash are still hashable in JRuby, for some reason.
     it 'ignores methods from modules that override Object#hash incompatibly' do
       _m = Module.new do

--- a/spec/documentation_helper_spec.rb
+++ b/spec/documentation_helper_spec.rb
@@ -1,8 +1,8 @@
 require_relative 'helper'
 
-describe Pry::Helpers::DocumentationHelpers do
+describe Pry::Helpers::Documentation do
   before do
-    @helper = Pry::Helpers::DocumentationHelpers
+    @helper = Pry::Helpers::Documentation
   end
 
   describe "get_comment_content" do

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -10,7 +10,7 @@ describe Pry::Editor do
     # OS-specific tempdir name. For GNU/Linux it's "tmp", for Windows it's
     # something "Temp".
     @tf_dir =
-      if Pry::Helpers::BaseHelpers.mri_19?
+      if Pry::Helpers::Base.mri_19?
         Pathname.new(Dir::Tmpname.tmpdir)
       else
         Pathname.new(Dir.tmpdir)
@@ -21,7 +21,7 @@ describe Pry::Editor do
     @editor = Pry::Editor.new(Pry.new)
   end
 
-  unless Pry::Helpers::BaseHelpers.windows?
+  unless Pry::Helpers::Base.windows?
     describe "build_editor_invocation_string" do
       it 'should shell-escape files' do
         invocation_str = @editor.build_editor_invocation_string(@tf_path, 5, true)

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -20,7 +20,7 @@ end.new(nil)
 
 # to help with tracking down bugs that cause an infinite loop in the test suite
 if ENV["SET_TRACE_FUNC"]
-  require 'set_trace' if Pry::Helpers::BaseHelpers.rbx?
+  require 'set_trace' if Pry::Helpers::Base.rbx?
   set_trace_func proc { |event, file, line, id, binding, classname|
      STDERR.printf "%8s %s:%-2d %10s %8s\n", event, file, line, id, classname
   }

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -119,7 +119,7 @@ describe Pry::Method do
     end
 
     # Our source_location trick doesn't work, due to https://github.com/rubinius/rubinius/issues/953
-    unless Pry::Helpers::BaseHelpers.rbx?
+    unless Pry::Helpers::Base.rbx?
        it 'should find the super method correctly' do
         a = Class.new{ def gag33; binding; end; def self.line; __LINE__; end }
         b = Class.new(a){ def gag33; super; end }
@@ -145,7 +145,7 @@ describe Pry::Method do
     end
 
     # Temporarily disabled to work around rubinius/rubinius#2871.
-    unless Pry::Helpers::BaseHelpers.rbx?
+    unless Pry::Helpers::Base.rbx?
       it "should find the right method from a BasicObject" do
         a = Class.new(BasicObject) { def gag; ::Kernel.binding; end; def self.line; __LINE__; end }
 

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -370,7 +370,7 @@ describe "test Pry defaults" do
     end
 
     # https://github.com/rubinius/rubinius/issues/1779
-    unless Pry::Helpers::BaseHelpers.rbx?
+    unless Pry::Helpers::Base.rbx?
       it 'should define private methods on Object' do
         TOPLEVEL_BINDING.eval 'def gooey_fooey; end'
         expect(method(:gooey_fooey).owner).to eq Object

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -369,9 +369,9 @@ describe Pry do
         it 'should define a method on the class of an object when performing "def meth;end" inside an immediate value or Numeric' do
           # JRuby behaves different than CRuby here (seems it always has to some extent, see 'unless' below).
           # It didn't seem trivial to work around. Skip for now.
-          skip "JRuby incompatibility" if Pry::Helpers::BaseHelpers.jruby?
+          skip "JRuby incompatibility" if Pry::Helpers::Base.jruby?
           [:test, 0, true, false, nil,
-              (0.0 unless Pry::Helpers::BaseHelpers.jruby?)].each do |val|
+              (0.0 unless Pry::Helpers::Base.jruby?)].each do |val|
             pry_eval(val, "def hello; end");
             expect(val.class.instance_methods(false).map(&:to_sym).include?(:hello)).to eq true
           end

--- a/spec/pryrc_spec.rb
+++ b/spec/pryrc_spec.rb
@@ -26,7 +26,7 @@ describe Pry do
     end
 
     # Resolving symlinks doesn't work on jruby 1.9 [jruby issue #538]
-    unless Pry::Helpers::BaseHelpers.jruby_19?
+    unless Pry::Helpers::Base.jruby_19?
       it "should not load the rc file twice if it's symlinked differently" do
         Pry::HOME_RC_FILE.replace "spec/fixtures/testrc"
         Pry::LOCAL_RC_FILE.replace "spec/fixtures/testlinkrc"

--- a/spec/syntax_checking_spec.rb
+++ b/spec/syntax_checking_spec.rb
@@ -28,7 +28,7 @@ describe Pry do
     ["puts )("],
     ["1 1"],
     ["puts :"]
-  ] + (Pry::Helpers::BaseHelpers.rbx? ? [] : [
+  ] + (Pry::Helpers::Base.rbx? ? [] : [
     ["def", "method(1"], # in this case the syntax error is "expecting ')'".
     ["o = Object.new.tap{ def o.render;","'MEH'", "}"] # in this case the syntax error is "expecting keyword_end".
   ])).compact.each do |foo|


### PR DESCRIPTION
Notes:
 - Resolves #1676
 - Accomplished by renaming the helper modules (commit 1) by removing `Helper` suffix. I agree that the namespace implies the suffix :)
 - Searched project for `BaseHelpers|CommandHelpers|DocumentationHelpers|OptionsHelpers` and replaced each instance with the suffix-less version (commit 2).
 - Ran tests and ensured all still passed (thanks for the comprehensive tests!!)
 - Does not change `Pry::Helpers::Text` which was already non-repetitive
 - Does not change table helpers in `lib/pry/helpers/table.rb` as they were not in a `TableHelpers` submodule (might be worth addressing as `Pry::Helpers::Table` for consistency)
 - Also updates the changelog to mention this PR change (commit 3)