### PR TITLE
support keyword args in `show-doc`

### DIFF
--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -354,19 +354,20 @@ class Pry
 
     # @return [String] A representation of the method's signature, including its
     #   name and parameters. Optional and "rest" parameters are marked with `*`
-    #   and block parameters with `&`. Keyword arguments are shown qith `={}`
+    #   and block parameters with `&`. Keyword arguments are shown with `:`
     #   If the parameter names are unavailable, they're given numbered names instead.
     #   Paraphrased from `awesome_print` gem.
     def signature
       if respond_to?(:parameters)
-        args = parameters.inject([]) do |arr, (typ, nam)|
-          nam ||= (typ == :block ? 'block' : "arg#{arr.size + 1}")
-          arr << case typ
-                 when :req   then nam.to_s
-                 when :opt   then "#{nam}=?"
-                 when :rest  then "*#{nam}"
-                 when :block then "&#{nam}"
-                 when :key   then "#{nam}={}"
+        args = parameters.inject([]) do |args_array, (arg_type, name)|
+          name ||= (arg_type == :block ? 'block' : "arg#{args_array.size + 1}")
+          args_array << case arg_type
+                 when :req    then name.to_s
+                 when :opt    then "#{name}=?"
+                 when :rest   then "*#{name}"
+                 when :block  then "&#{name}"
+                 when :key    then "#{name}:?"
+                 when :keyreq then "#{name}:"
                  else '?'
                  end
         end

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -354,8 +354,8 @@ class Pry
 
     # @return [String] A representation of the method's signature, including its
     #   name and parameters. Optional and "rest" parameters are marked with `*`
-    #   and block parameters with `&`. If the parameter names are unavailable,
-    #   they're given numbered names instead.
+    #   and block parameters with `&`. Keyword arguments are shown qith `={}`
+    #   If the parameter names are unavailable, they're given numbered names instead.
     #   Paraphrased from `awesome_print` gem.
     def signature
       if respond_to?(:parameters)
@@ -366,6 +366,7 @@ class Pry
                  when :opt   then "#{nam}=?"
                  when :rest  then "*#{nam}"
                  when :block then "&#{nam}"
+                 when :key   then "#{nam}={}"
                  else '?'
                  end
         end

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -508,4 +508,47 @@ describe Pry::Method do
       expect(aliases).to eq Set.new(["include?", "member?", "has_key?"])
     end
   end
+
+  describe '.signature' do
+    before do
+      @class = Class.new {
+        def self.standard_arg(arg) end
+        def self.block_arg(&block) end
+        def self.rest(*splat) end
+        def self.keyword(keyword_arg: "") end
+        def self.required_keyword(required_key:) end
+        def self.optional(option=nil) end
+      }
+    end
+
+    it 'should print the name of regular args' do
+      signature = Pry::Method.new(@class.method(:standard_arg)).signature
+      expect(signature).to eq("standard_arg(arg)")
+    end
+
+    it 'should print the name of block args, with an & label' do
+      signature = Pry::Method.new(@class.method(:block_arg)).signature
+      expect(signature).to eq("block_arg(&block)")
+    end
+
+    it 'should print the name of additional args, with an * label' do
+      signature = Pry::Method.new(@class.method(:rest)).signature
+      expect(signature).to eq("rest(*splat)")
+    end
+
+    it 'should print the name of keyword args, with :? after the arg name' do
+      signature = Pry::Method.new(@class.method(:keyword)).signature
+      expect(signature).to eq("keyword(keyword_arg:?)")
+    end
+
+    it 'should print the name of keyword args, with : after the arg name' do
+      signature = Pry::Method.new(@class.method(:required_keyword)).signature
+      expect(signature).to eq("required_keyword(required_key:)")
+    end
+
+    it 'should print the name of optional args, with =? after the arg name' do
+      signature = Pry::Method.new(@class.method(:optional)).signature
+      expect(signature).to eq("optional(option=?)")
+    end
+  end
 end


### PR DESCRIPTION
On the current version, keyword arguments get displayed with a `?`, and this PR displays them as `key_name={}` which I think is more appropriate and useful.