### PR TITLE
Fix rubocop empty line after guard clause style violations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -167,11 +167,6 @@ Layout/EmptyComment:
   Exclude:
     - 'spec/command_spec.rb'
 
-# Offense count: 57
-# Cop supports --auto-correct.
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Layout/EmptyLineAfterMagicComment:

--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -13,6 +13,7 @@ class Pry
   # The default hooks - display messages when beginning and ending Pry sessions.
   DEFAULT_HOOKS = Pry::Hooks.new.add_hook(:before_session, :default) do |out, target, _pry_|
     next if _pry_.quiet?
+
     _pry_.run_command("whereami --quiet")
   end
 

--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -201,6 +201,7 @@ class Pry
     # @return [Code]
     def grep(pattern)
       return self unless pattern
+
       pattern = Regexp.new(pattern)
 
       select do |loc|

--- a/lib/pry/code/code_range.rb
+++ b/lib/pry/code/code_range.rb
@@ -49,12 +49,14 @@ class Pry
       # @return [Integer]
       def find_start_index(lines)
         return start_line if start_line < 0
+
         lines.index { |loc| loc.lineno >= start_line } || lines.length
       end
 
       # @return [Integer]
       def find_end_index(lines)
         return end_line if end_line < 0
+
         (lines.index { |loc| loc.lineno > end_line } || 0) - 1
       end
 

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -170,6 +170,7 @@ class Pry
     def safe_to_evaluate?(str)
       return true if str.strip == "self"
       return false if str =~ /%/
+
       kind = target.eval("defined?(#{str})")
       kind =~ /variable|constant/
     end

--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -40,6 +40,7 @@ class Pry
       end
     rescue => e
       raise if e.is_a? Pry::Pager::StopPaging
+
       begin
         str = obj.inspect
       rescue Exception 

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -354,6 +354,7 @@ class Pry
 
       # please call Command.matches? before Command#call_safely
       raise CommandError, "fatal: called a command which didn't match?!" unless Regexp.last_match
+
       captures = Regexp.last_match.captures
       pos = Regexp.last_match.end(0)
 

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -351,6 +351,7 @@ class Pry
       unless Class === command && command < Pry::Command
         raise TypeError, "command is not a subclass of Pry::Command"
       end
+
       bind_command_to_pattern = pattern != command.match
       if bind_command_to_pattern
         command_copy = command.dup

--- a/lib/pry/commands/cat.rb
+++ b/lib/pry/commands/cat.rb
@@ -52,6 +52,7 @@ class Pry
       $LOAD_PATH.flat_map do |path|
         Dir[path + '/**/*'].map { |f|
           next if File.directory?(f)
+
           f.sub!(path + '/', '')
         }
       end

--- a/lib/pry/commands/exit.rb
+++ b/lib/pry/commands/exit.rb
@@ -33,6 +33,7 @@ class Pry
 
       # return a user-specified value if given otherwise return the object
       return target.eval(arg_string) unless arg_string.empty?
+
       popped_object
     end
   end

--- a/lib/pry/commands/find_method.rb
+++ b/lib/pry/commands/find_method.rb
@@ -31,6 +31,7 @@ class Pry
 
     def process
       return if args.size < 1
+
       klass = search_class
 
       matches = opts.content? ? content_search(klass) : name_search(klass)
@@ -119,6 +120,7 @@ class Pry
 
       klass.constants.each do |name|
         next if klass.autoload?(name)
+
         begin
           const = klass.const_get(name)
         rescue RescuableException
@@ -146,6 +148,7 @@ class Pry
       recurse_namespace(namespace) do |klass|
         (Pry::Method.all_from_class(klass) + Pry::Method.all_from_obj(klass)).each do |method|
           next if done[method.owner][method.name]
+
           done[method.owner][method.name] = true
 
           matches << method if yield method

--- a/lib/pry/commands/gist.rb
+++ b/lib/pry/commands/gist.rb
@@ -28,6 +28,7 @@ class Pry
 
     def process
       return ::Gist.login! if opts.present?(:login)
+
       cc = CodeCollector.new(args, opts, _pry_)
 
       if cc.content =~ /\A\s*\z/

--- a/lib/pry/commands/install_command.rb
+++ b/lib/pry/commands/install_command.rb
@@ -30,6 +30,7 @@ class Pry
 
       gems_to_install.each do |g|
         next if Rubygem.installed?(g)
