### PR TITLE
Avoid YARD UnknownParam warning

### DIFF
--- a/lib/pry/testable/variables.rb
+++ b/lib/pry/testable/variables.rb
@@ -8,7 +8,7 @@ module Pry::Testable::Variables
   #   Foo # => NameError
   #   Bar # => NameError
   #
-  # @param [Array<Symbol>] *names
+  # @param [Array<Symbol>] names
   #   An array of constant names that be defined by a block,
   #   and removed by this method afterwards.
   #


### PR DESCRIPTION
This PR avoids a YARD warning.

See https://stackoverflow.com/questions/23328411/how-can-one-document-a-function-with-a-variable-number-of-arguments-in-yard for discussion of varargs in YARD.