### PR TITLE
Move prompt related code from pry.rb to prompt.rb

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -59,44 +59,6 @@ class Pry
     end
   end
 
-  DEFAULT_PROMPT_NAME = 'pry'
-
-  # The default prompt; includes the target and nesting level
-  DEFAULT_PROMPT = [
-                    proc { |target_self, nest_level, pry|
-                      "[#{pry.input_ring.count}] #{pry.config.prompt_name}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}> "
-                    },
-
-                    proc { |target_self, nest_level, pry|
-                      "[#{pry.input_ring.count}] #{pry.config.prompt_name}(#{Pry.view_clip(target_self)})#{":#{nest_level}" unless nest_level.zero?}* "
-                    }
-                   ]
-
-  DEFAULT_PROMPT_SAFE_OBJECTS = [String, Numeric, Symbol, nil, true, false]
-
-  # A simple prompt - doesn't display target or nesting level
-  SIMPLE_PROMPT = [proc { ">> " }, proc { " | " }]
-
-  NO_PROMPT = [proc { '' }, proc { '' }]
-
-  SHELL_PROMPT = [
-                  proc { |target_self, _, _pry_| "#{_pry_.config.prompt_name} #{Pry.view_clip(target_self)}:#{Dir.pwd} $ " },
-                  proc { |target_self, _, _pry_| "#{_pry_.config.prompt_name} #{Pry.view_clip(target_self)}:#{Dir.pwd} * " }
-                 ]
-
-  # A prompt that includes the full object path as well as
-  # input/output (_in_ and _out_) information. Good for navigation.
-  NAV_PROMPT = [
-                proc do |_, _, _pry_|
-                  tree = _pry_.binding_stack.map { |b| Pry.view_clip(b.eval("self")) }.join " / "
-                  "[#{_pry_.input_ring.count}] (#{_pry_.config.prompt_name}) #{tree}: #{_pry_.binding_stack.size - 1}> "
-                end,
-                proc do |_, _, _pry_|
-                  tree = _pry_.binding_stack.map { |b| Pry.view_clip(b.eval("self")) }.join " / "
-                  "[#{_pry_.input_ring.count}] (#{ _pry_.config.prompt_name}) #{tree}: #{_pry_.binding_stack.size - 1}* "
-                end,
-               ]
-
   # Deal with the ^D key being pressed. Different behaviour in different cases:
   #   1. In an expression behave like `!` command.
   #   2. At top-level session behave like `exit` command.

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -185,11 +185,11 @@ Copyright (c) 2016 John Mair (banisterfiend)
   end
 
   on "simple-prompt", "Enable simple prompt mode" do
-    Pry.config.prompt = Pry::SIMPLE_PROMPT
+    Pry.config.prompt = Pry::Prompt::SIMPLE
   end
 
   on "noprompt", "No prompt mode" do
-    Pry.config.prompt = Pry::NO_PROMPT
+    Pry.config.prompt = Pry::Prompt::NO_PROMPT
   end
 
   on :r, :require=, "`require` a Ruby script at startup" do |file|

--- a/lib/pry/commands/shell_mode.rb
+++ b/lib/pry/commands/shell_mode.rb
@@ -10,11 +10,11 @@ class Pry
 
     def process
       case _pry_.prompt
-      when Pry::SHELL_PROMPT
+      when Pry::Prompt::SHELL
         _pry_.pop_prompt
         _pry_.custom_completions = _pry_.config.file_completions
       else
-        _pry_.push_prompt Pry::SHELL_PROMPT
+        _pry_.push_prompt Pry::Prompt::SHELL
         _pry_.custom_completions = _pry_.config.command_completions
       end
     end

--- a/lib/pry/commands/simple_prompt.rb
+++ b/lib/pry/commands/simple_prompt.rb
@@ -10,10 +10,10 @@ class Pry
 
     def process
       case _pry_.prompt
-      when Pry::SIMPLE_PROMPT
+      when Pry::Prompt::SIMPLE
         _pry_.pop_prompt
       else
