### PR TITLE
Test with help of CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ references:
     run:
       name: Run unit tests
       command: bundle exec rake
+      environment:
+        # Make sure TERM is set so Pry can indent correctly inside tests.
+        TERM: screen-256color
 
   install_alpine_nano: &install_alpine_nano
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
     steps:
       - <<: *repo_restore_cache
       - <<: *bundle_install
+      - <<: *install_alpine_nano
       - <<: *unit
   "ruby-2.0":
     docker:
@@ -69,6 +70,7 @@ jobs:
     steps:
       - <<: *repo_restore_cache
       - <<: *bundle_install
+      - <<: *install_alpine_nano
       - <<: *unit
   "ruby-2.1":
     docker:
@@ -77,6 +79,7 @@ jobs:
     steps:
       - <<: *repo_restore_cache
       - <<: *bundle_install
+      - <<: *install_ubuntu_nano
       - <<: *unit
   "ruby-2.2":
     docker:
@@ -85,6 +88,7 @@ jobs:
     steps:
       - <<: *repo_restore_cache
       - <<: *bundle_install
+      - <<: *install_ubuntu_nano
       - <<: *unit
   "ruby-2.3":
     docker:
@@ -93,6 +97,7 @@ jobs:
     steps:
       - <<: *repo_restore_cache
       - <<: *bundle_install
+      - <<: *install_ubuntu_nano
       - <<: *unit
   "ruby-2.4":
     docker:
@@ -101,6 +106,7 @@ jobs:
     steps:
       - <<: *repo_restore_cache
       - <<: *bundle_install
+      - <<: *install_ubuntu_nano
       - <<: *unit
   "ruby-2.5":
     docker:
@@ -109,6 +115,7 @@ jobs:
     steps:
       - <<: *repo_restore_cache
       - <<: *bundle_install
+      - <<: *install_ubuntu_nano
       - <<: *unit
   "jruby-9.1-jdk":
     docker:
@@ -117,6 +124,7 @@ jobs:
     steps:
       - <<: *repo_restore_cache
       - <<: *bundle_install
+      - <<: *install_ubuntu_nano
       - <<: *unit
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,159 @@
+version: 2
+references:
+  repo_restore_cache: &repo_restore_cache
+    restore_cache:
+      keys:
+        - repo-{{ .Environment.CIRCLE_SHA1 }}
+
+  repo_save_cache: &repo_save_cache
+    save_cache:
+      key: repo-{{ .Environment.CIRCLE_SHA1 }}-{{ epoch }}
+      paths:
+        - ~/pry
+
+  bundle_install: &bundle_install
+    run:
+      name: Install Bundler dependencies
+      command: bundle install --path ~/pry/vendor/bundle --jobs 15
+
+  unit: &unit
+    run:
+      name: Run unit tests
+      command: bundle exec rake
+
+  install_alpine_nano: &install_alpine_nano
+    run:
+      name: Install Nano text editor on Alpine Linux
+      command: apk add nano
+
+  install_ubuntu_nano: &install_ubuntu_nano
+    run:
+      name: Install Nano text editor on Ubuntu
+      command: sudo apt-get install nano
+
+jobs:
+  rubocop_lint:
+    docker:
+      - image: circleci/ruby:2.5
+    working_directory: ~/pry
+    steps:
+      - checkout
+      - <<: *repo_save_cache
+      - <<: *bundle_install
+      - run:
+          name: Run RuboCop linting
+          command: bundle exec rubocop --parallel
+  yard_lint:
+    docker:
+      - image: circleci/ruby:2.5
+    working_directory: ~/pry
+    steps:
+      - checkout
+      - <<: *repo_save_cache
+      - <<: *bundle_install
+      - run:
+          name: Run YARD linting
+          command: bundle exec yardoc --fail-on-warning --no-progress
+  "ruby-1.9":
+    docker:
+      - image: kyrylo/ruby-1.9.3p551
+    working_directory: /home/circleci/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *unit
+  "ruby-2.0":
+    docker:
+      - image: kyrylo/ruby-2.0.0p648
+    working_directory: /home/circleci/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *unit
+  "ruby-2.1":
+    docker:
+      - image: circleci/ruby:2.1
+    working_directory: ~/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *unit
+  "ruby-2.2":
+    docker:
+      - image: circleci/ruby:2.2
+    working_directory: ~/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *unit
+  "ruby-2.3":
+    docker:
+      - image: circleci/ruby:2.3
+    working_directory: ~/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *unit
+  "ruby-2.4":
+    docker:
+      - image: circleci/ruby:2.4
+    working_directory: ~/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *unit
+  "ruby-2.5":
+    docker:
+      - image: circleci/ruby:2.5
+    working_directory: ~/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *unit
+  "jruby-9.1-jdk":
+    docker:
+      - image: circleci/jruby:9.1-jdk
+    working_directory: ~/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *unit
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - rubocop_lint
+      - yard_lint
+      - "ruby-1.9":
+          requires:
+            - rubocop_lint
+            - yard_lint
+      - "ruby-2.0":
+          requires:
+            - rubocop_lint
+            - yard_lint
+      - "ruby-2.1":
+          requires:
+            - rubocop_lint
+            - yard_lint
+      - "ruby-2.2":
+          requires:
+            - rubocop_lint
+            - yard_lint
+      - "ruby-2.3":
+          requires:
+            - rubocop_lint
+            - yard_lint
+      - "ruby-2.4":
+          requires:
+            - rubocop_lint
+            - yard_lint
+      - "ruby-2.5":
+          requires:
+            - rubocop_lint
+            - yard_lint
+      - "jruby-9.1-jdk":
+          requires:
+            - rubocop_lint
+            - yard_lint

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,9 @@ source 'https://rubygems.org'
 gemspec
 gem 'rake', '~> 10.0'
 
-# For Guard
 group :development do
   gem 'gist'
   gem 'yard'
-  gem 'rb-inotify', require: false
-  gem 'rb-fsevent', require: false
 
   # Rubocop supports only >=2.2.0
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')


### PR DESCRIPTION
CircleCI provides much faster builds than TravisCI:

CircleCI - less than 1 minute
TravisCI- 6 minutes

The cost is the complexity of the config:
https://circleci.com/docs/2.0/configuration-reference/

---

Gemfile: delete gems that were needed for Guard

`rb-inotify` has a dependency on `ffi`, which fails to compile on Ruby 1.9.3
while running on CircleCI. I don't think anyone who develops Pry (seems to be
just me so far) uses Guard in their worfklow. Our repo is missing an obligatory
Guardfile, too, which makes me think it's a very safe change to make (rather
than wasting time with`ffi` and CircleCI).