### PR TITLE
Fix test failures due to 'uninitialized constant Pry::Forwardable' in ruby 2.5

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,6 +1,6 @@
 require 'bundler/setup'
-require 'pry/testable'
 Bundler.require :default, :test
+require 'pry/testable'
 require_relative 'spec_helpers/mock_pry'
 require_relative 'spec_helpers/repl_tester'
 


### PR DESCRIPTION
As @ko1 mentioned in #1727, all the tests against Ruby 2.5 are [failing due to `NameError: uninitialized constant Pry::Forwardable`](https://travis-ci.org/pry/pry/jobs/320502644). I'm not sure why 2.5 requires an explicit `require`, but at least this will fix most of the failures.