### PR TITLE
pry: move INITIAL_PWD to code/code_file

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -122,10 +122,6 @@ class Pry
     end
   end
 
-  # Store the current working directory. This allows show-source etc. to work if
-  # your process has changed directory since boot. [Issue #675]
-  INITIAL_PWD = Dir.pwd
-
   # This is to keep from breaking under Rails 3.2 for people who are doing that
   # IRB = Pry thing.
   module ExtendCommandBundle; end

--- a/lib/pry/code/code_file.rb
+++ b/lib/pry/code/code_file.rb
@@ -25,6 +25,10 @@ class Pry
       %w(Gemfile Rakefile Guardfile Capfile) => :ruby
     }
 
+    # Store the current working directory. This allows show-source etc. to work if
+    # your process has changed directory since boot. [Issue #675]
+    INITIAL_PWD = Dir.pwd
+
     # @return [Symbol] The type of code stored in this wrapper.
     attr_reader :code_type
 
@@ -95,7 +99,7 @@ class Pry
 
     # @return [String]
     def from_pry_init_pwd
-      File.expand_path(@filename, Pry::INITIAL_PWD)
+      File.expand_path(@filename, INITIAL_PWD)
     end
 
     # @return [String]


### PR DESCRIPTION
This constant is not used anywhere else but this file so it makes sense to keep
it there.