### PR TITLE
update Behaviour#forget to remove a key from self, and its parents

### DIFF
--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -75,16 +75,21 @@ module Pry::Config::Behavior
   end
 
   #
-  # Removes a key from self.
+  # Removes a key from self, and its parents excluding
+  # the last default.
   #
-  # @param [String] key
-  #  a key (as a String)
+  # @param [Array<String, #to_s>] *keys
+  #   One or more key names.
   #
   # @return [void]
   #
-  def forget(key)
-    key = key.to_s
-    __remove(key)
+  def forget(*keys)
+    keys.each do |key|
+      key = key.to_s
+      __remove(key)           and
+      default != last_default and
+      default.forget(key)
+    end
   end
 
   #

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -145,12 +145,13 @@ describe Pry::Config do
   end
 
   describe "#forget" do
-    it "forgets a local key" do
-      local = Pry::Config.new Pry::Config.from_hash(foo: 1)
-      local.foo = 2
-      expect(local.foo).to eq 2
-      local.forget(:foo)
-      expect(local.foo).to eq(1)
+    it "forgets a key from self and all parents excluding the last parent" do
+      parent1 = Pry::Config.from_hash({foo: 42}, nil)
+      parent2 = Pry::Config.from_hash({foo: 2}, parent1)
+      config = Pry::Config.from_hash({foo: 3}, parent2)
+      expect(config.foo).to eq(3)
+      config.forget(:foo)
+      expect(config.foo).to eq(42)
     end
   end
 


### PR DESCRIPTION
excluding the last parent. This can be used to restore a key to its
original default value, eg:

```ruby
Pry.config.output = CustomIO.new
pry.config.output = Pry.config.output # This is an error if you did
                                      # not expect CustomIO to be
				      # the restoree and in fact
				      # expected $stdout.
```

```ruby
Pry.config.output = CustomIO.new
pry.forget(:output)
pry.output # Returns $stdout, as expected.
           # Other '_pry_' keep a copy of
	   # CustomIO.new until they call
	   # .forget as well, so also ok.
```