### PR TITLE
helpers/text: delete the 'bright_default' alias

### DIFF
--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -60,7 +60,6 @@ class Pry
       def default(text)
         text.to_s
       end
-      alias_method :bright_default, :bold
 
       #
       # @yield


### PR DESCRIPTION
Replaces https://github.com/pry/pry/pull/1692
(Remove the "default" method from `Pry::Helpers::Text`)

This alias serves no real purpose because `bold` is already superior: it's short
and understandable.