### PR TITLE
Feature/add optional proc for options

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -54,11 +54,11 @@ class Pry
   # The default prompt; includes the target and nesting level
   DEFAULT_PROMPT = [
                     proc { |target_self, nest_level, pry|
-                      "[#{pry.input_array.size}] #{pry.config.prompt_name}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}> "
+                      "[#{pry.input_array.size}] #{pry.config.prompt_name_value}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}> "
                     },
 
                     proc { |target_self, nest_level, pry|
-                      "[#{pry.input_array.size}] #{pry.config.prompt_name}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}* "
+                      "[#{pry.input_array.size}] #{pry.config.prompt_name_value}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}* "
                     }
                    ]
 
@@ -70,8 +70,8 @@ class Pry
   NO_PROMPT = [proc { '' }, proc { '' }]
 
   SHELL_PROMPT = [
-                  proc { |target_self, _, _pry_| "#{_pry_.config.prompt_name} #{Pry.view_clip(target_self)}:#{Dir.pwd} $ " },
-                  proc { |target_self, _, _pry_| "#{_pry_.config.prompt_name} #{Pry.view_clip(target_self)}:#{Dir.pwd} * " }
+                  proc { |target_self, _, _pry_| "#{_pry_.config.prompt_name_value} #{Pry.view_clip(target_self)}:#{Dir.pwd} $ " },
+                  proc { |target_self, _, _pry_| "#{_pry_.config.prompt_name_value} #{Pry.view_clip(target_self)}:#{Dir.pwd} * " }
                  ]
 
   # A prompt that includes the full object path as well as
@@ -79,11 +79,11 @@ class Pry
   NAV_PROMPT = [
                 proc do |_, _, _pry_|
                   tree = _pry_.binding_stack.map { |b| Pry.view_clip(b.eval("self")) }.join " / "
-                  "[#{_pry_.input_array.count}] (#{_pry_.config.prompt_name}) #{tree}: #{_pry_.binding_stack.size - 1}> "
+                  "[#{_pry_.input_array.count}] (#{_pry_.config.prompt_name_value}) #{tree}: #{_pry_.binding_stack.size - 1}> "
                 end,
                 proc do |_, _, _pry_|
                   tree = _pry_.binding_stack.map { |b| Pry.view_clip(b.eval("self")) }.join " / "
-                  "[#{_pry_.input_array.count}] (#{ _pry_.config.prompt_name}) #{tree}: #{_pry_.binding_stack.size - 1}* "
+                  "[#{_pry_.input_array.count}] (#{ _pry_.config.prompt_name_value}) #{tree}: #{_pry_.binding_stack.size - 1}* "
                 end,
                ]
 

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -1,5 +1,6 @@
 module Pry::Config::Behavior
   ASSIGNMENT     = "=".freeze
+  VALUE_SUFFIX   = "_value".freeze
   NODUP          = [TrueClass, FalseClass, NilClass, Symbol, Numeric, Module, Proc].freeze
   INSPECT_REGEXP = /#{Regexp.escape "default=#<"}/
   ReservedKeyError = Class.new(RuntimeError)
@@ -194,6 +195,11 @@ module Pry::Config::Behavior
     if key[-1] == ASSIGNMENT
       short_key = key[0..-2]
       self[short_key] = args[0]
+    elsif key[-6..-1] == VALUE_SUFFIX
+      return self[key] if self[key]
+      short_key = key[0..-7]
+      value = @default.public_send(short_key, *args, &block)
+      value.respond_to?(:call) ? value.call : self[key] = value
     elsif key?(key)
       self[key]
     elsif @default.respond_to?(name)

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -192,12 +192,12 @@ module Pry::Config::Behavior
 
   def method_missing(name, *args, &block)
     key = name.to_s
-    if key[-1] == ASSIGNMENT
-      short_key = key[0..-2]
+    if key.end_with?(ASSIGNMENT)
+      short_key = key.chomp(ASSIGNMENT)
       self[short_key] = args[0]
-    elsif key[-6..-1] == VALUE_SUFFIX
+    elsif key.end_with?(VALUE_SUFFIX)
       return self[key] if self[key]
-      short_key = key[0..-7]
+      short_key = key.chomp(VALUE_SUFFIX)
       value = @default.public_send(short_key, *args, &block)
       value.respond_to?(:call) ? value.call : self[key] = value
     elsif key?(key)


### PR DESCRIPTION
This change enables calling an optional proc for any of the config options we wish as described here:

> (2) If we made all 'value' config options take an optional proc instead of a value then we wouldn't need to mess around with hooks at all we could just have:
>
> `Pry.config.prompt_name = proc { rand(100) }`
>
> This approach is way better and many javascript APIs behave like this too.
> --  https://github.com/pry/pry/issues/1738#issuecomment-357820769 by @banister

**Before I spend time writing tests I just want to make sure what I've done so far will be OK**. The first commit is the real change, the second commit is an optional change which you may or may not want.

I was initially doing this in another way but had to change to this method where we specifically call `<option_name>_value` for any options where we want an optional proc to be called. This seems to work better anyway as it doesn't break existing behaviour (no existing tests had to change) and it will only stop memoizing an option if it's value is a proc and we have specifically enabled this functionality for that option. Which means existing options that supported a proc are not affected.