### PR TITLE
Remove repetitive suffix for helper modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ See pull request [#1723](https://github.com/pry/pry/pull/1723)
 * Fixed `NoMethodError` on code objects that have a comment but no source when
   invoking `show-source` ([#1779](https://github.com/pry/pry/pull/1779))
 
+#### Dev-facing changes
+* Remove repetitive helper module suffix ([#1835](https://github.com/pry/pry/pull/1835))
+
 #### Pry developers
 
 * Optionally skip a spec on specific Ruby engine(s) by providing `expect_failure: [:mri, :jruby]`

--- a/lib/pry/code/loc.rb
+++ b/lib/pry/code/loc.rb
@@ -63,7 +63,7 @@ class Pry
       # @return [void]
       def add_line_number(max_width = 0, color = false)
         padded = lineno.to_s.rjust(max_width)
-        colorized_lineno = color ? Pry::Helpers::BaseHelpers.colorize_code(padded) : padded
+        colorized_lineno = color ? Pry::Helpers::Base.colorize_code(padded) : padded
         properly_padded_line = handle_multiline_entries_from_edit_command(line, max_width)
         tuple[0] = "#{ colorized_lineno }: #{ properly_padded_line }"
       end

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -61,7 +61,7 @@ class Pry
       end
     end
 
-    include Pry::Helpers::CommandHelpers
+    include Pry::Helpers::Command
 
     class << self
       def lookup(str, _pry_, options={})

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -7,7 +7,7 @@ class Pry
   # {Pry::CommandSet#command} which creates a BlockCommand or {Pry::CommandSet#create_command}
   # which creates a ClassCommand. Please don't use this class directly.
   class Command
-    extend Helpers::DocumentationHelpers
+    extend Helpers::Documentation
     extend CodeObject::Helpers
 
     # represents a void return value for a command
@@ -264,7 +264,7 @@ class Pry
     #
     # @deprecated
     #   Please use black(), white(), etc directly instead (as you would with helper
-    #   functions from BaseHelpers and CommandHelpers)
+    #   functions from Helpers::Base and Helpers::Command)
     #
     # @return [Module]
     #   Returns Pry::Helpers::Text
@@ -277,8 +277,8 @@ class Pry
       VOID_VALUE
     end
 
-    include Pry::Helpers::BaseHelpers
-    include Pry::Helpers::CommandHelpers
+    include Pry::Helpers::Base
+    include Pry::Helpers::Command
     include Pry::Helpers::Text
 
     # Instantiate a command, in preparation for calling it.

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -9,7 +9,7 @@ class Pry
   # different sets, aliased, removed, etc.
   class CommandSet
     include Enumerable
-    include Pry::Helpers::BaseHelpers
+    include Pry::Helpers::Base
     attr_reader :helper_module
 
     # @param [Array<Commandset>] imported_sets
@@ -194,7 +194,7 @@ class Pry
     # @return [Command] The command object matched.
     def find_command_by_match_or_listing(match_or_listing)
       cmd = (@commands[match_or_listing] ||
-        Pry::Helpers::BaseHelpers.find_command(match_or_listing, @commands))
+        Pry::Helpers::Base.find_command(match_or_listing, @commands))
       cmd or raise ArgumentError, "Cannot find a command: '#{match_or_listing}'!"
     end
 

--- a/lib/pry/commands/cat/abstract_formatter.rb
+++ b/lib/pry/commands/cat/abstract_formatter.rb
@@ -1,8 +1,8 @@
 class Pry
   class Command::Cat
     class AbstractFormatter
-      include Pry::Helpers::CommandHelpers
-      include Pry::Helpers::BaseHelpers
+      include Pry::Helpers::Command
+      include Pry::Helpers::Base
 
       private
       def decorate(content)

--- a/lib/pry/commands/code_collector.rb
+++ b/lib/pry/commands/code_collector.rb
@@ -1,6 +1,6 @@
 class Pry
   class Command::CodeCollector
-    include Helpers::CommandHelpers
+    include Helpers::Command
 
     attr_reader :args
     attr_reader :opts

--- a/lib/pry/commands/find_method.rb
+++ b/lib/pry/commands/find_method.rb
@@ -1,6 +1,6 @@
 class Pry
   class Command::FindMethod < Pry::ClassCommand
-    extend Pry::Helpers::BaseHelpers
+    extend Pry::Helpers::Base
 
     match 'find-method'
     group 'Context'

--- a/lib/pry/commands/ls/constants.rb
+++ b/lib/pry/commands/ls/constants.rb
@@ -4,7 +4,7 @@ class Pry
   class Command::Ls < Pry::ClassCommand
     class Constants < Pry::Command::Ls::Formatter
       DEPRECATED_CONSTANTS = [:Data, :Fixnum, :Bignum, :TimeoutError, :NIL, :FALSE, :TRUE]
-      DEPRECATED_CONSTANTS << :JavaPackageModuleTemplate if Pry::Helpers::BaseHelpers.jruby?
+      DEPRECATED_CONSTANTS << :JavaPackageModuleTemplate if Pry::Helpers::Base.jruby?
       include Pry::Command::Ls::Interrogatable
 
       def initialize(interrogatee, no_user_opts, opts, _pry_)

--- a/lib/pry/commands/ls/methods_helper.rb
+++ b/lib/pry/commands/ls/methods_helper.rb
@@ -14,7 +14,7 @@ module Pry::Command::Ls::MethodsHelper
                 Pry::Method.all_from_obj(@interrogatee)
               end
 
-    if Pry::Helpers::BaseHelpers.jruby? && !@jruby_switch
+    if Pry::Helpers::Base.jruby? && !@jruby_switch
       methods = trim_jruby_aliases(methods)
     end
 

--- a/lib/pry/commands/show_doc.rb
+++ b/lib/pry/commands/show_doc.rb
@@ -2,7 +2,7 @@ require 'pry/commands/show_info'
 
 class Pry
   class Command::ShowDoc < Command::ShowInfo
-    include Pry::Helpers::DocumentationHelpers
+    include Pry::Helpers::Documentation
 
     match 'show-doc'
     group 'Introspection'

--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -1,6 +1,6 @@
 class Pry
   class Command::ShowInfo < Pry::ClassCommand
-    extend Pry::Helpers::BaseHelpers
+    extend Pry::Helpers::Base
 
     command_options shellwords: false, interpolate: false
 

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -45,7 +45,7 @@ class Pry
           Pry::DEFAULT_SYSTEM
         },
         color: proc {
-          Pry::Helpers::BaseHelpers.use_ansi_codes?
+          Pry::Helpers::Base.use_ansi_codes?
         },
         default_window_size: proc {
           5
@@ -69,7 +69,7 @@ class Pry
           ""
         },
         auto_indent: proc {
-          Pry::Helpers::BaseHelpers.use_ansi_codes?
+          Pry::Helpers::Base.use_ansi_codes?
         },
         correct_indent: proc {
           true

--- a/lib/pry/core_extensions.rb
+++ b/lib/pry/core_extensions.rb
@@ -81,7 +81,7 @@ class Object
       # This fixes the following two spec failures, at https://travis-ci.org/pry/pry/jobs/274470002
       # 1) ./spec/pry_spec.rb:360:in `block in (root)'
       # 2) ./spec/pry_spec.rb:366:in `block in (root)'
-      return class_eval {binding} if Pry::Helpers::BaseHelpers.jruby? and self.name == nil
+      return class_eval {binding} if Pry::Helpers::Base.jruby? and self.name == nil
 
       # class_eval sets both self and the default definee to this class.
       return class_eval("binding")

--- a/lib/pry/editor.rb
+++ b/lib/pry/editor.rb
@@ -1,7 +1,7 @@
 class Pry
   class Editor
-    include Pry::Helpers::BaseHelpers
-    include Pry::Helpers::CommandHelpers
+    include Pry::Helpers::Base
+    include Pry::Helpers::Command
 
     attr_reader :_pry_
 

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -1,5 +1,5 @@
 module Pry::Helpers; end
-module Pry::Helpers::BaseHelpers
+module Pry::Helpers::Base
   include Pry::Platform
   extend self
 

--- a/lib/pry/helpers/command_helpers.rb
+++ b/lib/pry/helpers/command_helpers.rb
@@ -2,7 +2,7 @@ class Pry
   module Helpers
 
     module Command
-      include OptionsHelpers
+      include Options
 
       module_function
 

--- a/lib/pry/helpers/command_helpers.rb
+++ b/lib/pry/helpers/command_helpers.rb
@@ -1,7 +1,7 @@
 class Pry
   module Helpers
 
-    module CommandHelpers
+    module Command
       include OptionsHelpers
 
       module_function

--- a/lib/pry/helpers/documentation_helpers.rb
+++ b/lib/pry/helpers/documentation_helpers.rb
@@ -69,7 +69,7 @@ class Pry
       # @param [String] text
       # @return [String]
       def strip_leading_whitespace(text)
-        Pry::Helpers::CommandHelpers.unindent(text)
+        Pry::Helpers::Command.unindent(text)
       end
     end
   end

--- a/lib/pry/helpers/documentation_helpers.rb
+++ b/lib/pry/helpers/documentation_helpers.rb
@@ -3,7 +3,7 @@ class Pry
 
     # This class contains methods useful for extracting
     # documentation from methods and classes.
-    module DocumentationHelpers
+    module Documentation
 
       module_function
 

--- a/lib/pry/helpers/options_helpers.rb
+++ b/lib/pry/helpers/options_helpers.rb
@@ -1,6 +1,6 @@
 class Pry
   module Helpers
-    module OptionsHelpers
+    module Options
       module_function
 
       # Add method options to the Pry::Slop instance

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -9,7 +9,7 @@ class Pry
   # will be indented or un-indented by correctly.
   #
   class Indent
-    include Helpers::BaseHelpers
+    include Helpers::Base
 
     # Raised if {#module_nesting} would not work.
     class UnparseableNestingError < StandardError; end
@@ -395,7 +395,7 @@ class Pry
       cols = Terminal.width!
       lines = cols == 0 ? 1 : (line_to_measure.length / cols + 1).to_i
 
-      if Pry::Helpers::BaseHelpers.windows_ansi?
+      if Pry::Helpers::Base.windows_ansi?
         move_up = "\e[#{lines}F"
         move_down = "\e[#{lines}E"
       else

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -20,9 +20,9 @@ class Pry
     require 'pry/method/disowned'
     require 'pry/method/patcher'
 
-    extend Helpers::BaseHelpers
-    include Helpers::BaseHelpers
-    include Helpers::DocumentationHelpers
+    extend Helpers::Base
+    include Helpers::Base
+    include Helpers::Documentation
     include CodeObject::Helpers
 
     class << self

--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -51,7 +51,7 @@ class Pry::Pager
   def best_available
     if !_pry_.config.pager
       NullPager.new(_pry_.output)
-    elsif !SystemPager.available? || Pry::Helpers::BaseHelpers.jruby?
+    elsif !SystemPager.available? || Pry::Helpers::Base.jruby?
       SimplePager.new(_pry_.output)
     else
       SystemPager.new(_pry_.output)
@@ -139,7 +139,7 @@ class Pry::Pager
       if @system_pager.nil?
         @system_pager = begin
           pager_executable = default_pager.split(' ').first
-          if Pry::Helpers::BaseHelpers.windows? || Pry::Helpers::BaseHelpers.windows_ansi?
+          if Pry::Helpers::Base.windows? || Pry::Helpers::Base.windows_ansi?
             `where /Q #{pager_executable}`
           else
             `which #{pager_executable}`

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -157,7 +157,7 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
     load_requires if Pry.config.should_load_requires
     load_history if Pry.config.history.should_load
     load_traps if Pry.config.should_trap_interrupts
-    load_win32console if Pry::Helpers::BaseHelpers.windows? && !Pry::Helpers::BaseHelpers.windows_ansi?
+    load_win32console if Pry::Helpers::Base.windows? && !Pry::Helpers::Base.windows_ansi?
   end
 
   # Start a Pry REPL.
@@ -297,7 +297,7 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
     return ENV['VISUAL'] if ENV['VISUAL'] and not ENV['VISUAL'].empty?
     return ENV['EDITOR'] if ENV['EDITOR'] and not ENV['EDITOR'].empty?
 
-    if Helpers::BaseHelpers.windows?
+    if Helpers::Base.windows?
       'notepad'
     else
       %w(editor nano vi).detect do |editor|

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -332,7 +332,7 @@ class Pry
       # This workaround has a side effect: java exceptions specified
       # in `Pry.config.exception_whitelist` are ignored.
       jruby_exceptions = []
-      if Pry::Helpers::BaseHelpers.jruby?
+      if Pry::Helpers::Base.jruby?
         jruby_exceptions << Java::JavaLang::Exception
       end
 
@@ -347,7 +347,7 @@ class Pry
         # Eliminate following warning:
         # warning: singleton on non-persistent Java type X
         # (http://wiki.jruby.org/Persistence)
-        if Pry::Helpers::BaseHelpers.jruby? && e.class.respond_to?('__persistent__')
+        if Pry::Helpers::Base.jruby? && e.class.respond_to?('__persistent__')
           e.class.__persistent__ = true
         end
         self.last_exception = e

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -49,7 +49,7 @@ class Pry
 
       # Clear the line before starting Pry. This fixes issue #566.
       if pry.config.correct_indent
-        Kernel.print Pry::Helpers::BaseHelpers.windows_ansi? ? "\e[0F" : "\e[0G"
+        Kernel.print Pry::Helpers::Base.windows_ansi? ? "\e[0F" : "\e[0G"
       end
     end
 
@@ -104,7 +104,7 @@ class Pry
         original_val = "#{indentation}#{val}"
         indented_val = @indent.indent(val)
 
-        if output.tty? && pry.config.correct_indent && Pry::Helpers::BaseHelpers.use_ansi_codes?
+        if output.tty? && pry.config.correct_indent && Pry::Helpers::Base.use_ansi_codes?
           output.print @indent.correct_indentation(
             current_prompt,
             indented_val,
@@ -220,7 +220,7 @@ class Pry
     def piping?
       return false unless $stdout.respond_to?(:tty?)
 
-      !$stdout.tty? && $stdin.tty? && !Pry::Helpers::BaseHelpers.windows?
+      !$stdout.tty? && $stdin.tty? && !Pry::Helpers::Base.windows?
     end
 
     # @return [void]

--- a/lib/pry/terminal.rb
+++ b/lib/pry/terminal.rb
@@ -41,7 +41,7 @@ class Pry::Terminal
     end
 
     def screen_size_according_to_io_console
-      return if Pry::Helpers::BaseHelpers.jruby?
+      return if Pry::Helpers::Base.jruby?
 
       begin
         require 'io/console'

--- a/lib/pry/testable/utility.rb
+++ b/lib/pry/testable/utility.rb
@@ -15,7 +15,7 @@ module Pry::Testable::Utility
   end
 
   def unindent(*args)
-    Pry::Helpers::CommandHelpers.unindent(*args)
+    Pry::Helpers::Command.unindent(*args)
   end
 
   def inner_scope

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -14,7 +14,7 @@ class Pry
   end
 
   class WrappedModule
-    include Helpers::BaseHelpers
+    include Helpers::Base
     include CodeObject::Helpers
 
     attr_reader :wrapped
@@ -136,7 +136,7 @@ class Pry
     def singleton_instance
       raise ArgumentError, "tried to get instance of non singleton class" unless singleton_class?
 
-      if Helpers::BaseHelpers.jruby?
+      if Helpers::Base.jruby?
         wrapped.to_java.attached
       else
         @singleton_instance ||= ObjectSpace.each_object(wrapped).detect{ |x| (class << x; self; end) == wrapped }
@@ -251,7 +251,7 @@ class Pry
                  y.yield candidate(num)
                end
              end
-      Pry::Helpers::BaseHelpers.jruby_19? ? enum.to_a : enum
+      Pry::Helpers::Base.jruby_19? ? enum.to_a : enum
     end
 
     # @return [Boolean] Whether YARD docs are available for this module.

--- a/lib/pry/wrapped_module/candidate.rb
+++ b/lib/pry/wrapped_module/candidate.rb
@@ -7,7 +7,7 @@ class Pry
     # It provides access to the source, documentation, line and file
     # for a monkeypatch (reopening) of a class/module.
     class Candidate
-      include Pry::Helpers::DocumentationHelpers
+      include Pry::Helpers::Documentation
       include Pry::CodeObject::Helpers
       extend Pry::Forwardable
 

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -95,7 +95,7 @@ describe Pry::Code do
 
   describe '#initialize' do
     before do
-      @str = Pry::Helpers::CommandHelpers.unindent <<-CODE
+      @str = Pry::Helpers::Command.unindent <<-CODE
         def hay
           :guys
         end
@@ -119,7 +119,7 @@ describe Pry::Code do
 
   describe 'filters and formatters' do
     before do
-      @code = Pry::Code(Pry::Helpers::CommandHelpers.unindent <<-STR)
+      @code = Pry::Code(Pry::Helpers::Command.unindent <<-STR)
         class MyProgram
           def self.main
             puts 'Hello, world!'

--- a/spec/command_helpers_spec.rb
+++ b/spec/command_helpers_spec.rb
@@ -1,8 +1,8 @@
 require_relative 'helper'
 
-describe Pry::Helpers::CommandHelpers do
+describe Pry::Helpers::Command do
   before do
-    @helper = Pry::Helpers::CommandHelpers
+    @helper = Pry::Helpers::Command
   end
 
   describe "unindent" do

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -20,7 +20,7 @@ describe "edit" do
       # OS-specific tempdir name. For GNU/Linux it's "tmp", for Windows it's
       # something "Temp".
       @tf_dir =
-        if Pry::Helpers::BaseHelpers.mri_19?
+        if Pry::Helpers::Base.mri_19?
           Pathname.new(Dir::Tmpname.tmpdir)
         else
           Pathname.new(Dir.tmpdir)

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -238,7 +238,7 @@ describe "ls" do
     end
   end
 
-  if Pry::Helpers::BaseHelpers.jruby?
+  if Pry::Helpers::Base.jruby?
     describe 'on java objects' do
       it 'should omit java-esque aliases by default' do
         expect(pry_eval('ls java.lang.Thread.current_thread')).to match(/\bthread_group\b/)

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -28,7 +28,7 @@ describe Pry::InputCompleter do
   end
 
   # another jruby hack :((
-  if !Pry::Helpers::BaseHelpers.jruby?
+  if !Pry::Helpers::Base.jruby?
     it "should not crash if there's a Module that has a symbolic name." do
       expect { Pry::InputCompleter.new(Readline).call "a.to_s.", target: Pry.binding_for(Object.new) }.not_to raise_error
     end
@@ -225,7 +225,7 @@ describe Pry::InputCompleter do
     completer_test(self, nil, false).call("[].size.parse_printf_format")
   end
 
-  if !Pry::Helpers::BaseHelpers.jruby?
+  if !Pry::Helpers::Base.jruby?
     # Classes that override .hash are still hashable in JRuby, for some reason.
     it 'ignores methods from modules that override Object#hash incompatibly' do
       _m = Module.new do

--- a/spec/documentation_helper_spec.rb
+++ b/spec/documentation_helper_spec.rb
@@ -1,8 +1,8 @@
 require_relative 'helper'
 
-describe Pry::Helpers::DocumentationHelpers do
+describe Pry::Helpers::Documentation do
   before do
-    @helper = Pry::Helpers::DocumentationHelpers
+    @helper = Pry::Helpers::Documentation
   end
 
   describe "get_comment_content" do

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -10,7 +10,7 @@ describe Pry::Editor do
     # OS-specific tempdir name. For GNU/Linux it's "tmp", for Windows it's
     # something "Temp".
     @tf_dir =
-      if Pry::Helpers::BaseHelpers.mri_19?
+      if Pry::Helpers::Base.mri_19?
         Pathname.new(Dir::Tmpname.tmpdir)
       else
         Pathname.new(Dir.tmpdir)
@@ -21,7 +21,7 @@ describe Pry::Editor do
     @editor = Pry::Editor.new(Pry.new)
   end
 
-  unless Pry::Helpers::BaseHelpers.windows?
+  unless Pry::Helpers::Base.windows?
     describe "build_editor_invocation_string" do
       it 'should shell-escape files' do
         invocation_str = @editor.build_editor_invocation_string(@tf_path, 5, true)

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -369,9 +369,9 @@ describe Pry do
         it 'should define a method on the class of an object when performing "def meth;end" inside an immediate value or Numeric' do
           # JRuby behaves different than CRuby here (seems it always has to some extent, see 'unless' below).
           # It didn't seem trivial to work around. Skip for now.
-          skip "JRuby incompatibility" if Pry::Helpers::BaseHelpers.jruby?
+          skip "JRuby incompatibility" if Pry::Helpers::Base.jruby?
           [:test, 0, true, false, nil,
-              (0.0 unless Pry::Helpers::BaseHelpers.jruby?)].each do |val|
+              (0.0 unless Pry::Helpers::Base.jruby?)].each do |val|
             pry_eval(val, "def hello; end");
             expect(val.class.instance_methods(false).map(&:to_sym).include?(:hello)).to eq true
           end

--- a/spec/pryrc_spec.rb
+++ b/spec/pryrc_spec.rb
@@ -26,7 +26,7 @@ describe Pry do
     end
 
     # Resolving symlinks doesn't work on jruby 1.9 [jruby issue #538]
-    unless Pry::Helpers::BaseHelpers.jruby_19?
+    unless Pry::Helpers::Base.jruby_19?
       it "should not load the rc file twice if it's symlinked differently" do
         Pry::HOME_RC_FILE.replace "spec/fixtures/testrc"
         Pry::LOCAL_RC_FILE.replace "spec/fixtures/testlinkrc"


### PR DESCRIPTION
Another attempt at #1682, rebased on latest master.

Thank you for the feedback on the original PR and apologies I did not get to it sooner (or reply). Hoping to shepherd this one through.

I took a similar approach here as the original PR:

 - Resolves #1676
 - Accomplished by renaming the helper modules (commit 1) by removing `Helper` suffix. I agree that the namespace implies the suffix :)
 - Searched project for `BaseHelpers|CommandHelpers|DocumentationHelpers|OptionsHelpers` and replaced each instance with the suffix-less version (commit 2).
 - Ran tests and ensured all still passed (thanks for the comprehensive tests!!)
 - Does not change `Pry::Helpers::Text` which was already non-repetitive
 - Does not change table helpers in `lib/pry/helpers/table.rb` as they were not in a `TableHelpers` submodule (might be worth addressing as `Pry::Helpers::Table` for consistency)
 - Also updates the changelog to mention this PR change (commit 3)

One thing this PR does not include yet is the request to add `deprecate_constant` as suggested in the last PR. To be honest I haven't used this feature yet so was unsure exactly how. Where should the `deprecate_method` be called? In the `Pry::Helpers` module? Happy to make a follow-up commit. I've also made sure "Allow edits from maintainers" so feel free to make the change yourself if it's easier.

Would a follow-up PR to make the table helpers consistent be welcome?

Thanks again.