### PR TITLE
travis: generate docs and fail if there are warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ matrix:
     - rvm: 2.5
       name: "Run RuboCop linting"
       script: ruby -S bundle _1.15.4_ exec rubocop --parallel
+    - rvm: 2.5
+      name: "Run YARD linting"
+      script: ruby -S bundle _1.15.4_ exec yardoc --fail-on-warning --no-progress
 
 notifications:
   irc: "irc.freenode.org#pry"

--- a/README.md
+++ b/README.md
@@ -8,14 +8,6 @@
 
 © John Mair ([banisterfiend](https://twitter.com/banisterfiend)) 2018<br>
 
-**Sponsors**
-
-[Launch School](https://launchschool.com)<br/>
-[Atomic Object](https://atomicobject.com/)<br/>
-[Hashrocket](https://hashrocket.com/)<br/>
-[Intridea](http://www.intridea.com)<br/>
-[Gaslight](https://teamgaslight.com)<br/>
-
 **Other Resources**
 
 [Skip to the website (recommended)](http://pryrepl.org/) <br />


### PR DESCRIPTION
The idea is extracted from https://github.com/pry/pry/pull/1720.

This ensures that documentation mistakes don't slip through the cracks in the
future.