### PR TITLE
config/default: rename prompt_safe_objects to prompt_safe_contexts

### DIFF
--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -18,8 +18,8 @@ class Pry::Config::Default
     prompt: proc {
       Pry::Prompt::DEFAULT
     },
-    prompt_safe_objects: proc {
-      Pry::Prompt::SAFE_OBJECTS
+    prompt_safe_contexts: proc {
+      Pry::Prompt::SAFE_CONTEXTS
     },
     print: proc {
       Pry::DEFAULT_PRINT

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -2,7 +2,7 @@ class Pry
   class Prompt
     DEFAULT_NAME = 'pry'.freeze
 
-    SAFE_OBJECTS = [String, Numeric, Symbol, nil, true, false].freeze
+    SAFE_CONTEXTS = [String, Numeric, Symbol, nil, true, false].freeze
 
     # @return [String]
     DEFAULT_TEMPLATE =

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -241,7 +241,7 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
       # fixed as of https://github.com/jruby/jruby/commit/d365ebd309cf9df3dde28f5eb36ea97056e0c039
       # we can drop in the future.
       obj.to_s
-    elsif Pry.config.prompt_safe_objects.any? { |v| v === obj } && obj.inspect.length <= max
+    elsif Pry.config.prompt_safe_contexts.any? { |v| v === obj } && obj.inspect.length <= max
       obj.inspect
     else
       id == true ? "#<#{obj.class}:0x%x>" % (obj.object_id << 1) : "#<#{obj.class}>"

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -274,7 +274,7 @@ describe "test Pry defaults" do
 
       it "returns the #inspect of the custom prompt safe objects" do
         Barbie = Class.new { def inspect; "life is plastic, it's fantastic" end }
-        Pry.config.prompt_safe_objects << Barbie
+        Pry.config.prompt_safe_contexts << Barbie
         output = Pry.view_clip(Barbie.new, DEFAULT_OPTIONS)
         expect(output).to eq "life is plastic, it's fantastic"
       end


### PR DESCRIPTION
It makes sense to rename it because "objects" we are referring in the context of
prompt are actually prompt "contexts".