### PR TITLE
fix a bug where "cd Hash.new" reported self as a Pry::Config in prompt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ See pull request [#1694](https://github.com/pry/pry/pull/1694).
 
 See pull request [#1701](https://github.com/pry/pry/pull/1701).
 
+* Add new method Pry::Config.assign(), for creating a Config non-recursively.
+
+See pull request [#1723](https://github.com/pry/pry/pull/1723)
+
 #### Bug fixes
 
 * Fix a bug where 'cd Hash.new' reported self as an instance of Pry::Config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ See pull request [#1694](https://github.com/pry/pry/pull/1694).
 
 See pull request [#1701](https://github.com/pry/pry/pull/1701).
 
+#### Bug fixes
+
+* Fix a bug where 'cd Hash.new' reported self as an instance of Pry::Config
+  in the prompt.
+
+See pull request [#1723](https://github.com/pry/pry/pull/1723)
+
 #### Pry developers
 
 * Optionally skip a spec on specific Ruby engine(s) by providing `expect_failure: [:mri, :jruby]`

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -6,6 +6,23 @@ module Pry::Config::Behavior
 
   module Builder
     #
+    # Returns a new Behavior, non-recursively (unlike {#from_hash}).
+    #
+    # @param
+    #   (see #from_hash)
+    #
+    # @return
+    #   (see #from_hash)
+    #
+    def assign(attributes, default = nil)
+      new(default).tap do |behavior|
+        behavior.merge!(attributes)
+      end
+    end
+
+    #
+    # Returns a new Behavior, recursively walking attributes.
+    #
     # @param [Hash] attributes
     #   a hash to initialize an instance of self with.
     #

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -532,8 +532,7 @@ class Pry
     open_token = @indent.open_delimiters.any? ? @indent.open_delimiters.last :
       @indent.stack.last
 
-    c = Pry::Config.new(nil)
-    c.merge!({
+    c = Pry::Config.assign({
         :object         => object,
         :nesting_level  => binding_stack.size - 1,
         :open_token     => open_token,

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -529,28 +529,28 @@ class Pry
   # @return [String] The prompt.
   def select_prompt
     object = current_binding.eval('self')
-
     open_token = @indent.open_delimiters.any? ? @indent.open_delimiters.last :
       @indent.stack.last
 
-    c = Pry::Config.from_hash({
-                       :object         => object,
-                       :nesting_level  => binding_stack.size - 1,
-                       :open_token     => open_token,
-                       :session_line   => Pry.history.session_line_count + 1,
-                       :history_line   => Pry.history.history_line_count + 1,
-                       :expr_number    => input_array.count,
-                       :_pry_          => self,
-                       :binding_stack  => binding_stack,
-                       :input_array    => input_array,
-                       :eval_string    => @eval_string,
-                       :cont           => !@eval_string.empty?})
+    c = Pry::Config.new(nil)
+    c.merge!({
+        :object         => object,
+        :nesting_level  => binding_stack.size - 1,
+        :open_token     => open_token,
+        :session_line   => Pry.history.session_line_count + 1,
+        :history_line   => Pry.history.history_line_count + 1,
+        :expr_number    => input_array.count,
+        :_pry_          => self,
+        :binding_stack  => binding_stack,
+        :input_array    => input_array,
+        :eval_string    => @eval_string,
+        :cont           => !@eval_string.empty?
+      })
 
     Pry.critical_section do
       # If input buffer is empty then use normal prompt
       if eval_string.empty?
         generate_prompt(Array(prompt).first, c)
-
       # Otherwise use the wait prompt (indicating multi-line expression)
       else
         generate_prompt(Array(prompt).last, c)

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -31,6 +31,15 @@ describe "Prompts" do
       expect(config._pry_.is_a?(Pry)).to eq true
       expect(config.object).to eq self
     end
+
+    specify "object is Hash when current binding is a Hash" do
+      config = nil
+      h = {}
+      redirect_pry_io(InputTester.new("exit-all")) do
+        Pry.start(h, prompt: proc{|v| config = v })
+      end
+      expect(config.object).to be(h)
+    end
   end
 
   describe "BACKWARDS COMPATIBILITY: 3 parameter prompt proc" do


### PR DESCRIPTION
from_hash is recursive, turning Hash values into Pry::Config objects.
fix #1724