+
         output.puts "Installing #{ green(g) } gem..."
         Rubygem.install(g)
       end

--- a/lib/pry/commands/ls/constants.rb
+++ b/lib/pry/commands/ls/constants.rb
@@ -39,6 +39,7 @@ class Pry
             !show_deprecated_constants?
             next
           end
+
           if const = (!mod.autoload?(name) && (mod.const_get(name) || true) rescue nil)
             if (const < Exception rescue false)
               color(:exception_constant, name)

--- a/lib/pry/commands/ls/formatter.rb
+++ b/lib/pry/commands/ls/formatter.rb
@@ -12,6 +12,7 @@ class Pry
 
       def write_out
         return false unless correct_opts?
+
         output_self
       end
 
@@ -25,6 +26,7 @@ class Pry
       # Outputs nothing if the section would be empty.
       def output_section(heading, body)
         return '' if body.compact.empty?
+
         fancy_heading = Pry::Helpers::Text.bold(color(:heading, heading))
         Pry::Helpers.tablify_or_one_line(fancy_heading, body)
       end

--- a/lib/pry/commands/raise_up.rb
+++ b/lib/pry/commands/raise_up.rb
@@ -23,6 +23,7 @@ class Pry
 
     def process
       return _pry.pager.page help if captures[0] =~ /(-h|--help)\b/
+
       # Handle 'raise-up', 'raise-up "foo"', 'raise-up RuntimeError, 'farble' in a rubyesque manner
       target.eval("_pry_.raise_up#{captures[0]}")
     end

--- a/lib/pry/commands/shell_command.rb
+++ b/lib/pry/commands/shell_command.rb
@@ -33,6 +33,7 @@ class Pry
     def parse_destination(dest)
       return "~" if dest.empty?
       return dest unless dest == "-"
+
       state.old_pwd || raise(CommandError, "No prior directory available")
     end
 

--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -20,6 +20,7 @@ class Pry
     def process
       code_object = Pry::CodeObject.lookup(obj_name, _pry_, super: opts[:super])
       raise CommandError, no_definition_message if !code_object
+
       @original_code_object = code_object
 
       if !obj_name && code_object.c_module? && !opts[:all]

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -88,6 +88,7 @@ module Pry::Config::Behavior
     if @reserved_keys.include?(key)
       raise ReservedKeyError, "It is not possible to use '#{key}' as a key name, please choose a different key name."
     end
+
     __push(key,value)
   end
 
@@ -113,6 +114,7 @@ module Pry::Config::Behavior
   def merge!(other)
     other = __try_convert_to_hash(other)
     raise TypeError, "unable to convert argument into a Hash" unless other
+
     other.each do |key, value|
       self[key] = value
     end

--- a/lib/pry/core_extensions.rb
+++ b/lib/pry/core_extensions.rb
@@ -82,6 +82,7 @@ class Object
       # 1) ./spec/pry_spec.rb:360:in `block in (root)'
       # 2) ./spec/pry_spec.rb:366:in `block in (root)'
       return class_eval {binding} if Pry::Helpers::BaseHelpers.jruby? and self.name == nil
+
       # class_eval sets both self and the default definee to this class.
       return class_eval("binding")
     end

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -35,6 +35,7 @@ module Pry::Helpers::BaseHelpers
 
   def command_dependencies_met?(options)
     return true if !options[:requires_gem]
+
     Array(options[:requires_gem]).all? do |g|
       Pry::Rubygem.installed?(g)
     end

--- a/lib/pry/helpers/command_helpers.rb
+++ b/lib/pry/helpers/command_helpers.rb
@@ -144,6 +144,7 @@ class Pry
 
       def set_file_and_dir_locals(file_name, _pry_=_pry_(), target=target())
         return if !target or !file_name
+
         _pry_.last_file = File.expand_path(file_name)
         _pry_.inject_local("_file_", _pry_.last_file, target)
 

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -44,6 +44,7 @@ class Pry
           padded = []
           r.each_with_index do |e,i|
             next unless e
+
             item = e.ljust(widths[i])
             item.sub! e, _recall_color_for(e) if :color_on == style
             padded << item
@@ -94,6 +95,7 @@ class Pry
       def _recolumn
         @rows_without_colors = []
         return if items.size.zero?
