### PR TITLE
Pull request for issue #1749

### DIFF
--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -35,16 +35,29 @@ class Pry
       opt.on :r, :reload,  "Reload the edited code immediately (default for ruby files)"
       opt.on :p, :patch,   "Instead of editing the object's file, try to edit in a tempfile and apply as a monkey patch"
       opt.on :m, :method,  "Explicitly edit the _current_ method (when inside a method context)."
+
+      opt.on :s, :history,    "Edit a given history entry",
+                           :argument => true, :as => Integer
     end
 
     def process
       if bad_option_combination?
-        raise CommandError, "Only one of --ex, --temp, --in, --method and FILE may be specified."
+        raise CommandError, "Only one of --ex, --temp, --in, --method, --history and FILE may be specified."
       end
 
       if repl_edit?
-        # code defined in pry, eval'd within pry.
-        repl_edit
+        if opts.present?(:history)
+          if opts[:history].abs > Pry.history.to_a.size || opts[:history] >= 0
+            raise CommandError, "You must provide a valid negative index."
+          else
+            tmp = Pry.history.to_a[opts[:history]-1]
+            puts "Replaying: #{tmp}"
+            repl_edit_ tmp
+          end
+        else
+          # code defined in pry, eval'd within pry.
+          repl_edit
+        end
       elsif runtime_patch?
         # patch code without persisting changes, implies future changes are patches
         apply_runtime_patch
@@ -55,16 +68,21 @@ class Pry
     end
 
     def repl_edit?
-      !opts.present?(:ex) && !opts.present?(:current) && !opts.present?(:method) &&
-        filename_argument.empty?
+      !opts.present?(:ex) && !opts.present?(:current) &&
+        !opts.present?(:method) && filename_argument.empty?
     end
 
     def repl_edit
-      content = Pry::Editor.new(_pry_).edit_tempfile_with_content(initial_temp_file_content,
-                                                       initial_temp_file_content.lines.count)
+      repl_edit_ initial_temp_file_content
+    end
+
+    def repl_edit_ to_edit
+      content = Pry::Editor.new(_pry_).edit_tempfile_with_content(to_edit, to_edit.lines.count)
       silence_warnings do
         eval_string.replace content
       end
+
+      Pry.history.push content.chomp
     end
 
     def file_based_exception?
@@ -150,7 +168,8 @@ class Pry
 
     def bad_option_combination?
       [opts.present?(:ex), opts.present?(:temp),
-       opts.present?(:in), opts.present?(:method), !filename_argument.empty?].count(true) > 1
+       opts.present?(:in), opts.present?(:method),
+       opts.present?(:history), !filename_argument.empty?].count(true) > 1
     end
 
     def input_expression

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -47,7 +47,7 @@ class Pry
 
       if repl_edit?
         if opts.present?(:history)
-          if opts[:history].abs > Pry.history.to_a.size || opts[:history] >= 0
+          if opts[:history].abs > Pry.history.to_a.size-1 || opts[:history] >= 0
             raise CommandError, "You must provide a valid negative index."
           else
             tmp = Pry.history.to_a[opts[:history]-1]

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -393,7 +393,7 @@ describe "edit" do
     end
 
     it "should not work with a filename" do
-      expect { pry_eval 'edit ruby.rb -i' }.to raise_error(Pry::CommandError, /Only one of --ex, --temp, --in, --method and FILE/)
+      expect { pry_eval 'edit ruby.rb -i' }.to raise_error(Pry::CommandError, /Only one of --ex, --temp, --in, --method, --history and FILE/)
     end
 
     it "should not work with nonsense" do


### PR DESCRIPTION
Just check <https://github.com/pry/pry/issues/1749>.

Basically this pull request adds a feature to Pry' `edit` command. The new flag `--history` allows the user to edit externally any command that has been saved to history. Also, the `edit` command now save the code in history.