### PR TITLE
plugins: use require_relative instead of require

### DIFF
--- a/lib/pry/plugins.rb
+++ b/lib/pry/plugins.rb
@@ -36,9 +36,7 @@ class Pry
       def load_cli_options
         cli_options_file = File.join(spec.full_gem_path, "lib/#{spec.name}/cli.rb")
         return unless File.exist?(cli_options_file)
-
-        cli_options_file = File.realpath(cli_options_file) if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.4")
-        require cli_options_file
+        require_relative cli_options_file
       end
       # Activate the plugin (require the gem - enables/loads the
       # plugin immediately at point of call, even if plugin is


### PR DESCRIPTION
I've stumbled upon the following commit:
https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/63046/diff/spec/ruby/core/file/ftype_spec.rb

It looks like `require_relative` resolves symlinks for us, so there's no need to
use `realpath` introduced in https://github.com/pry/pry/pull/1762.

One caveat is that `require_relative` is not a thing in Ruby 1.9, however the
plan is to drop support for it for
v1.0.0 (https://github.com/pry/pry/issues/1371).

This is more of a proof of concept for now since we *still* support 1.9.3, so
it cannot be merged immediately.