### PR TITLE
Silence output message in Windows when pager doesn't exist.

### DIFF
--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -139,7 +139,7 @@ class Pry::Pager
         @system_pager = begin
           pager_executable = default_pager.split(' ').first
           if Pry::Helpers::BaseHelpers.windows? || Pry::Helpers::BaseHelpers.windows_ansi?
-            `where #{pager_executable}`
+            `where /Q #{pager_executable}`
           else
             `which #{pager_executable}`
           end


### PR DESCRIPTION
In Windows, if `less` (or another pager) isn't found by `where.exe` it outputs this info to stderr:

```
[1] pry(main)> 1
INFO: Could not find files for the given pattern(s).
=> 1
```

The `/Q` flag silences this message:

```
[1] pry(main)> 1
=> 1
```

Tested on Conemu, cmd and PowerShell.