### PR TITLE
Recover from any SystemCallError on failure to read or write history file

### DIFF
--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -107,8 +107,8 @@ class Pry
       if File.exist?(path)
         File.foreach(path) { |line| yield(line) }
       end
-    rescue => error
-      warn "History file not loaded: #{error.message}"
+    rescue SystemCallError => error
+      warn "Unable to read history file: #{error.message}"
     end
 
     # The default pusher. Appends the given line to Readline::HISTORY.
@@ -136,8 +136,8 @@ class Pry
           file.sync = true
         end
       end
-    rescue Errno::EACCES
-      warn 'History not saved; unable to open your history file for writing.'
+    rescue SystemCallError => error
+      warn "Unable to write history file: #{error.message}"
       @history_file = false
     end
 

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -181,4 +181,24 @@ describe Pry do
       expect { history.push 'a line' }.to raise_error error
     end
   end
+
+  describe "file io errors" do
+    let(:history) { Pry::History.new(file_path: file_path) }
+    let(:file_path) { Tempfile.new("pry_history_spec").path }
+
+    [Errno::EACCES, Errno::ENOENT].each do |error_class|
+      it "handles #{ error_class } failure to read from history" do
+        expect(File).to receive(:foreach).and_raise(error_class)
+        expect(history).to receive(:warn).with(/Unable to read history file:/)
+        expect { history.load }.to_not raise_error
+      end
+
+      it "handles #{ error_class } failure to write history" do
+        Pry.config.history.should_save = true
+        expect(File).to receive(:open).with(file_path, "a", 0600).and_raise(error_class)
+        expect(history).to receive(:warn).with(/Unable to write history file:/)
+        expect { history.push("anything") }.to_not raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Handling failure to read or write the history file is inconsistent and can raise where it should not.

Currently for reading the file we capture _all_ errors, including some we might now. For writing the file we only capture `Errno:EACCES`.

This updates the read and write to have consistent behavior. Both rescue all `SystemCallError` classes and `Kernel#warn` with the message, then keep going.

The tests are not super nice. But any testing file IO is fragile. I settled on stubbing and expecting on some pretty specific file operations. I'd love to use something like `FakeFS`, but this fixes a bug with how `FakeFS` and `pry` work together so 🤷‍♂️ 

Closes https://github.com/fakefs/fakefs/issues/362
Fixes #1593
