### PR TITLE
correct the mri fail message

### DIFF
--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -486,7 +486,7 @@ class Pry
       else
         fail_msg = "Cannot locate this method: #{name}."
         if mri?
-          fail_msg += " Invoke the 'gem-install pry-doc' Pry command to get access to Ruby Core documentation.\n"
+          fail_msg += " Invoke the 'gem install pry-doc' Pry command to get access to Ruby Core documentation.\n"
         end
         raise CommandError, fail_msg
       end


### PR DESCRIPTION
It should be `gem install pry-doc` not `gem-install pry-doc`.

Was introduced here https://github.com/pry/pry/commit/b928092abef70ac72f14914e31185a7556dcf380