### PR TITLE
Pry local config The following methods take a third required argument, an instance of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+### HEAD
+
+#### Features
+
+* Add a new command, "gem-stat", inspired by the rubygem of a similar
+  name (gem-stats) by [@dannytatom](https://github.com/dannytatom).
+
+See pull request [#1705](https://github.com/pry/pry/pull/1705].
+
+* Add Pry::Platform#known_engines, returns an Array of Ruby engines
+  (MRI, JRuby, Rubinius) that Pry is known to run on.
+
+See pull request [#1694](https://github.com/pry/pry/pull/1694).
+
+* Deprecate Pry::Command#text. Please use black(), white(), etc directly
+  instead (as you would with helper functions from BaseHelpers and
+  CommandHelpers)
+
+See pull request [#1701](https://github.com/pry/pry/pull/1701).
+
+#### Bug fixes
+
+* The following methods take a third required argument, an instance of Pry, in order to fulfil
+  queries to `_pry_.config`.
+
+  * Pry::Helpers.tablify
+  * Pry::Helpers.tablify\_to\_screen\_width
+  * Pry::Helpers.tablify\_or\_one\_line
+
+   The "Pry::Helpers::Table" class also takes the same required third argument.
+   **Breaking change**
+
+
+#### Pry developers
+
+* Optionally skip a spec on specific Ruby engine(s) by providing `expect_failure: [:mri, :jruby]`
+  as a metadata Hash to the example group.
+
+See pull request [#1694](https://github.com/pry/pry/pull/1694).
+
+
 ### 0.11.3
 
 #### Features
@@ -43,6 +84,7 @@ See pull request [#1691](https://github.com/pry/pry/pull/1691).
 * Fix `String#pp` output color.
 
 See pull request [#1674](https://github.com/pry/pry/pull/1674).
+
 
 ### 0.11.0
 

--- a/lib/pry/commands/ls/formatter.rb
+++ b/lib/pry/commands/ls/formatter.rb
@@ -26,7 +26,7 @@ class Pry
       def output_section(heading, body)
         return '' if body.compact.empty?
         fancy_heading = Pry::Helpers::Text.bold(color(:heading, heading))
-        Pry::Helpers.tablify_or_one_line(fancy_heading, body)
+        Pry::Helpers.tablify_or_one_line(fancy_heading, body, @_pry_)
       end
 
       def format_value(value)

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -1,27 +1,28 @@
 class Pry
   module Helpers
-    def self.tablify_or_one_line(heading, things)
+    def self.tablify_or_one_line(heading, things, pry)
       plain_heading = Pry::Helpers::Text.strip_color(heading)
-      attempt = Table.new(things, :column_count => things.size)
+      attempt = Table.new(things,{column_count: things.size}, pry)
       if attempt.fits_on_line?(Terminal.width! - plain_heading.size - 2)
         "#{heading}: #{attempt}\n"
       else
-        "#{heading}: \n#{tablify_to_screen_width(things, :indent => '  ')}\n"
+        "#{heading}: \n#{tablify_to_screen_width(things, {:indent => '  '}, pry)}\n"
       end
     end
 
-    def self.tablify_to_screen_width(things, options = {})
+    def self.tablify_to_screen_width(things, options, pry)
+      options ||= {}
       things = things.compact
       if indent = options[:indent]
         usable_width = Terminal.width! - indent.size
-        tablify(things, usable_width).to_s.gsub(/^/, indent)
+        tablify(things, usable_width, pry).to_s.gsub(/^/, indent)
       else
-        tablify(things, Terminal.width!).to_s
+        tablify(things, Terminal.width!, pry).to_s
       end
     end
 
-    def self.tablify(things, line_length)
-      table = Table.new(things, :column_count => things.size)
+    def self.tablify(things, line_length, pry)
+      table = Table.new(things, {column_count: things.size}, pry)
       table.column_count -= 1 until 1 == table.column_count or
         table.fits_on_line?(line_length)
       table
@@ -29,8 +30,9 @@ class Pry
 
     class Table
       attr_reader :items, :column_count
-      def initialize items, args = {}
+      def initialize items, args, pry
         @column_count = args[:column_count]
+        @pry = pry
         self.items = items
       end
 
@@ -48,7 +50,7 @@ class Pry
             item.sub! e, _recall_color_for(e) if :color_on == style
             padded << item
           end
-          padded.join(Pry.config.ls.separator)
+          padded.join(@pry.config.ls.separator)
         end
       end
 

--- a/spec/helpers/table_spec.rb
+++ b/spec/helpers/table_spec.rb
@@ -2,7 +2,7 @@ require_relative '../helper'
 
 describe 'Formatting Table' do
   it 'knows about colorized fitting' do
-    t = Pry::Helpers::Table.new %w(hihi), :column_count => 1
+    t = Pry::Helpers::Table.new %w(hihi), {:column_count => 1}, Pry.new
     expect(t.fits_on_line?(4)).to eq true
     t.items = []
     expect(t.fits_on_line?(4)).to eq true
@@ -24,7 +24,7 @@ describe 'Formatting Table' do
     FAKE_COLUMNS = 62
     def try_round_trip(expected)
       things = expected.split(/\s+/).sort
-      actual = Pry::Helpers.tablify(things, FAKE_COLUMNS).to_s.strip
+      actual = Pry::Helpers.tablify(things, FAKE_COLUMNS, Pry.new).to_s.strip
       [expected, actual].each{|e| e.gsub!(/\s+$/, '')}
       if actual != expected
         bar = '-'*25
@@ -88,17 +88,17 @@ asfadsssaaad    fasfaafdssd     s
     end
 
     it 'should not raise error' do
-      expect { Pry::Helpers.tablify(@out, @elem_len - 1) }.not_to raise_error
+      expect { Pry::Helpers.tablify(@out, @elem_len - 1, Pry.new) }.not_to raise_error
 
     end
 
     it 'should format output as one column' do
-      table = Pry::Helpers.tablify(@out, @elem_len - 1).to_s
+      table = Pry::Helpers.tablify(@out, @elem_len - 1, Pry.new).to_s
       expect(table).to eq "swizzle\ncrime  \nfun    "
     end
   end
 
   specify 'decide between one-line or indented output' do
-    expect(Pry::Helpers.tablify_or_one_line('head', %w(ing))).to eq "head: ing\n"
+    expect(Pry::Helpers.tablify_or_one_line('head', %w(ing), Pry.new)).to eq "head: ing\n"
   end
 end


### PR DESCRIPTION
…Pry,

in order to fulfil queries to `_pry_.config`.

* Pry::Helpers.tablify
* Pry::Helpers.tablify\_to\_screen\_width
* Pry::Helpers.tablify\_or\_one\_line

The "Pry::Helpers::Table" class also takes the same required third argument.
**Breaking change**

Although a breaking change, it brings this code in line with how the rest of Pry
works, where session-local configuration queries are made to `_pry_.config` and
not `Pry.config` (which sets defaults, normally from ~/.pryrc or plugin code)