### PR TITLE
Push edit contents to history (issue #1749)

### DIFF
--- a/lib/pry/code/loc.rb
+++ b/lib/pry/code/loc.rb
@@ -1,10 +1,12 @@
 class Pry
   class Code
 
-    # Represents a line of code. A line of code is a tuple, which consists of a
-    # line and a line number. A `LOC` object's state (namely, the line
-    # parameter) can be changed via instance methods. `Pry::Code` heavily uses
-    # this class.
+    # Represents a line of code (which may, in fact, contain multiple lines if the
+    # entirety was eval'd as a single unit following the `edit` command).
+    #
+    # A line of code is a tuple, which consists of a line and a line number. A
+    # `LOC` object's state (namely, the line parameter) can be changed via
+    # instance methods.  `Pry::Code` heavily uses this class.
     #
     # @api private
     # @example
@@ -62,7 +64,8 @@ class Pry
       def add_line_number(max_width = 0, color = false)
         padded = lineno.to_s.rjust(max_width)
         colorized_lineno = color ? Pry::Helpers::BaseHelpers.colorize_code(padded) : padded
-        tuple[0] = "#{ colorized_lineno }: #{ line }"
+        properly_padded_line = handle_multiline_entries_from_edit_command(line, max_width)
+        tuple[0] = "#{ colorized_lineno }: #{ properly_padded_line }"
       end
 
       # Prepends a marker "=>" or an empty marker to the +line+.
@@ -85,6 +88,12 @@ class Pry
       # @return [void]
       def indent(distance)
         tuple[0] = "#{ ' ' * distance }#{ line }"
+      end
+
+      def handle_multiline_entries_from_edit_command(line, max_width)
+        line.split("\n").map.with_index do |inner_line, i|
+          i.zero? ? inner_line : "#{' '* (max_width + 2)}#{inner_line}"
+        end.join("\n")
       end
     end
 

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -65,6 +65,7 @@ class Pry
       silence_warnings do
         eval_string.replace content
       end
+      Pry.history.push(content)
     end
 
     def file_based_exception?

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -195,6 +195,13 @@ describe Pry::Code do
           expect(@code).to match(/1:/)
         end
 
+        specify 'pad multiline units created with edit command' do
+          multiline_unit = "def am_i_pretty?\n  'yes i am'\n  end"
+          code = Pry::Code.new(multiline_unit).with_line_numbers
+          middle_line  = code.split("\n")[1]
+          expect(middle_line).to match(/2:   'yes i am'/)
+        end
+
         specify 'disable line numbers when falsy' do
           @code = @code.with_line_numbers
           @code = @code.with_line_numbers(false)

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -369,6 +369,18 @@ describe "edit" do
         FileUtils.rm "spec/fixtures/foo.rb"
       end
     end
+
+    it "should write the evaluated command to history" do
+      quote = 'history repeats itself, first as tradegy...'
+      Pry.config.editor = lambda {|file, line|
+        File.open(file, 'w'){
+          |f| f << quote
+        }
+        nil
+      }
+      @t.process_command 'edit'
+      expect(Pry.history.to_a.last).to eq quote
+    end
   end
 
   describe "with --in" do


### PR DESCRIPTION
As discussed here (https://github.com/pry/pry/issues/1749), the edit command doesn't push to history, and this makes it impossible to hit 'up-and-enter', that long-loved staple of REPL programming.

This PR is a surgical fix that narrowly addresses this one feature. The basic history pushing functionality is in `commands\edit.rb`, and an additional modification was also necessary to `code\loc.rb` because pushing the multiline contents of the `edit` command caused the padding in the `hist` command look messy in the following way:

![screen shot 2018-03-25 at 16 34 08](https://user-images.githubusercontent.com/151206/37877029-2e86253e-3055-11e8-91b2-49cc26bb3896.png)

With the fix applied, the history now looks as it should:
![screen shot 2018-03-25 at 17 53 14](https://user-images.githubusercontent.com/151206/37877051-7dd24c80-3055-11e8-95dc-8f54bf353198.png)
