### PR TITLE
cli: fix `-f` not suppressing load of `pryrc`

### DIFF
--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -62,9 +62,6 @@ class Pry
           raise NoOptionsError, "No command line options defined! Use Pry::CLI.add_options to add command line options."
         end
 
-        # Load config files etc first, ensuring that cli options will take precedence.
-        Pry.initial_session_setup
-
         self.input_args = args
 
         begin
@@ -81,6 +78,7 @@ class Pry
           exit
         end
 
+        Pry.initial_session_setup
         Pry.final_session_setup
 
         # Option processors are optional.


### PR DESCRIPTION
Fixes #1761 (`pry -f` can no longer suppress the loading of .pryrc)

If I recall correctly, we split session loading in #1393 because of `Pry.start`.
This broke `-f`. I think we can get away with a simple reorder in #parse_options