### PR TITLE
Remove the "default" method from `Pry::Helpers::Text`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@
 
 #### Bug fixes
 
+* Remove the "default" method from `Pry::Helpers::Text`, it does not do what it describes
+  itself as doing in the documentation and its name is too generic. **breaking change**
+
+  See pull request [#1692](https://github.com/pry/pry/pull/1692).
+
+* Remove "bright_default" alias of "bold". Use "bold" instead. **breaking change**.
+
+  See pull request [#1692](https://github.com/pry/pry/pull/1692).
+
 * Do not capture unused Proc objects in Text helper methods `no_color` and `no_paging`,
   for performance reasons. Improve the documentation of both methods.
 

--- a/lib/pry/commands/gem_list.rb
+++ b/lib/pry/commands/gem_list.rb
@@ -24,7 +24,7 @@ class Pry
           index == 0 ? text.bright_green(spec.version.to_s) : text.green(spec.version.to_s)
         end
 
-        output.puts "#{text.default gem} (#{versions.join ', '})"
+        output.puts "#{text.strip_color gem} (#{versions.join ', '})"
       end
     end
   end

--- a/lib/pry/commands/ls.rb
+++ b/lib/pry/commands/ls.rb
@@ -3,18 +3,18 @@ class Pry
   class Command::Ls < Pry::ClassCommand
     DEFAULT_OPTIONS = {
       :heading_color            => :bright_blue,
-      :public_method_color      => :default,
+      :public_method_color      => :strip_color,
       :private_method_color     => :blue,
       :protected_method_color   => :blue,
       :method_missing_color     => :bright_red,
       :local_var_color          => :yellow,
-      :pry_var_color            => :default,     # e.g. _, _pry_, _file_
+      :pry_var_color            => :strip_color, # e.g. _, _pry_, _file_
       :instance_var_color       => :blue,        # e.g. @foo
       :class_var_color          => :bright_blue, # e.g. @@foo
-      :global_var_color         => :default,     # e.g. $CODERAY_DEBUG, $eventmachine_library
+      :global_var_color         => :strip_color, # e.g. $CODERAY_DEBUG, $eventmachine_library
       :builtin_global_color     => :cyan,        # e.g. $stdin, $-w, $PID
       :pseudo_global_color      => :cyan,        # e.g. $~, $1..$9, $LAST_MATCH_INFO
-      :constant_color           => :default,     # e.g. VERSION, ARGF
+      :constant_color           => :strip_color, # e.g. VERSION, ARGF
       :class_constant_color     => :blue,        # e.g. Object, Kernel
       :exception_constant_color => :magenta,     # e.g. Exception, RuntimeError
       :unloaded_constant_color  => :yellow,      # Any constant that is still in .autoload? state

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -44,23 +44,16 @@ class Pry
         text.to_s.gsub(/(\001)?\e\[.*?(\d)+m(\002)?/ , '')
       end
 
-      # Returns _text_ as bold text for use on a terminal.
       #
       # @param [String, #to_s] text
-      # @return [String] _text_
+      #   A string.
+      #
+      # @return [String]
+      #   Returns a bold string
+      #
       def bold(text)
         "\e[1m#{text}\e[0m"
       end
-
-      # Returns `text` in the default foreground colour.
-      # Use this instead of "black" or "white" when you mean absence of colour.
-      #
-      # @param [String, #to_s] text
-      # @return [String]
-      def default(text)
-        text.to_s
-      end
-      alias_method :bright_default, :bold
 
       #
       # @yield


### PR DESCRIPTION
It does not do what it describes itself as doing in the documentation,
for that purpose there is already "strip_color" (which the Ls command
has been updated to use.)

Also remove "bright_default" since it no longer has a pair, and "bold"
is a decent name already.