### PR TITLE
Backport certain methods for smother transition

### DIFF
--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -87,17 +87,33 @@ class Pry
     exec_hook(:when_started, target, options, self)
   end
 
+  @input_array_warn = false
   # @deprecated Use {#input_ring} instead.
   def input_array
-    warn "[DEPRECATED] '#{self.class.name}##{__method__}' is deprecated. " \
-         "Use '#{self.class.name}#input_ring' instead."
+    unless @input_array_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: method #{self.class}##{__method__} " \
+        "is deprecated. Use #{self.class}#input_ring instead"
+      )
+      @input_array_warn = true
+    end
+
     @input_ring
   end
 
+  @output_array_warn = false
   # @deprecated Use {#output_ring} instead.
   def output_array
-    warn "[DEPRECATED] '#{self.class.name}##{__method__}' is deprecated. " \
-         "Use '#{self.class.name}#output_ring' instead"
+    unless @output_array_warn
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: method #{self.class}##{__method__} " \
+        "is deprecated. Use #{self.class}#output_ring instead"
+      )
+      @output_array_warn = true
+    end
+
     @output_ring
   end
 

--- a/lib/pry/ring.rb
+++ b/lib/pry/ring.rb
@@ -24,6 +24,7 @@ class Pry
     # @return [Integer] how many objects were added during the lifetime of the
     #   ring
     attr_reader :count
+    alias size count
 
     # @param [Integer] max_size Maximum buffer size. The buffer will start
     #   overwriting elements once its reaches its maximum capacity


### PR DESCRIPTION
* ring: alias #count as #size

This is for backwards compatibility. Pry Rails uses `#size`:
https://github.com/rweng/pry-rails/blob/77f770f376077e37c69116dda39ff03ee7961f64/lib/pry-rails/prompt.rb#L23

* pry_instance: properly deprecate #{input,output}_array

Without this the warning will actually be printed on every line.