### PR TITLE
PluginManager#load_cli_options: use the realpath

### DIFF
--- a/lib/pry/plugins.rb
+++ b/lib/pry/plugins.rb
@@ -34,7 +34,7 @@ class Pry
 
       # Load the Command line options defined by this plugin (if they exist)
       def load_cli_options
-        cli_options_file = File.join(spec.full_gem_path, "lib/#{spec.name}/cli.rb")
+        cli_options_file = File.realpath(File.join(spec.full_gem_path, "lib/#{spec.name}/cli.rb"))
         require cli_options_file if File.exist?(cli_options_file)
       end
       # Activate the plugin (require the gem - enables/loads the

--- a/lib/pry/plugins.rb
+++ b/lib/pry/plugins.rb
@@ -34,7 +34,8 @@ class Pry
 
       # Load the Command line options defined by this plugin (if they exist)
       def load_cli_options
-        cli_options_file = File.realpath(File.join(spec.full_gem_path, "lib/#{spec.name}/cli.rb"))
+        cli_options_file = File.join(spec.full_gem_path, "lib/#{spec.name}/cli.rb")
+        cli_options_file = File.realpath(cli_options_file) if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.4")
         require cli_options_file if File.exist?(cli_options_file)
       end
       # Activate the plugin (require the gem - enables/loads the


### PR DESCRIPTION
Since ruby 2.5, `require 'foo'` will use the realpath of the file
corresponding to foo.rb. However `require '/absolute/path/to/foo.rb'`
won't use the realpath.

So when $GEM_HOME contains a symlink (ie it is not the realpath), when a
pry plugin is loaded, by `activate!`:
~~~ ruby
require gem_name if !active?
~~~
the real_path of `gem_name` is used.

But then in load_cli_options:
~~~ ruby
cli_options_file = File.join(spec.full_gem_path, "lib/#{spec.name}/cli.rb")
require cli_options_file if File.exist?(cli_options_file)
~~~
since the path given is absolute, it will be used directly without realpath.

This means that cli.rb may potentially be required twice (once via its realpath if the plugin requires it, the other via its $GEM_HOME path when required by `load_cli_options`), which could raise some errors.

Fix this by using the realpath in load_cli_options too.

Note: one problem with this pr is that for ruby versions <2.5, since
`require 'foo'` do not use the realpath, merging this pr will potentially
introduce bugs for those versions.