### PR TITLE
Check for existance of cli_options_file before calling realpath()

### DIFF
--- a/lib/pry/plugins.rb
+++ b/lib/pry/plugins.rb
@@ -35,8 +35,10 @@ class Pry
       # Load the Command line options defined by this plugin (if they exist)
       def load_cli_options
         cli_options_file = File.join(spec.full_gem_path, "lib/#{spec.name}/cli.rb")
+        return unless File.exist?(cli_options_file)
+
         cli_options_file = File.realpath(cli_options_file) if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.4")
-        require cli_options_file if File.exist?(cli_options_file)
+        require cli_options_file
       end
       # Activate the plugin (require the gem - enables/loads the
       # plugin immediately at point of call, even if plugin is


### PR DESCRIPTION
The recent change (
https://github.com/pry/pry/pull/1762) to use realpath in line with Ruby >= 2.4.4 unfortunately missed that realpath fails for files that do not exist, making the check for existence in the following require() a futile exercise in a quests already lost.