### PR TITLE
helpers/base: properly backport deprecated methods

### DIFF
--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -1,6 +1,148 @@
 module Pry::Helpers; end
+
+# rubocop:disable Metrics/ModuleLength
 module Pry::Helpers::BaseHelpers
   extend self
+
+  @mac_osx_warn = false
+  # @deprecated Use {Pry::Helpers::Platform.mac_osx?} instead.
+  def mac_osx?
+    unless @mac_osx_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: method BaseHelpers##{__method__} " \
+        "is deprecated. Use Pry:Helpers::Platform.#{__method__} instead"
+      )
+      @mac_osx_warn = true
+    end
+    Pry::Helpers::Platform.mac_osx?
+  end
+
+  @linux_warn = false
+  # @deprecated Use {Pry::Helpers::Platform.mac_osx?} instead.
+  def linux?
+    unless @linux_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: method BaseHelpers##{__method__} " \
+        "is deprecated. Use Pry:Helpers::Platform.#{__method__} instead"
+      )
+      @linux_warn = true
+    end
+    Pry::Helpers::Platform.linux?
+  end
+
+  @windows_warn = false
+  # @deprecated Use {Pry::Helpers::Platform.windows?} instead.
+  def windows?
+    unless @windows_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: method BaseHelpers##{__method__} " \
+        "is deprecated. Use Pry:Helpers::Platform.#{__method__} instead"
+      )
+      @windows_warn = true
+    end
+    Pry::Helpers::Platform.windows?
+  end
+
+  @windows_ansi_warn = false
+  # @deprecated Use {Pry::Helpers::Platform.windows_ansi?} instead.
+  def windows_ansi?
+    unless @windows_ansi_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: method BaseHelpers##{__method__} " \
+        "is deprecated. Use Pry:Helpers::Platform.#{__method__} instead"
+      )
+      @windows_ansi_warn = true
+    end
+    Pry::Helpers::Platform.windows_ansi?
+  end
+
+  @jruby_warn = false
+  # @deprecated Use {Pry::Helpers::Platform.jruby?} instead.
+  def jruby?
+    unless @jruby_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: method BaseHelpers##{__method__} " \
+        "is deprecated. Use Pry:Helpers::Platform.#{__method__} instead"
+      )
+      @jruby_warn = true
+    end
+    Pry::Helpers::Platform.jruby?
+  end
+
+  @jruby19_warn = false
+  # @deprecated Use {Pry::Helpers::Platform.jruby_19?} instead.
+  def jruby_19?
+    unless @jruby19_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: method BaseHelpers##{__method__} " \
+        "is deprecated. Use Pry:Helpers::Platform.#{__method__} instead"
+      )
+      @jruby19_warn = true
+    end
+    Pry::Helpers::Platform.jruby_19?
+  end
+
+  @mri_warn = false
+  # @deprecated Use {Pry::Helpers::Platform.mri?} instead.
+  def mri?
+    unless @mri_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: method BaseHelpers##{__method__} " \
+        "is deprecated. Use Pry:Helpers::Platform.#{__method__} instead"
+      )
+      @mri_warn = true
+    end
+    Pry::Helpers::Platform.mri?
+  end
+
+  @mri19_warn = false
+  # @deprecated Use {Pry::Helpers::Platform.mri_19?} instead.
+  def mri_19?
+    unless @mri19_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: method BaseHelpers##{__method__} " \
+        "is deprecated. Use Pry:Helpers::Platform.#{__method__} instead"
+      )
+      @mri19_warn = true
+    end
+    Pry::Helpers::Platform.mri_19?
+  end
+
+  @mri2_warn = false
+  # @deprecated Use {Pry::Helpers::Platform.mri_2?} instead.
+  def mri_2?
+    unless @mri2_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: method BaseHelpers##{__method__} " \
+        "is deprecated. Use Pry:Helpers::Platform.#{__method__} instead"
+      )
+      @mri2_warn = true
+    end
+    Pry::Helpers::Platform.mri_2?
+  end
+
+  @known_engines_warn = false
+  # @deprecated This will be removed in the next release.
+  def known_engines
+    unless @known_engines_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: BaseHelpers.#{__method__} is " \
+        "deprecated and will be removed in the next Pry release"
+      )
+      @known_engines_warn = true
+    end
+    [:jruby, :mri]
+  end
 
   def silence_warnings
     old_verbose = $VERBOSE
@@ -69,3 +211,4 @@ module Pry::Helpers::BaseHelpers
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
The code is extremely ugly but this way people will have more time to update
their plugins. I'll revert this PR as soon as the new Pry version is out.