### PR TITLE
Rakefile: unit test with help of RSpec::Core::RakeTask

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,31 +7,9 @@ require 'pry/version'
 CLOBBER.include('**/*~', '**/*#*', '**/*.log')
 CLEAN.include('**/*#*', '**/*#*.*', '**/*_flymake*.*', '**/*_flymake', '**/*.rbc', '**/.#*.*')
 
-desc "Set up and run tests"
-task :default => [:test]
-
-def run_specs paths
-  format = ENV['VERBOSE'] ? '--format documentation ' : ''
-  sh "bundle exec rspec #{format}#{paths.join ' '}"
-end
-
-desc "Run tests"
-task :test do
-  paths =
-    if explicit_list = ENV['run']
-      explicit_list.split(',')
-    else
-      Dir['spec/**/*_spec.rb'].shuffle!
-    end
-  run_specs paths
-end
-task :spec => :test
-
-task :recspec do
-  all = Dir['spec/**/*_spec.rb'].sort_by{|path| File.mtime(path)}.reverse
-  warn "Running all, sorting by mtime: #{all[0..2].join(' ')} ...etc."
-  run_specs all
-end
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
+task :default => :spec
 
 desc "Run pry (you can pass arguments using _ in place of -)"
 task :pry do


### PR DESCRIPTION
Commit a99861f1b1cea84d044c458ec5fba401d88c6802 broke some tests for me when I
try to run them locally. Example failures:

```
Failures:

  1) gist nominally logs in
     Failure/Error: expect(Pad.gist_calls[:login!]).not_to be_nil

       expected: not nil
            got: nil

  2) show-doc on modules show-doc -a messages relating to -a indicates...
     Failure/Error:
       raise CommandError, "No docs found for: #{
         obj_name ? obj_name : 'current context'

     Pry::CommandError:
       No docs found for: TestClassForShowSource
```

There's little reason to use our own task for specs since RSpec already provides
one. Switching to that deletes some old (likely unused) code and fixes the
failures for me. Win-win.