### PR TITLE
Restore #1649 (sort of)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.4
   - ruby-head
   - rbx-3.69
+  - jruby-9.1.13.0
   - jruby
   - jruby-head
 


### PR DESCRIPTION
:crossed_fingers: 
~~'jruby' as a catch-all for the latest jruby appears to work again.
If this ever fails for reasons outside of our control again, I recommend
reverting this commit and considering a different CI service for jruby.~~