### PR TITLE
Delete Pry::CommandSet#{before,after}_command

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -170,8 +170,6 @@ class Pry
 
       # @deprecated Replaced with {Pry::Hooks#add_hook}. Left for compatibility.
       # Store hooks to be run before or after the command body.
-      # @see Pry::CommandSet#before_command
-      # @see Pry::CommandSet#after_command
       def hooks
         Pry.hooks
       end

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -116,41 +116,6 @@ class Pry
       @commands[match]
     end
 
-    # Execute a block of code before a command is invoked. The block also
-    # gets access to parameters that will be passed to the command and
-    # is evaluated in the same context.
-    # @param [String, Regexp] search The match or listing of the command.
-    # @yield The block to be run before the command.
-    # @example Display parameter before invoking command
-    #   Pry.config.commands.before_command("whereami") do |n|
-    #     output.puts "parameter passed was #{n}"
-    #   end
-    # @deprecated Use {Pry::Hooks#add_hook} instead.
-    def before_command(search, &block)
-      cmd = find_command_by_match_or_listing(search)
-      cmd.hooks.add_hook("before_#{cmd.command_name}", random_hook_name, block)
-    end
-
-    # Execute a block of code after a command is invoked. The block also
-    # gets access to parameters that will be passed to the command and
-    # is evaluated in the same context.
-    # @param [String, Regexp] search The match or listing of the command.
-    # @yield The block to be run after the command.
-    # @example Display text 'command complete' after invoking command
-    #   Pry.config.commands.after_command("whereami") do |n|
-    #     output.puts "command complete!"
-    #   end
-    # @deprecated Use {Pry::Hooks#add_hook} instead.
-    def after_command(search, &block)
-      cmd = find_command_by_match_or_listing(search)
-      cmd.hooks.add_hook("after_#{cmd.command_name}", random_hook_name, block)
-    end
-
-    def random_hook_name
-      (0...8).map { ('a'..'z').to_a[rand(26)] }.join
-    end
-    private :random_hook_name
-
     def each(&block)
       @commands.each(&block)
     end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -45,34 +45,6 @@ describe "Pry::Command" do
       expect(mock_command(cmd).return).to eq 5
     end
 
-    context "deprecated API" do
-      it "should call hooks in the right order" do
-        cmd = @set.create_command 'marvin', "Pained by the diodes in his left side" do
-          def process
-            output.puts 1 + args[0].to_i
-          end
-        end
-
-        @set.before_command 'marvin' do |i|
-          output.puts 3 - i.to_i
-        end
-
-        @set.before_command 'marvin' do |i|
-          output.puts 4 - i.to_i
-        end
-
-        @set.after_command 'marvin' do |i|
-          output.puts 2 + i.to_i
-        end
-
-        @set.after_command 'marvin' do |i|
-          output.puts 3 + i.to_i
-        end
-
-        expect(mock_command(cmd, %w(2)).output).to eq "1\n2\n3\n4\n5\n"
-      end
-    end
-
     context "hooks API" do
       before do
         @set.create_command 'jamaica', 'Out of Many, One People' do
@@ -105,21 +77,6 @@ describe "Pry::Command" do
         out = pry_tester(hooks: hooks, commands: @set).process_command('jamaica 2')
         expect(out).to eq("1\n2\n3\n4\n5\n")
       end
-    end
-
-    # TODO: This strikes me as rather silly...
-    it 'should return the value from the last hook with keep_retval' do
-      cmd = @set.create_command 'slartibartfast', "Designs Fjords", keep_retval: true do
-        def process
-          22
-        end
-      end
-
-      @set.after_command 'slartibartfast' do
-        10
-      end
-
-      expect(mock_command(cmd).return).to eq 10
     end
   end
 


### PR DESCRIPTION
These commands have been deprecated for years. It's high time to get rid of them.