### PR TITLE
spec/commands/edit: delete unwanted unlinking

### DIFF
--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -182,7 +182,6 @@ describe "edit" do
 
       after do
         @tf.close(true)
-        File.unlink("#{@path}c") if File.exist?("#{@path}c")
       end
 
       it "should reload the file" do


### PR DESCRIPTION
This line was needed for Rubinius but since we dropped it, it serves no purpose. Thanks to @rf- for pointing out.