### PR TITLE
ommands/ls/formatter,helpers/table: pass local Pry config

### DIFF
--- a/lib/pry/commands/ls/formatter.rb
+++ b/lib/pry/commands/ls/formatter.rb
@@ -28,7 +28,7 @@ class Pry
         return '' if body.compact.empty?
 
         fancy_heading = Pry::Helpers::Text.bold(color(:heading, heading))
-        Pry::Helpers.tablify_or_one_line(fancy_heading, body)
+        Pry::Helpers.tablify_or_one_line(fancy_heading, body, @_pry_.config)
       end
 
       def format_value(value)

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -1,27 +1,28 @@
 class Pry
   module Helpers
-    def self.tablify_or_one_line(heading, things)
+    def self.tablify_or_one_line(heading, things, config = Pry.config)
       plain_heading = Pry::Helpers::Text.strip_color(heading)
       attempt = Table.new(things, column_count: things.size)
       if attempt.fits_on_line?(Terminal.width! - plain_heading.size - 2)
         "#{heading}: #{attempt}\n"
       else
-        "#{heading}: \n#{tablify_to_screen_width(things, indent: '  ')}\n"
+        "#{heading}: \n#{tablify_to_screen_width(things, { indent: '  ' }, config)}\n"
       end
     end
 
-    def self.tablify_to_screen_width(things, options = {})
+    def self.tablify_to_screen_width(things, options, config = Pry.config)
+      options ||= {}
       things = things.compact
       if indent = options[:indent]
         usable_width = Terminal.width! - indent.size
-        tablify(things, usable_width).to_s.gsub(/^/, indent)
+        tablify(things, usable_width, config).to_s.gsub(/^/, indent)
       else
-        tablify(things, Terminal.width!).to_s
+        tablify(things, Terminal.width!, config).to_s
       end
     end
 
-    def self.tablify(things, line_length)
-      table = Table.new(things, column_count: things.size)
+    def self.tablify(things, line_length, config = Pry.config)
+      table = Table.new(things, { column_count: things.size }, config)
       table.column_count -= 1 until 1 == table.column_count or
         table.fits_on_line?(line_length)
       table
@@ -29,8 +30,9 @@ class Pry
 
     class Table
       attr_reader :items, :column_count
-      def initialize items, args = {}
+      def initialize(items, args, config = Pry.config)
         @column_count = args[:column_count]
+        @config = config
         self.items = items
       end
 
@@ -49,7 +51,7 @@ class Pry
             item.sub! e, _recall_color_for(e) if :color_on == style
             padded << item
           end
-          padded.join(Pry.config.ls.separator)
+          padded.join(@config.ls.separator)
         end
       end
 


### PR DESCRIPTION
Replaces #1713
(Pry local config The following methods take a third required argument, an
instance of Pry)

This fulfills queries to `_pry_.config` in:

* Pry::Helpers.tablify
* Pry::Helpers.tablify_to_screen_width
* Pry::Helpers.tablify_or_one_line

Unlike #1713 this PR doesn't introduce any breaking changes thanks to the
default parameter value trick, *except* the `Table#new` signature.

Overall, this brings the code in line with how the rest of Pry works.