### PR TITLE
Avoid YARD RedundantBraces warnings

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -169,8 +169,8 @@ class Pry
 
       # @deprecated Replaced with {Pry::Hooks#add_hook}. Left for compatibility.
       # Store hooks to be run before or after the command body.
-      # @see {Pry::CommandSet#before_command}
-      # @see {Pry::CommandSet#after_command}
+      # @see Pry::CommandSet#before_command
+      # @see Pry::CommandSet#after_command
       def hooks
         Pry.hooks
       end

--- a/lib/pry/hooks.rb
+++ b/lib/pry/hooks.rb
@@ -32,7 +32,7 @@ class Pry
     #
     # @param [Pry::Hooks] other The `Pry::Hooks` instance to merge
     # @return [Pry:Hooks] The receiver.
-    # @see {#merge}
+    # @see #merge
     def merge!(other)
       @hooks.merge!(other.dup.hooks) do |key, array, other_array|
         temp_hash, output = {}, []


### PR DESCRIPTION
This PR changes the YARD docblocks so that warnings about `@see` are not emitted.