+
         row_count = (items.size.to_f/column_count).ceil
         row_count.times do |i|
           row_indices = (0...column_count).map{|e| row_count*e+i}

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -172,6 +172,7 @@ class Pry::InputCompleter
           to_ignore = ignored_modules
           ObjectSpace.each_object(Module){|m|
             next if (to_ignore.include?(m) rescue true)
+
             # jruby doesn't always provide #instance_methods() on each
             # object.
             if m.respond_to?(:instance_methods)
@@ -222,6 +223,7 @@ class Pry::InputCompleter
   def build_path(input)
     # check to see if the input is a regex
     return proc {|i| i.to_s }, input if input[/\/\./]
+
     trailing_slash = input.end_with?('/')
     contexts = input.chomp('/').split(/\//)
     input = contexts[-1]
@@ -242,6 +244,7 @@ class Pry::InputCompleter
 
     scanner = lambda do |m|
       next if s.include?(m) # IRB::ExtendCommandBundle::EXCB recurses.
+
       s << m
       m.constants(false).each do |c|
         value = m.const_get(c)
@@ -252,6 +255,7 @@ class Pry::InputCompleter
     # FIXME: Add Pry here as well?
     [:IRB, :SLex, :RubyLex, :RubyToken].each do |module_name|
       next unless Object.const_defined?(module_name)
+
       scanner.call(Object.const_get(module_name))
     end
 

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -398,6 +398,7 @@ class Pry
     #   before any aliasing, or `nil` if it can't be determined.
     def original_name
       return nil if source_type != :ruby
+
       method_name_from_first_line(source.lines.first)
     end
 

--- a/lib/pry/method/disowned.rb
+++ b/lib/pry/method/disowned.rb
@@ -47,6 +47,7 @@ class Pry
       # Raise a more useful error message instead of trying to forward to nil.
       def method_missing(meth_name, *args, &block)
         raise "Cannot call '#{meth_name}' on an undef'd method." if method(:name).respond_to?(meth_name)
+
         Object.instance_method(:method_missing).bind(self).call(meth_name, *args, &block)
       end
     end

--- a/lib/pry/method/weird_method_locator.rb
+++ b/lib/pry/method/weird_method_locator.rb
@@ -109,6 +109,7 @@ class Pry
         if skip_superclass_search?
           return guess
         end
+
         while guess
           # needs rescue if this is a Disowned method or a C method or something...
           # TODO: Fix up the exception handling so we don't need a bare rescue
@@ -135,6 +136,7 @@ class Pry
       #   renamed method
       def find_renamed_method
         return if !valid_file?(target_file)
+
         alias_name = all_methods_for(target_self).find do |v|
           expanded_source_location(target_self.method(v).source_location) == renamed_method_source_location
         end

--- a/lib/pry/output.rb
+++ b/lib/pry/output.rb
@@ -8,6 +8,7 @@ class Pry::Output
 
   def puts(*objs)
     return print "\n" if objs.empty?
+
     objs.each do |obj|
       if ary = Array.try_convert(obj)
         puts(*ary)

--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -111,6 +111,7 @@ class Pry::Pager
           @out.print "<page break> --- Press enter to continue " \
                      "( q<enter> to break ) --- <page break>\n"
           raise StopPaging if Readline.readline("").chomp == "q"
+
           @tracker.reset
         end
       end

--- a/lib/pry/platform.rb
+++ b/lib/pry/platform.rb
@@ -40,6 +40,7 @@ module Pry::Platform
   #
   def windows_ansi?
     return false if not windows?
+
     !!(defined?(Win32::Console) or ENV['ANSICON'] or mri_2?)
   end
 

--- a/lib/pry/plugins.rb
+++ b/lib/pry/plugins.rb
@@ -84,6 +84,7 @@ class Pry
     def locate_plugins
       gem_list.each do |gem|
         next if gem.name !~ PRY_PLUGIN_PREFIX
+
         plugin_name = gem.name.split('-', 2).last
         plugin = Plugin.new(plugin_name, gem.name, gem, false)
         @plugins << plugin.tap(&:enable!) if plugin.supported? && !plugin_located?(plugin)

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -142,6 +142,7 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
   # requires, and history.
   def self.initial_session_setup
     return unless initial_session?
+
     @initial_session = false
 
     # note these have to be loaded here rather than in pry_instance as
@@ -151,6 +152,7 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
 
   def self.final_session_setup
     return if @session_finalized
+
     @session_finalized = true
     load_plugins if Pry.config.should_load_plugins
     load_requires if Pry.config.should_load_requires
@@ -171,6 +173,7 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
     if ENV['FAIL_PRY']
       raise 'You have FAIL_PRY set to true, which results in Pry calls failing'
     end
+
     options = options.to_hash
 
     if in_critical_section?
@@ -294,6 +297,7 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
   def self.default_editor_for_platform
     return ENV['VISUAL'] if ENV['VISUAL'] and not ENV['VISUAL'].empty?
     return ENV['EDITOR'] if ENV['EDITOR'] and not ENV['EDITOR'].empty?
+
     if Helpers::BaseHelpers.windows?
       'notepad'
     else

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -132,6 +132,7 @@ class Pry
   #
   def complete(str)
     return EMPTY_COMPLETIONS unless config.completer
+
     Pry.critical_section do
       completer = config.completer.new(config.input, self)
       completer.call str, target: current_binding, custom_completions: custom_completions.call.push(*sticky_locals.keys)
@@ -254,6 +255,7 @@ class Pry
 
     # TODO: make this configurable?
     raise exception if exception
+
     return false
   end
 

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -218,12 +218,14 @@ class Pry
     #   % pry | tee log
     def piping?
       return false unless $stdout.respond_to?(:tty?)
+
       !$stdout.tty? && $stdin.tty? && !Pry::Helpers::BaseHelpers.windows?
     end
 
     # @return [void]
     def set_readline_output
       return if @readline_output
+
       if piping?
         @readline_output = (Readline.output = Pry.config.output)
       end

--- a/lib/pry/slop.rb
+++ b/lib/pry/slop.rb
@@ -465,6 +465,7 @@ class Pry::Slop
   # Returns nothing.
   def process_item(items, index, &block)
     return unless item = items[index]
+
     option, argument = extract_option(item) if item.start_with?('-')
 
     if option
@@ -514,6 +515,7 @@ class Pry::Slop
       if config[:multiple_switches] && strict?
         raise InvalidOptionError, "Unknown option -#{item}"
       end
+
       return
     end
 
@@ -545,6 +547,7 @@ class Pry::Slop
     execute_option(option, nil, index)
     argument.split('').each do |key|
       next unless opt = fetch_option(key)
+
       opt.count += 1
       execute_option(opt, nil, index, key)
     end

--- a/lib/pry/terminal.rb
+++ b/lib/pry/terminal.rb
@@ -77,6 +77,7 @@ class Pry::Terminal
 
     def screen_size_according_to_ansicon_env
       return unless ENV['ANSICON'] =~ /\((.*)x(.*)\)/
+
       size = [$2, $1]
       size if nonzero_column?(size)
     end

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -49,6 +49,7 @@ class Pry
       def safe_to_evaluate?(str, target)
         return true if str.strip == "self"
         return false if str =~ /%/
+
         kind = target.eval("defined?(#{str})")
         kind =~ /variable|constant/
       end
@@ -58,6 +59,7 @@ class Pry
     # @param [Module] mod
     def initialize(mod)
       raise ArgumentError, "Tried to initialize a WrappedModule with a non-module #{mod.inspect}" unless ::Module === mod
+
       @wrapped = mod
       @memoized_candidates = []
       @host_file_lines = nil
@@ -345,9 +347,11 @@ class Pry
 
     def nested_module?(parent, name)
       return if safe_send(parent, :autoload?, name)
+
       child = safe_send(parent, :const_get, name)
       return unless Module === child
       return unless safe_send(child, :name) == "#{safe_send(parent, :name)}::#{name}"
+
       child
     end
 

--- a/lib/pry/wrapped_module/candidate.rb
+++ b/lib/pry/wrapped_module/candidate.rb
@@ -64,6 +64,7 @@ class Pry
       # @return [String] The documentation for the candidate.
       def doc
         return nil if file.nil?
+
         @doc ||= get_comment_content(Pry::Code.from_file(file).comment_describing(line))
       end
 


### PR DESCRIPTION
- Fix rubocop violations
- Remove corresponding line from .rubocop_todo.yml