### PR TITLE
do not capture a Proc in Text helper methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,14 @@
 
 #### Bug fixes
 
+* Do not capture unused Proc objects in Text helper methods `no_color` and `no_paging`,
+  for performance reasons. Improve the documentation of both methods.
+
+See pull request [#1691](https://github.com/pry/pry/pull/1691).
+
 * Fix `String#pp` output color.
-[#1674](https://github.com/pry/pry/pull/1674)
+
+See pull request [#1674](https://github.com/pry/pry/pull/1674).
 
 ### 0.11.0
 

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -62,10 +62,13 @@ class Pry
       end
       alias_method :bright_default, :bold
 
-      # Executes the block with `Pry.config.color` set to false.
+      #
       # @yield
+      #   Yields a block with color turned off.
+      #
       # @return [void]
-      def no_color(&block)
+      #
+      def no_color
         boolean = Pry.config.color
         Pry.config.color = false
         yield
@@ -73,10 +76,13 @@ class Pry
         Pry.config.color = boolean
       end
 
-      # Executes the block with `Pry.config.pager` set to false.
+      #
       # @yield
+      #   Yields a block with paging turned off.
+      #
       # @return [void]
-      def no_pager(&block)
+      #
+      def no_pager
         boolean = Pry.config.pager
         Pry.config.pager = false
         yield
@@ -108,4 +114,3 @@ class Pry
     end
   end
 end
-


### PR DESCRIPTION
The &block we were capturing is not used or passed anywhere. For performance,
we shouldn't capture what we do not use.