### PR TITLE
repl: calculate JRuby overhang (or rather not)

### DIFF
--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -241,12 +241,19 @@ class Pry
     #   indicators in 99% of cases.
     def calculate_overhang(current_prompt, original_val, indented_val)
       overhang = original_val.length - indented_val.length
-      if readline_available? &&
-         # rb-readline doesn't support this method:
-         # https://github.com/ConnorAtherton/rb-readline/issues/152
-         Readline.respond_to?(:vi_editing_mode?) &&
-         Readline.vi_editing_mode?
-        overhang += current_prompt.length - indented_val.length
+
+      if readline_available? && Readline.respond_to?(:vi_editing_mode?)
+        begin
+          # rb-readline doesn't support this method:
+          # https://github.com/ConnorAtherton/rb-readline/issues/152
+          if Readline.vi_editing_mode?
+            overhang += current_prompt.length - indented_val.length
+          end
+        rescue NotImplementedError
+          # VI editing mode is unsupported on JRuby.
+          # https://github.com/pry/pry/issues/1840
+          nil
+        end
       end
       [0, overhang].max
     end


### PR DESCRIPTION
Fixes #1840
(NotImplementedError: vi_editing_mode?() function is unimplemented on this
machine)