-        _pry_.push_prompt Pry::SIMPLE_PROMPT
+        _pry_.push_prompt Pry::Prompt::SIMPLE
       end
     end
   end

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -13,13 +13,13 @@ class Pry::Config::Default
       Pry::Commands
     },
     prompt_name: proc {
-      Pry::DEFAULT_PROMPT_NAME
+      Pry::Prompt::DEFAULT_NAME
     },
     prompt: proc {
-      Pry::DEFAULT_PROMPT
+      Pry::Prompt::DEFAULT
     },
     prompt_safe_objects: proc {
-      Pry::DEFAULT_PROMPT_SAFE_OBJECTS
+      Pry::Prompt::SAFE_OBJECTS
     },
     print: proc {
       Pry::DEFAULT_PRINT

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -1,26 +1,28 @@
-class Pry::Prompt
-  MAP = {
-    "default" => {
-      value: Pry::DEFAULT_PROMPT,
-      description: "The default Pry prompt. Includes information about the\n" \
-                   "current expression number, evaluation context, and nesting\n" \
-                   "level, plus a reminder that you're using Pry."
-    },
+class Pry
+  class Prompt
+    MAP = {
+      "default" => {
+        value: Pry::DEFAULT_PROMPT,
+        description: "The default Pry prompt. Includes information about the\n" \
+                     "current expression number, evaluation context, and nesting\n" \
+                     "level, plus a reminder that you're using Pry."
+      },
 
-    "simple" => {
-      value: Pry::SIMPLE_PROMPT,
-      description: "A simple '>>'."
-    },
+      "simple" => {
+        value: Pry::SIMPLE_PROMPT,
+        description: "A simple '>>'."
+      },
 
-    "nav" => {
-      value: Pry::NAV_PROMPT,
-      description: "A prompt that displays the binding stack as a path and\n" \
-                   "includes information about _in_ and _out_."
-    },
+      "nav" => {
+        value: Pry::NAV_PROMPT,
+        description: "A prompt that displays the binding stack as a path and\n" \
+                     "includes information about _in_ and _out_."
+      },
 
-    "none" => {
-      value: Pry::NO_PROMPT,
-      description: "Wave goodbye to the Pry prompt."
+      "none" => {
+        value: Pry::NO_PROMPT,
+        description: "Wave goodbye to the Pry prompt."
+      }
     }
- }
+  end
 end

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -1,28 +1,108 @@
 class Pry
   class Prompt
+    DEFAULT_NAME = 'pry'.freeze
+
+    SAFE_OBJECTS = [String, Numeric, Symbol, nil, true, false].freeze
+
+    # @return [String]
+    DEFAULT_TEMPLATE =
+      "[%<in_count>s] %<name>s(%<context>s)%<nesting>s%<separator>s ".freeze
+
+    # The default Pry prompt, which includes the context and nesting level.
+    # @return [Array<Proc>]
+    DEFAULT = [
+      proc { |context, nesting, _pry_|
+        format(
+          DEFAULT_TEMPLATE,
+          in_count: _pry_.input_ring.count,
+          name: _pry_.config.prompt_name,
+          context: Pry.view_clip(context),
+          nesting: (nesting > 0 ? ":#{nesting}" : ''),
+          separator: '>'
+        )
+      },
+      proc { |context, nesting, _pry_|
+        format(
+          DEFAULT_TEMPLATE,
+          in_count: _pry_.input_ring.count,
+          name: _pry_.config.prompt_name,
+          context: Pry.view_clip(context),
+          nesting: (nesting > 0 ? ":#{nesting}" : ''),
+          separator: '*'
+        )
+      }
+    ].freeze
+
+    # Simple prompt doesn't display target or nesting level.
+    # @return [Array<Proc>]
+    SIMPLE = [proc { '>> ' }, proc { ' | ' }].freeze
+
+    # @return [Array<Proc>]
+    NO_PROMPT = Array.new(2) { proc { '' } }.freeze
+
+    SHELL_TEMPLATE = "%<name>s %<context>s:%<pwd>s %<separator>s ".freeze
+
+    SHELL = [
+      proc do |context, _nesting, _pry_|
+        format(
+          SHELL_TEMPLATE,
+          name: _pry_.config.prompt_name,
+          context: Pry.view_clip(context),
+          pwd: Dir.pwd,
+          separator: '$'
+        )
+      end,
+      proc do |context, _nesting, _pry_|
+        format(
+          SHELL_TEMPLATE,
+          name: _pry_.config.prompt_name,
+          context: Pry.view_clip(context),
+          pwd: Dir.pwd,
+          separator: '*'
+        )
+      end
+    ].freeze
+
+    NAV_TEMPLATE = "[%<in_count>s] (%<name>s) %<tree>s: %<stack_size>s> ".freeze
+
+    # A prompt that includes the full object path as well as
+    # input/output (_in_ and _out_) information. Good for navigation.
+    NAV = Array.new(2) do
+      proc do |_context, _nesting, _pry_|
+        tree = _pry_.binding_stack.map { |b| Pry.view_clip(b.eval('self')) }
+        format(
+          NAV_TEMPLATE,
+          in_count: _pry_.input_ring.count,
+          name: _pry_.config.prompt_name,
+          tree: tree.join(' / '),
+          stack_size: _pry_.binding_stack.size - 1
+        )
+      end
+    end.freeze
+
     MAP = {
       "default" => {
-        value: Pry::DEFAULT_PROMPT,
+        value: DEFAULT,
         description: "The default Pry prompt. Includes information about the\n" \
                      "current expression number, evaluation context, and nesting\n" \
-                     "level, plus a reminder that you're using Pry."
+                     "level, plus a reminder that you're using Pry.".freeze
       },
 
       "simple" => {
-        value: Pry::SIMPLE_PROMPT,
-        description: "A simple '>>'."
+        value: SIMPLE,
+        description: "A simple '>>'.".freeze
       },
 
       "nav" => {
-        value: Pry::NAV_PROMPT,
+        value: NAV,
         description: "A prompt that displays the binding stack as a path and\n" \
-                     "includes information about _in_ and _out_."
+                     "includes information about _in_ and _out_.".freeze
       },
 
       "none" => {
-        value: Pry::NO_PROMPT,
-        description: "Wave goodbye to the Pry prompt."
+        value: NO_PROMPT,
+        description: "Wave goodbye to the Pry prompt.".freeze
       }
-    }
+    }.freeze
   end
 end

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -105,8 +105,8 @@ class Pry
   # This is the prompt at the top of the prompt stack.
   #
   # @example
-  #    self.prompt = Pry::SIMPLE_PROMPT
-  #    self.prompt # => Pry::SIMPLE_PROMPT
+  #    self.prompt = Pry::Prompt::SIMPLE
+  #    self.prompt # => Pry::Prompt::SIMPLE
   #
   # @return [Array<Proc>] Current prompt.
   def prompt


### PR DESCRIPTION
It makes a lot more sense to keep these procs under the `Pry::Prompt` namespace
than `Pry`, which is already heavily populated by other various things.