### PR TITLE
commands/show_source: handle when source is nil but comment exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ See pull request [#1723](https://github.com/pry/pry/pull/1723)
   `require`](https://bugs.ruby-lang.org/issues/10222)
   ([#1762](https://github.com/pry/pry/pull/1762),
   [#1774](https://github.com/pry/pry/pull/1762))
+* Fixed `NoMethodError` on code objects that have a comment but no source when
+  invoking `show-source` ([#1779](https://github.com/pry/pry/pull/1779))
 
 #### Pry developers
 

--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -100,11 +100,17 @@ class Pry
     # object types: methods, modules, commands, procs...
     def header(code_object)
       file_name, line_num = file_and_line_for(code_object)
+      content = content_for(code_object)
+
       h = "\n#{bold('From:')} #{file_name} "
       h << code_object_header(code_object, line_num)
-      h << "\n#{bold('Number of lines:')} " <<
-        "#{content_for(code_object).lines.count}\n\n"
+      h << "\n#{bold('Number of lines:')} " << "#{content.lines.count}\n\n"
       h << bold('** Warning:') << " Cannot find code for #{@original_code_object.nonblank_name}. Showing superclass #{code_object.nonblank_name} instead. **\n\n" if @used_super
+
+      if content.lines.none?
+        h << bold('** Warning:') << " Cannot find code for '#{code_object.name}' (source_location is nil)"
+      end
+
       h
     end
 

--- a/lib/pry/commands/show_source.rb
+++ b/lib/pry/commands/show_source.rb
@@ -39,8 +39,11 @@ class Pry
 
     # The source for code_object prepared for display.
     def content_for(code_object)
-      Code.new(code_object.source, start_line_for(code_object)).
-        with_line_numbers(use_line_numbers?).highlighted
+      code = Code.new(
+        code_object.source || [],
+        start_line_for(code_object)
+      )
+      code.with_line_numbers(use_line_numbers?).highlighted
     end
   end
 

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -184,6 +184,32 @@ describe "show-source" do
     Pry.config.commands.delete "hubba-hubba"
   end
 
+  context "when there's no source code but the comment exists" do
+    before do
+      class Foo
+        # Bingo.
+        def bar; end
+      end
+
+      allow_any_instance_of(Pry::Method).to receive(:source).and_return(nil)
+    end
+
+    after do
+      Object.remove_const(:Foo)
+    end
+
+    it "outputs zero line numbers" do
+      out = pry_eval('show-source Foo#bar')
+      expect(out).to match(/
+        Owner:\sFoo
+        .+
+        Number\sof\slines:\s0
+        .+
+        \*\*\sWarning:\sCannot\sfind\scode\sfor\s'bar'\s\(source_location\sis\snil\)
+      /mx)
+    end
+  end
+
   describe "finding super methods with help of `--super` switch" do
     before do
       class Foo


### PR DESCRIPTION
Fixes https://github.com/pry/pry/issues/1452.
($ RuntimeError.exception fails)

Alternative to https://github.com/pry/pry/pull/1453.