### PR TITLE
ring: rewrite the class to improve API

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -64,11 +64,11 @@ class Pry
   # The default prompt; includes the target and nesting level
   DEFAULT_PROMPT = [
                     proc { |target_self, nest_level, pry|
-                      "[#{pry.input_ring.size}] #{pry.config.prompt_name}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}> "
+                      "[#{pry.input_ring.count}] #{pry.config.prompt_name}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}> "
                     },
 
                     proc { |target_self, nest_level, pry|
-                      "[#{pry.input_ring.size}] #{pry.config.prompt_name}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}* "
+                      "[#{pry.input_ring.count}] #{pry.config.prompt_name}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}* "
                     }
                    ]
 

--- a/lib/pry/commands/cat/input_expression_formatter.rb
+++ b/lib/pry/commands/cat/input_expression_formatter.rb
@@ -36,7 +36,7 @@ class Pry
       end
 
       def normalized_expression_range
-        absolute_index_range(opts[:i], input_expressions.length)
+        absolute_index_range(opts[:i], input_expressions.count)
       end
     end
   end

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -186,7 +186,7 @@ class Pry
       when eval_string.strip != ""
         eval_string
       else
-        _pry_.input_ring.reverse_each.find { |x| x && x.strip != "" } || ""
+        _pry_.input_ring.to_a.reverse_each.find { |x| x && x.strip != "" } || ""
       end
     end
 


### PR DESCRIPTION
Currently, the Ring class is written with help of Hash as backend store.
According to the comments, the implementation should behave like a circular
buffer, however it doesn't. Upon reaching maximum capacity Ring doesn't replace
old elements but keeps writing to new cells, deleting old cells, so that the
hash contains `nil` entries.

The new implementation is based on Array and seems to be closer to the actual
Ring. Older elemens get overwritten with newer ones.

This class also includes Enumerable, however none of our APIs take advantage of
it, so it seems like an overkill. There was also a problem with with this API
because of the above-mentioned nils. For example, if the ring exceeds its
maximum size, then callin `Enumerable#first` on it returns `nil`.

The new implementation deals with this with removal of Enumerable. The `#[]`
syntax is preserved, and now `ring[0]` returns an actual element instead of
`nil`. In case users need the Enumerable functionality, they can call
`Ring#to_a` to build the array, which supports the wanted methods.

As for the speed, the new implementation is:

* slower overall because it's thread-safe
* faster without mutexes for `#<<`
* slower without mutexes for `#[]`

Benchmark for old implementation:

```
Warming up --------------------------------------
             Ring#<<   223.451k i/100ms
             Ring#[]     2.837k i/100ms
Calculating -------------------------------------
             Ring#<<    223.157B (± 3.4%) i/s -    778.097B
             Ring#[]     82.485M (± 9.4%) i/s -    402.602M in   4.957792s
```

Benchmark for this implementation:

```
Warming up --------------------------------------
             Ring#<<   211.587k i/100ms
             Ring#[]     1.974k i/100ms
Calculating -------------------------------------
             Ring#<<    211.385B (± 2.8%) i/s -    698.439B
             Ring#[]     40.292M (±17.0%) i/s -    190.069M in   4.971195s
```

The benchmark:

```rb
require './lib/pry'
require 'benchmark/ips'

Benchmark.ips do |x|
  empty_ring = Pry::Ring.new(100)
  populated_ring = Pry::Ring.new(100)
  150.times { |i| populated_ring << i }

  x.report("Ring#<<") do |times|
    empty_ring << times
  end

  x.report("Ring#[]") do |times|
    populated_ring[0]
    populated_ring[1]
    populated_ring[2]

    populated_ring[-1]
    populated_ring[-2]
    populated_ring[-3]

    populated_ring[1..2]
    populated_ring[-2..-1]
    populated_ring[-2..3]

    populated_ring[0..-1]

    populated_ring[2..-1]
    populated_ring[-1..10]

    populated_ring[-1..0]
    populated_ring[-1..1]
  end
end
```