### PR TITLE
Add a new command, "clear-screen", that clears the content of the

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### Features
 
+* Add a new command, "clear-screen", that clears the content of the
+  screen Pry is running in regardless of platform (Windows or UNIX-like).
+
 * Add a new command, "gem-stat", inspired by the rubygem of a similar
   name (gem-stats) by [@dannytatom](https://github.com/dannytatom).
 

--- a/lib/pry/commands/clear_screen.rb
+++ b/lib/pry/commands/clear_screen.rb
@@ -1,0 +1,14 @@
+class Pry::Command::ClearScreen < Pry::ClassCommand
+  match 'clear-screen'
+  group 'Input and Output'
+  description 'Clear the contents of the screen/window Pry is running in.'
+
+  def process
+    if windows?
+      _pry_.config.system.call(_pry_.output, 'cls', _pry_)
+    else
+      _pry_.config.system.call(_pry_.output, 'clear', _pry_)
+    end
+  end
+  Pry::Commands.add_command(self)
+end


### PR DESCRIPTION
screen Pry is running in regardless of platform (Windows or UNIX-like). This change was suggested by a user and rejected by @kyrylo but I think it should be reconsidered because I have found it useful when working on Windows and UNIX-y OSes. Remembering the difference is sometimes troublesome, so I think this command is worth it.

This change was lost in the great _force push_.
Actually I have many small changes like this in bigger feature branches, such as Pry::Prompt and Pry::Deprecate, two features that would be great to eventually merge once again.

See #1624 for Pry::Prompt details.