### PR TITLE
Tweak documentation for pryrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ is trivial to set it to read from any object that has a `readline` method and wr
 `puts` method - many other aspects of Pry are also configurable making
 it a good choice for implementing custom shells.
 
-Pry comes with an executable so it can be invoked at the command line.
-Just enter `pry` to start. A `.pryrc` file in the user's home directory will
-be loaded if it exists. Type `pry --help` at the command line for more
-information.
+Pry comes with an executable so it can be invoked at the command line.  Just
+enter `pry` to start. A `pryrc` file in `$XDG_CONFIG_HOME/pry/` or the user's
+home directory will be loaded if it exists. Type `pry --help` at the command
+line for more information.
 
 Try `gem install pry-doc` for additional documentation on Ruby Core
 methods. The additional docs are accessed through the `show-doc` and
@@ -180,9 +180,8 @@ present working directory into the Pry prompt and bring in (limited at this stag
 We can also interpolate Ruby code directly into the shell by
 using the normal `#{}` string interpolation syntax.
 
-In the code below we're going to switch to `shell-mode` and edit the
-`.pryrc` file in the home directory. We'll then cat its contents and
-reload the file.
+In the code below we're going to switch to `shell-mode` and edit the `pryrc`
+file. We'll then cat its contents and reload the file.
 
     pry(main)> shell-mode
     pry main:/home/john/ruby/projects/pry $ .cd ~
@@ -383,7 +382,7 @@ gem.
 
 You can toggle the syntax highlighting on and off in a session by
 using the `toggle-color` command. Alternatively, you can turn it off
-permanently by putting the line `Pry.color = false` in your `~/.pryrc`
+permanently by putting the line `Pry.color = false` in your `pryrc`
 file.
 
 ### Future Directions

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -159,7 +159,7 @@ Copyright (c) 2016 John Mair (banisterfiend)
     Pry.config.color = false
   end
 
-  on :f, "Suppress loading of ~/.pryrc and ./.pryrc" do
+  on :f, "Suppress loading of pryrc" do
     Pry.config.should_load_rc = false
     Pry.config.should_load_local_rc = false
   end

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -207,7 +207,7 @@ class Pry
                        name, version = $1, $2
                        "#{name.to_s} (v#{version.to_s})"
                      when /pryrc/
-                       "~/.pryrc"
+                       "pryrc"
                      else
                        "(other)"
                      end

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -11,7 +11,7 @@ class Pry
       # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
       ENV['XDG_CONFIG_HOME'] + '/pry/pryrc'
     else
-      '~/.config/pry/config'
+      '~/.config/pry/pryrc'
     end
   LOCAL_RC_FILE = "./.pryrc"
 
@@ -133,14 +133,13 @@ class Pry
 For a better Pry experience on Windows, please use ansicon:
   https://github.com/adoxa/ansicon
 If you use an alternative to ansicon and don't want to see this warning again,
-you can add "Pry.config.windows_console_warning = false" to your .pryrc.
+you can add "Pry.config.windows_console_warning = false" to your pryrc.
       WARNING
     end
   end
 
-  # Do basic setup for initial session.
-  # Including: loading .pryrc, loading plugins, loading requires, and
-  # loading history.
+  # Do basic setup for initial session including: loading pryrc, plugins,
+  # requires, and history.
   def self.initial_session_setup
     return unless initial_session?
     @initial_session = false
@@ -161,8 +160,7 @@ you can add "Pry.config.windows_console_warning = false" to your .pryrc.
   end
 
   # Start a Pry REPL.
-  # This method also loads `~/.pryrc` and `./.pryrc` as necessary the
-  # first time it is invoked.
+  # This method also loads `pryrc` as necessary the first time it is invoked.
   # @param [Object, Binding] target The receiver of the Pry session
   # @param [Hash] options
   # @option options (see Pry#initialize)


### PR DESCRIPTION
Since `~/.pryrc` was replaced by `$XDG_CONFIG_HOME` and `~/.config/pry/pryrc` in
https://github.com/pry/pry/pull/1609, we need to adjust some
documentation. `~/.pryrc` becomes simply `pryrc`.

I've also edited the wiki with this similar change.