### PR TITLE
Add Pry#h.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 #### Features
 
+* Add `Pry#h` method thats returns a Module that has access to the same methods
+  as Pry commands, such `black()` and `yellow()`. These methods also
+  respect the configuration of the Pry instance they are associated with through
+  `Pry#h`. It is useful for passing 'pry' into a scope that doesn't want or need
+  to inherit one or more helper modules, and better than using the singleton
+  methods of Pry helper modules because Pry configuration is automatically
+  respected.
+
+See pull request [#1693]https://github.com/pry/pry/pull/1693)
+
 * Add a new command, "gem-stat", inspired by the rubygem of a similar
   name (gem-stats) by [@dannytatom](https://github.com/dannytatom).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,30 @@ See pull request [#1694](https://github.com/pry/pry/pull/1694).
 
 See pull request [#1701](https://github.com/pry/pry/pull/1701).
 
+#### Bug fixes
+
+* The following methods take a third required argument, an instance of Pry, in order to fulfil
+  queries to `_pry_.config`.
+
+  * Pry::Helpers.tablify
+  * Pry::Helpers.tablify\_to\_screen\_width
+  * Pry::Helpers.tablify\_or\_one\_line
+
+   The "Pry::Helpers::Table" class also takes the same required third argument.
+
+   **Breaking change**
+   Although a breaking change, it brings this code in line with how the rest of Pry
+   works, where session-local configuration queries are made to `_pry_.config` and
+   not `Pry.config` (which sets defaults, normally from ~/.pryrc or plugin code)
+
+   See pull request [#1713](https://github.com/pry/pry/pull/1713).
+
 #### Pry developers
 
 * Optionally skip a spec on specific Ruby engine(s) by providing `expect_failure: [:mri, :jruby]`
   as a metadata Hash to the example group.
 
 See pull request [#1694](https://github.com/pry/pry/pull/1694).
-
 
 ### 0.11.3
 

--- a/lib/pry/commands/ls/formatter.rb
+++ b/lib/pry/commands/ls/formatter.rb
@@ -26,7 +26,7 @@ class Pry
       def output_section(heading, body)
         return '' if body.compact.empty?
         fancy_heading = Pry::Helpers::Text.bold(color(:heading, heading))
-        Pry::Helpers.tablify_or_one_line(fancy_heading, body)
+        Pry::Helpers.tablify_or_one_line(fancy_heading, body, @_pry_)
       end
 
       def format_value(value)

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -1,27 +1,28 @@
 class Pry
   module Helpers
-    def self.tablify_or_one_line(heading, things)
+    def self.tablify_or_one_line(heading, things, pry)
       plain_heading = Pry::Helpers::Text.strip_color(heading)
-      attempt = Table.new(things, :column_count => things.size)
+      attempt = Table.new(things,{column_count: things.size}, pry)
       if attempt.fits_on_line?(Terminal.width! - plain_heading.size - 2)
         "#{heading}: #{attempt}\n"
       else
-        "#{heading}: \n#{tablify_to_screen_width(things, :indent => '  ')}\n"
+        "#{heading}: \n#{tablify_to_screen_width(things, {indent:'  '}, pry)}\n"
       end
     end
 
-    def self.tablify_to_screen_width(things, options = {})
+    def self.tablify_to_screen_width(things, options, pry)
+      options ||= {}
       things = things.compact
       if indent = options[:indent]
         usable_width = Terminal.width! - indent.size
-        tablify(things, usable_width).to_s.gsub(/^/, indent)
+        tablify(things, usable_width, pry).to_s.gsub(/^/, indent)
       else
-        tablify(things, Terminal.width!).to_s
+        tablify(things, Terminal.width!, pry).to_s
       end
     end
 
-    def self.tablify(things, line_length)
-      table = Table.new(things, :column_count => things.size)
+    def self.tablify(things, line_length, pry)
+      table = Table.new(things, {column_count: things.size}, pry)
       table.column_count -= 1 until 1 == table.column_count or
         table.fits_on_line?(line_length)
       table
@@ -29,8 +30,9 @@ class Pry
 
     class Table
       attr_reader :items, :column_count
-      def initialize items, args = {}
+      def initialize items, args, pry
         @column_count = args[:column_count]
+        @pry = pry
         self.items = items
       end
 
@@ -48,7 +50,7 @@ class Pry
             item.sub! e, _recall_color_for(e) if :color_on == style
             padded << item
           end
-          padded.join(Pry.config.ls.separator)
+          padded.join(@pry.config.ls.separator)
         end
       end
 
@@ -101,7 +103,7 @@ class Pry
       end
 
       def _recall_color_for thing
-        @colorless_cache[thing]
+        @colorless_cache[thing].to_s
       end
     end
 

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -14,21 +14,21 @@ module Pry::Helpers::Text
     }
 
   COLORS.each_pair do |color, value|
-    define_method color do |text, pry=(defined?(_pry_) and _pry_)|
+    define_method color do |text, pry=((defined?(_pry_) and _pry_) or Pry)|
       (pry and pry.color) ? "\033[0;#{30+value}m#{text}\033[0m" : text
     end
 
-    define_method "bright_#{color}" do |text, pry=(defined?(_pry_) and _pry_)|
-      (pry and pry.color) ? "\033[1;#{30+value}m#{text}\033[0m" : text
+    define_method "bright_#{color}" do |text, pry=((defined?(_pry_) and _pry_) or Pry)|
+      (pry.color) ? "\033[1;#{30+value}m#{text}\033[0m" : text
     end
 
     COLORS.each_pair do |bg_color, bg_value|
-      define_method "#{color}_on_#{bg_color}" do |text, pry=(defined?(_pry_) and _pry_)|
-        (pry and pry.color) ? "\033[0;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
+      define_method "#{color}_on_#{bg_color}" do |text, pry=((defined?(_pry_) and _pry_) or Pry)|
+        (pry.color) ? "\033[0;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
       end
 
-      define_method "bright_#{color}_on_#{bg_color}" do |text, pry=(defined?(_pry_) and _pry_)|
-        (pry and pry.color) ? "\033[1;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
+      define_method "bright_#{color}_on_#{bg_color}" do |text, pry=((defined?(_pry_) and _pry_) or Pry)|
+        (pry.color) ? "\033[1;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
       end
     end
   end
@@ -37,7 +37,7 @@ module Pry::Helpers::Text
   #
   # @param  [String, #to_s] text
   # @return [String] _text_ stripped of any color codes.
-  def strip_color(text, pry=(defined?(_pry_) and _pry_))
+  def strip_color(text, pry=((defined?(_pry_) and _pry_) or Pry))
     text.to_s.gsub(/(\001)?\e\[.*?(\d)+m(\002)?/ , '')
   end
 
@@ -45,8 +45,60 @@ module Pry::Helpers::Text
   #
   # @param [String, #to_s] text
   # @return [String] _text_
-  def bold(text, pry=(defined?(_pry_) and _pry_))
-    (pry and pry.color) ? "\e[1m#{text}\e[0m" : text
+  def bold text, pry=((defined?(_pry_) and _pry_) or Pry)
+    (pry.color) ? "\e[1m#{text}\e[0m" : text
+  end
+
+  #
+  # @yield
+  #   Yields a block with color turned off.
+  #
+  # @return [void]
+  #
+  def no_color pry=((defined?(_pry_) and _pry_) or Pry)
+    boolean = pry.config.color
+    pry.config.color = false
+    yield
+  ensure
+    pry.config.color = boolean
+  end
+
+  #
+  # @yield
+  #   Yields a block with paging turned off.
+  #
+  # @return [void]
+  #
+  def no_pager pry=((defined?(_pry_) and _pry_) or Pry)
+    boolean = pry.config.pager
+    pry.config.pager = false
+    yield
+  ensure
+    pry.config.pager = boolean
+  end
+
+  # Returns _text_ in a numbered list, beginning at _offset_.
+  #
+  # @param  [#each_line] text
+  # @param  [Fixnum] offset
+  # @return [String]
+  def with_line_numbers text, offset, color=:blue, pry=((defined?(_pry_) and _pry_) or Pry)
+    lines = text.each_line.to_a
+    max_width = (offset + lines.count).to_s.length
+    lines.each_with_index.map do |line, index|
+      adjusted_index = (index + offset).to_s.rjust(max_width)
+      pry.color ?
+      "#{self.send(color, adjusted_index)}: #{line}" :
+      "#{adjusted_index}: #{line}"
+    end.join
+  end
+
+  # Returns _text_ indented by _chars_ spaces.
+  #
+  # @param [String] text
+  # @param [Fixnum] chars
+  def indent(text, chars)
+    text.lines.map { |l| "#{' ' * chars}#{l}" }.join
   end
 
   # Returns `text` in the default foreground colour.
@@ -63,53 +115,4 @@ module Pry::Helpers::Text
   end
   alias_method :bright_default, :bold
 
-  #
-  # @yield
-  #   Yields a block with color turned off.
-  #
-  # @return [void]
-  #
-  def no_color pry=(defined?(_pry_) and _pry_)
-    boolean = pry.config.color
-    pry.config.color = false
-    yield
-  ensure
-    pry.config.color = boolean
-  end
-
-  #
-  # @yield
-  #   Yields a block with paging turned off.
-  #
-  # @return [void]
-  #
-  def no_pager pry=(defined?(_pry_) and _pry_)
-    boolean = pry.config.pager
-    pry.config.pager = false
-    yield
-  ensure
-    pry.config.pager = boolean
-  end
-
-  # Returns _text_ in a numbered list, beginning at _offset_.
-  #
-  # @param  [#each_line] text
-  # @param  [Fixnum] offset
-  # @return [String]
-  def with_line_numbers(text, offset, color=:blue)
-    lines = text.each_line.to_a
-    max_width = (offset + lines.count).to_s.length
-    lines.each_with_index.map do |line, index|
-      adjusted_index = (index + offset).to_s.rjust(max_width)
-      "#{self.send(color, adjusted_index)}: #{line}"
-    end.join
-  end
-
-  # Returns _text_ indented by _chars_ spaces.
-  #
-  # @param [String] text
-  # @param [Fixnum] chars
-  def indent(text, chars)
-    text.lines.map { |l| "#{' ' * chars}#{l}" }.join
-  end
 end

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -15,20 +15,20 @@ module Pry::Helpers::Text
 
   COLORS.each_pair do |color, value|
     define_method color do |text, pry=((defined?(_pry_) and _pry_) or Pry)|
-      (pry and pry.color) ? "\033[0;#{30+value}m#{text}\033[0m" : text
+      pry.color ? "\033[0;#{30+value}m#{text}\033[0m" : text
     end
 
     define_method "bright_#{color}" do |text, pry=((defined?(_pry_) and _pry_) or Pry)|
-      (pry.color) ? "\033[1;#{30+value}m#{text}\033[0m" : text
+      pry.color ? "\033[1;#{30+value}m#{text}\033[0m" : text
     end
 
     COLORS.each_pair do |bg_color, bg_value|
       define_method "#{color}_on_#{bg_color}" do |text, pry=((defined?(_pry_) and _pry_) or Pry)|
-        (pry.color) ? "\033[0;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
+        pry.color ? "\033[0;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
       end
 
       define_method "bright_#{color}_on_#{bg_color}" do |text, pry=((defined?(_pry_) and _pry_) or Pry)|
-        (pry.color) ? "\033[1;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
+        pry.color ? "\033[1;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
       end
     end
   end
@@ -114,5 +114,4 @@ module Pry::Helpers::Text
     text.to_s
   end
   alias_method :bright_default, :bold
-
 end

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -1,116 +1,115 @@
-class Pry
-  module Helpers
-    # The methods defined on {Text} are available to custom commands via {Pry::Command#text}.
-    module Text
-      extend self
-      COLORS =
-      {
-        "black"   => 0,
-        "red"     => 1,
-        "green"   => 2,
-        "yellow"  => 3,
-        "blue"    => 4,
-        "purple"  => 5,
-        "magenta" => 5,
-        "cyan"    => 6,
-        "white"   => 7
-      }
+module Pry::Helpers::Text
+  extend self
+  COLORS =
+    {
+      "black"   => 0,
+      "red"     => 1,
+      "green"   => 2,
+      "yellow"  => 3,
+      "blue"    => 4,
+      "purple"  => 5,
+      "magenta" => 5,
+      "cyan"    => 6,
+      "white"   => 7
+    }
 
-      COLORS.each_pair do |color, value|
-        define_method color do |text|
-          "\033[0;#{30+value}m#{text}\033[0m"
-        end
+  COLORS.each_pair do |color, value|
+    define_method color do |text, pry=(defined?(_pry_) and _pry_)|
+      (pry and pry.color) ? "\033[0;#{30+value}m#{text}\033[0m" : text
+    end
 
-        define_method "bright_#{color}" do |text|
-          "\033[1;#{30+value}m#{text}\033[0m"
-        end
+    define_method "bright_#{color}" do |text, pry=(defined?(_pry_) and _pry_)|
+      (pry and pry.color) ? "\033[1;#{30+value}m#{text}\033[0m" : text
+    end
 
-        COLORS.each_pair do |bg_color, bg_value|
-          define_method "#{color}_on_#{bg_color}" do |text|
-            "\033[0;#{30 + value};#{40 + bg_value}m#{text}\033[0m"
-          end
-
-          define_method "bright_#{color}_on_#{bg_color}" do |text|
-            "\033[1;#{30 + value};#{40 + bg_value}m#{text}\033[0m"
-          end
-        end
+    COLORS.each_pair do |bg_color, bg_value|
+      define_method "#{color}_on_#{bg_color}" do |text, pry=(defined?(_pry_) and _pry_)|
+        (pry and pry.color) ? "\033[0;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
       end
 
-      # Remove any color codes from _text_.
-      #
-      # @param  [String, #to_s] text
-      # @return [String] _text_ stripped of any color codes.
-      def strip_color(text)
-        text.to_s.gsub(/(\001)?\e\[.*?(\d)+m(\002)?/ , '')
-      end
-
-      # Returns _text_ as bold text for use on a terminal.
-      #
-      # @param [String, #to_s] text
-      # @return [String] _text_
-      def bold(text)
-        "\e[1m#{text}\e[0m"
-      end
-
-      # Returns `text` in the default foreground colour.
-      # Use this instead of "black" or "white" when you mean absence of colour.
-      #
-      # @param [String, #to_s] text
-      # @return [String]
-      def default(text)
-        text.to_s
-      end
-      alias_method :bright_default, :bold
-
-      #
-      # @yield
-      #   Yields a block with color turned off.
-      #
-      # @return [void]
-      #
-      def no_color
-        boolean = Pry.config.color
-        Pry.config.color = false
-        yield
-      ensure
-        Pry.config.color = boolean
-      end
-
-      #
-      # @yield
-      #   Yields a block with paging turned off.
-      #
-      # @return [void]
-      #
-      def no_pager
-        boolean = Pry.config.pager
-        Pry.config.pager = false
-        yield
-      ensure
-        Pry.config.pager = boolean
-      end
-
-      # Returns _text_ in a numbered list, beginning at _offset_.
-      #
-      # @param  [#each_line] text
-      # @param  [Fixnum] offset
-      # @return [String]
-      def with_line_numbers(text, offset, color=:blue)
-        lines = text.each_line.to_a
-        max_width = (offset + lines.count).to_s.length
-        lines.each_with_index.map do |line, index|
-          adjusted_index = (index + offset).to_s.rjust(max_width)
-          "#{self.send(color, adjusted_index)}: #{line}"
-        end.join
-      end
-
-      # Returns _text_ indented by _chars_ spaces.
-      #
-      # @param [String] text
-      # @param [Fixnum] chars
-      def indent(text, chars)
-        text.lines.map { |l| "#{' ' * chars}#{l}" }.join
+      define_method "bright_#{color}_on_#{bg_color}" do |text, pry=(defined?(_pry_) and _pry_)|
+        (pry and pry.color) ? "\033[1;#{30 + value};#{40 + bg_value}m#{text}\033[0m" : text
       end
     end
+  end
+
+  # Remove any color codes from _text_.
+  #
+  # @param  [String, #to_s] text
+  # @return [String] _text_ stripped of any color codes.
+  def strip_color(text, pry=(defined?(_pry_) and _pry_))
+    text.to_s.gsub(/(\001)?\e\[.*?(\d)+m(\002)?/ , '')
+  end
+
+  # Returns _text_ as bold text for use on a terminal.
+  #
+  # @param [String, #to_s] text
+  # @return [String] _text_
+  def bold(text, pry=(defined?(_pry_) and _pry_))
+    (pry and pry.color) ? "\e[1m#{text}\e[0m" : text
+  end
+
+  # Returns `text` in the default foreground colour.
+  # Use this instead of "black" or "white" when you mean absence of colour.
+  #
+  # @deprecated
+  #   This method doesn't do what it describes itself as doing.
+  #   Use {strip_color} instead.
+  #
+  # @param [String, #to_s] text
+  # @return [String]
+  def default(text)
+    text.to_s
+  end
+  alias_method :bright_default, :bold
+
+  #
+  # @yield
+  #   Yields a block with color turned off.
+  #
+  # @return [void]
+  #
+  def no_color pry=(defined?(_pry_) and _pry_)
+    boolean = pry.config.color
+    pry.config.color = false
+    yield
+  ensure
+    pry.config.color = boolean
+  end
+
+  #
+  # @yield
+  #   Yields a block with paging turned off.
+  #
+  # @return [void]
+  #
+  def no_pager pry=(defined?(_pry_) and _pry_)
+    boolean = pry.config.pager
+    pry.config.pager = false
+    yield
+  ensure
+    pry.config.pager = boolean
+  end
+
+  # Returns _text_ in a numbered list, beginning at _offset_.
+  #
+  # @param  [#each_line] text
+  # @param  [Fixnum] offset
+  # @return [String]
+  def with_line_numbers(text, offset, color=:blue)
+    lines = text.each_line.to_a
+    max_width = (offset + lines.count).to_s.length
+    lines.each_with_index.map do |line, index|
+      adjusted_index = (index + offset).to_s.rjust(max_width)
+      "#{self.send(color, adjusted_index)}: #{line}"
+    end.join
+  end
+
+  # Returns _text_ indented by _chars_ spaces.
+  #
+  # @param [String] text
+  # @param [Fixnum] chars
+  def indent(text, chars)
+    text.lines.map { |l| "#{' ' * chars}#{l}" }.join
   end
 end

--- a/lib/pry/platform.rb
+++ b/lib/pry/platform.rb
@@ -8,7 +8,7 @@ module Pry::Platform
   # @note
   #   Queries RbConfig::CONFIG['host_os'] with a best guess.
   #
-  def mac_osx?
+  def mac_osx? pry=(defined?(_pry_) and _pry_)
     !!(RbConfig::CONFIG['host_os'] =~ /\Adarwin/i)
   end
 
@@ -19,7 +19,7 @@ module Pry::Platform
   # @note
   #   Queries RbConfig::CONFIG['host_os'] with a best guess.
   #
-  def linux?
+  def linux? pry=(defined?(_pry_) and _pry_)
     !!(RbConfig::CONFIG['host_os'] =~ /linux/i)
   end
 
@@ -30,7 +30,7 @@ module Pry::Platform
   # @note
   #   Queries RbConfig::CONFIG['host_os'] with a best guess.
   #
-  def windows?
+  def windows? pry=(defined?(_pry_) and _pry_)
     !!(RbConfig::CONFIG['host_os'] =~ /mswin|mingw/)
   end
 
@@ -38,7 +38,7 @@ module Pry::Platform
   # @return [Boolean]
   #   Returns true when Pry is running on Windows with ANSI support.
   #
-  def windows_ansi?
+  def windows_ansi? pry=(defined?(_pry_) and _pry_)
     return false if not windows?
     !!(defined?(Win32::Console) or ENV['ANSICON'] or mri_2?)
   end
@@ -47,7 +47,7 @@ module Pry::Platform
   # @return [Boolean]
   #   Returns true when Pry is being run from JRuby.
   #
-  def jruby?
+  def jruby? pry=(defined?(_pry_) and _pry_)
     RbConfig::CONFIG['ruby_install_name'] == 'jruby'
   end
 
@@ -55,7 +55,7 @@ module Pry::Platform
   # @return [Boolean]
   #   Returns true when Pry is being run from JRuby in 1.9 mode.
   #
-  def jruby_19?
+  def jruby_19? pry=(defined?(_pry_) and _pry_)
     jruby? and RbConfig::CONFIG['ruby_version'] == '1.9'
   end
 
@@ -63,7 +63,7 @@ module Pry::Platform
   # @return [Boolean]
   #   Returns true when Pry is being run from Rubinius.
   #
-  def rbx?
+  def rbx? pry=(defined?(_pry_) and _pry_)
     RbConfig::CONFIG['ruby_install_name'] == 'rbx'
   end
 
@@ -71,7 +71,7 @@ module Pry::Platform
   # @return [Boolean]
   #   Returns true when Pry is being run from MRI (CRuby).
   #
-  def mri?
+  def mri? pry=(defined?(_pry_) and _pry_)
     RbConfig::CONFIG['ruby_install_name'] == 'ruby'
   end
 
@@ -79,7 +79,7 @@ module Pry::Platform
   # @return [Boolean]
   #   Returns true when Pry is being run from MRI v1.9+ (CRuby).
   #
-  def mri_19?
+  def mri_19? pry=(defined?(_pry_) and _pry_)
     !!(mri? and RUBY_VERSION =~ /\A1\.9/)
   end
 
@@ -87,7 +87,7 @@ module Pry::Platform
   # @return [Boolean]
   #   Returns true when Pry is being run from MRI v2+ (CRuby).
   #
-  def mri_2?
+  def mri_2? pry=(defined?(_pry_) and _pry_)
     !!(mri? and RUBY_VERSION =~ /\A2/)
   end
 

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -81,6 +81,30 @@ class Pry
     exec_hook(:when_started, target, options, self)
   end
 
+  #
+  # @example
+  #
+  #   _pry_.hooks.add_hook(:after_session, :on_exit) do |_, _, pry|
+  #     pry.pager.page pry.h.yellow("You take your boy home, yeah?")
+  #   end
+  #
+  # @return [Module]
+  #   Returns a Module that provides methods normally available to Pry commands and who
+  #   are also aware of this Pry instance.
+  #
+  def h
+    @h ||= lambda {
+      this = self
+      Module.new do
+        include Pry::Platform
+        include Pry::Helpers::BaseHelpers
+        include Pry::Helpers::Text
+        extend self
+        define_method(:_pry_) { this }
+      end
+    }.call
+  end
+
   # The current prompt.
   # This is the prompt at the top of the prompt stack.
   #

--- a/spec/helpers/table_spec.rb
+++ b/spec/helpers/table_spec.rb
@@ -2,7 +2,7 @@ require_relative '../helper'
 
 describe 'Formatting Table' do
   it 'knows about colorized fitting' do
-    t = Pry::Helpers::Table.new %w(hihi), :column_count => 1
+    t = Pry::Helpers::Table.new %w(hihi), {:column_count => 1}, Pry.new
     expect(t.fits_on_line?(4)).to eq true
     t.items = []
     expect(t.fits_on_line?(4)).to eq true
@@ -24,7 +24,7 @@ describe 'Formatting Table' do
     FAKE_COLUMNS = 62
     def try_round_trip(expected)
       things = expected.split(/\s+/).sort
-      actual = Pry::Helpers.tablify(things, FAKE_COLUMNS).to_s.strip
+      actual = Pry::Helpers.tablify(things, FAKE_COLUMNS, Pry.new).to_s.strip
       [expected, actual].each{|e| e.gsub!(/\s+$/, '')}
       if actual != expected
         bar = '-'*25
@@ -88,17 +88,17 @@ asfadsssaaad    fasfaafdssd     s
     end
 
     it 'should not raise error' do
-      expect { Pry::Helpers.tablify(@out, @elem_len - 1) }.not_to raise_error
+      expect { Pry::Helpers.tablify(@out, @elem_len - 1, Pry.new) }.not_to raise_error
 
     end
 
     it 'should format output as one column' do
-      table = Pry::Helpers.tablify(@out, @elem_len - 1).to_s
+      table = Pry::Helpers.tablify(@out, @elem_len - 1, Pry.new).to_s
       expect(table).to eq "swizzle\ncrime  \nfun    "
     end
   end
 
   specify 'decide between one-line or indented output' do
-    expect(Pry::Helpers.tablify_or_one_line('head', %w(ing))).to eq "head: ing\n"
+    expect(Pry::Helpers.tablify_or_one_line('head', %w(ing), Pry.new)).to eq "head: ing\n"
   end
 end


### PR DESCRIPTION
Returns a Module that provides methods normally available to Pry commands and who
are also aware of this Pry instance. Some helper modules have been excluded because
I am not sure how useful they are, yet.

A real case example of when this method is useful:
https://github.com/r-obert/pry-larryify/blob/7c920d9981fea51637d3c13e932f4253cdf4a850/lib/pry-larryify.rb#L79

That line can become simply:
:LarrySays => pry.h.green("Benchmark:")

Because `pry.h` is aware of the Pry instance it is associated with,
as are the methods implemented on top of it. This also makes the pry
instance that is passed around more powerful, and lends itself well
to a replacement for scenarios where 'Pry::Helpers::X.singleton_method?'
is used directly.

See '@example' in the documentation for this method as well.

The Pry::Deprecate pull request will depend on this commit, eg:
pry.h.deprecate_method! [method(:foo)], "foo is deprecated, use #bar instead."

Unfortunately other parts of Pry are coupled to always writing colour, so we
cannot remove Output#decolorize_maybe until. This PR opens the path for 'Pry#h'
though.