### PR TITLE
Travis: JRuby 9.1.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.4.3
   - 2.5
   - rbx-3.86
-  - jruby-9.1.14.0
+  - jruby-9.1.15.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html