### PR TITLE
gemspec: bump require method_source >= 0.9.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,15 @@ jobs:
       - <<: *bundle_install
       - <<: *install_ubuntu_nano
       - <<: *unit
+  "jruby-9.2-jdk":
+    docker:
+      - image: circleci/jruby:9.2-jdk
+    working_directory: ~/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *install_ubuntu_nano
+      - <<: *unit
 
 workflows:
   version: 2
@@ -165,6 +174,10 @@ workflows:
             - rubocop_lint
             - yard_lint
       - "jruby-9.1-jdk":
+          requires:
+            - rubocop_lint
+            - yard_lint
+      - "jruby-9.2-jdk":
           requires:
             - rubocop_lint
             - yard_lint

--- a/pry.gemspec
+++ b/pry.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 require File.expand_path('../lib/pry/version', __FILE__)
 
 Gem::Specification.new do |s|
@@ -29,6 +28,6 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files bin lib *.md LICENSE`.split("\n")
 
   s.add_dependency 'coderay',       '~> 1.1.0'
-  s.add_dependency 'method_source', '~> 0.9.0'
+  s.add_dependency 'method_source', '>= 0.9.1'
   s.add_development_dependency 'bundler', '~> 1.0'
 end


### PR DESCRIPTION
Fixes #1804
(JRuby 9.2.0.0 breaks `source_location` and therefore our test suite)