### PR TITLE
rubocop: fix offences regarding spaces

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -394,27 +394,6 @@ Layout/SpaceAfterSemicolon:
     - 'spec/commands/show_source_spec.rb'
     - 'spec/commands/whereami_spec.rb'
 
-# Offense count: 73
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceAroundEqualsInParameterDefault:
-  Enabled: false
-
-# Offense count: 38
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment.
-Layout/SpaceAroundOperators:
-  Enabled: false
-
-# Offense count: 117
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.
-# SupportedStyles: space, no_space
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceBeforeBlockBraces:
-  Enabled: false
-
 # Offense count: 8
 # Cop supports --auto-correct.
 Layout/SpaceBeforeComma:
@@ -459,14 +438,6 @@ Layout/SpaceInsideArrayLiteralBrackets:
 Layout/SpaceInsideArrayPercentLiteral:
   Exclude:
     - 'spec/helpers/table_spec.rb'
-
-# Offense count: 80
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.
-# SupportedStyles: space, no_space
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideBlockBraces:
-  Enabled: false
 
 # Offense count: 44
 # Cop supports --auto-correct.

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -54,7 +54,7 @@ class Pry
         self.option_processors = nil
       end
 
-      def parse_options(args=ARGV)
+      def parse_options(args = ARGV)
         unless options
           raise NoOptionsError, "No command line options defined! Use Pry::CLI.add_options to add command line options."
         end

--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -66,7 +66,7 @@ class Pry
       # @param [Integer, nil] start_line The line number to start on, or nil to
       #   use the method's original line numbers.
       # @return [Code]
-      def from_module(mod, candidate_rank = 0, start_line=nil)
+      def from_module(mod, candidate_rank = 0, start_line = nil)
         candidate = Pry::WrappedModule(mod).candidate(candidate_rank)
         start_line ||= candidate.line
         new(candidate.source, start_line, :ruby)
@@ -266,7 +266,7 @@ class Pry
 
     # Writes a formatted representation (based on the configuration of the
     # object) to the given output, which must respond to `#<<`.
-    def print_to_output(output, color=false)
+    def print_to_output(output, color = false)
       @lines.each do |loc|
         loc = loc.dup
         loc.colorize(@code_type)              if color
@@ -338,7 +338,7 @@ class Pry
     undef =~
 
     # Check whether String responds to missing methods.
-    def respond_to_missing?(name, include_all=false)
+    def respond_to_missing?(name, include_all = false)
       ''.respond_to?(name, include_all)
     end
 

--- a/lib/pry/code/loc.rb
+++ b/lib/pry/code/loc.rb
@@ -90,7 +90,7 @@ class Pry
 
       def handle_multiline_entries_from_edit_command(line, max_width)
         line.split("\n").map.with_index do |inner_line, i|
-          i.zero? ? inner_line : "#{' '* (max_width + 2)}#{inner_line}"
+          i.zero? ? inner_line : "#{' ' * (max_width + 2)}#{inner_line}"
         end.join("\n")
       end
     end

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -63,7 +63,7 @@ class Pry
     include Pry::Helpers::CommandHelpers
 
     class << self
-      def lookup(str, _pry_, options={})
+      def lookup(str, _pry_, options = {})
         co = new(str, _pry_, options)
 
         co.default_lookup || co.method_or_class_lookup ||
@@ -76,7 +76,7 @@ class Pry
     attr_accessor :_pry_
     attr_accessor :super_level
 
-    def initialize(str, _pry_, options={})
+    def initialize(str, _pry_, options = {})
       options = {
         super: 0,
       }.merge!(options)

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -23,7 +23,7 @@ class Pry
       attr_writer :command_options
       attr_writer :match
 
-      def match(arg=nil)
+      def match(arg = nil)
         if arg
           @command_options ||= default_options(arg)
           @command_options[:listing] = arg.is_a?(String) ? arg : arg.inspect
@@ -33,13 +33,13 @@ class Pry
       end
 
       # Define or get the command's description
-      def description(arg=nil)
+      def description(arg = nil)
         @description = arg if arg
         @description ||= nil
       end
 
       # Define or get the command's options
-      def command_options(arg=nil)
+      def command_options(arg = nil)
         @command_options ||= default_options(match)
         @command_options.merge!(arg) if arg
         @command_options
@@ -49,7 +49,7 @@ class Pry
       alias_method :options=, :command_options=
 
       # Define or get the command's banner
-      def banner(arg=nil)
+      def banner(arg = nil)
         @banner = arg if arg
         @banner ||= description
       end
@@ -194,7 +194,7 @@ class Pry
       # This is usually auto-generated from directory naming, but it can be
       # manually overridden if necessary.
       # Group should not be changed once it is initialized.
-      def group(name=nil)
+      def group(name = nil)
         @group ||= if name
                      name
                    else
@@ -274,7 +274,7 @@ class Pry
 
     # Instantiate a command, in preparation for calling it.
     # @param [Hash] context The runtime context to use with this command.
-    def initialize(context={})
+    def initialize(context = {})
       self.context      = context
       self.target       = context[:target]
       self.output       = context[:output]

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -75,7 +75,7 @@ class Pry
     #   # hello john, nice number: 10
     #   # pry(main)> help number
     #   # number-N regex command
-    def block_command(match, description="No description.", options={}, &block)
+    def block_command(match, description = "No description.", options = {}, &block)
       description, options = ["No description.", description] if description.is_a?(Hash)
       options = Pry::Command.default_options(match).merge!(options)
 
@@ -107,7 +107,7 @@ class Pry
     #     end
     #   end
     #
-    def create_command(match, description="No description.", options={}, &block)
+    def create_command(match, description = "No description.", options = {}, &block)
       description, options = ["No description.", description] if description.is_a?(Hash)
       options = Pry::Command.default_options(match).merge!(options)
 
@@ -210,7 +210,7 @@ class Pry
     #   command description to be passed this way too.
     # @example Renaming the `ls` command and changing its description.
     #   Pry.config.commands.rename "dir", "ls", :description => "DOS friendly ls"
-    def rename_command(new_match, search, options={})
+    def rename_command(new_match, search, options = {})
       cmd = find_command_by_match_or_listing(search)
 
       options = {
@@ -225,7 +225,7 @@ class Pry
       @commands.delete(cmd.match)
     end
 
-    def disabled_command(name_of_disabled_command, message, matcher=name_of_disabled_command)
+    def disabled_command(name_of_disabled_command, message, matcher = name_of_disabled_command)
       create_command name_of_disabled_command do
         match matcher
         description ""
@@ -247,7 +247,7 @@ class Pry
     #   end
     # @example Getting
     #   Pry.config.commands.desc "amend-line"
-    def desc(search, description=nil)
+    def desc(search, description = nil)
       cmd = find_command_by_match_or_listing(search)
       return cmd.description if !description
 
@@ -359,7 +359,7 @@ class Pry
     # @param [String] val The line to execute
     # @param [Hash] context The context to execute the commands with
     # @return [CommandSet::Result]
-    def process_line(val, context={})
+    def process_line(val, context = {})
       if (command = find_command(val))
         context = context.merge(command_set: self)
         retval = command.new(context).process_line(val)
@@ -379,13 +379,13 @@ class Pry
     # @param [String] search The line to search for
     # @param [Hash] context  The context to create the command with
     # @return [Array<String>]
-    def complete(search, context={})
+    def complete(search, context = {})
       if (command = find_command(search))
         command.new(context).complete(search)
       else
         @commands.keys.select do |key|
           String === key && key.start_with?(search)
-        end.map{ |key| key + " " }
+        end.map { |key| key + " " }
       end
     end
   end

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -173,7 +173,7 @@ class Pry
       opts.present?(:'no-reload') || _pry_.config.disable_auto_reload
     end
 
-    def reload?(file_name="")
+    def reload?(file_name = "")
       (reloadable? || file_name.end_with?(".rb")) && !never_reload?
     end
 

--- a/lib/pry/commands/find_method.rb
+++ b/lib/pry/commands/find_method.rb
@@ -75,7 +75,7 @@ class Pry
     # @param [Array<Method>] matches
     def print_matches(matches)
       grouped = matches.group_by(&:owner)
-      order = grouped.keys.sort_by{ |x| x.name || x.to_s }
+      order = grouped.keys.sort_by { |x| x.name || x.to_s }
 
       order.each do |klass|
         print_matches_for_class(klass, grouped)
@@ -102,7 +102,7 @@ class Pry
     end
 
     def matched_method_lines(header, method)
-      method.source.split(/\n/).select {|x| x =~ pattern }.join("\n#{' ' * header.length}")
+      method.source.split(/\n/).select { |x| x =~ pattern }.join("\n#{' ' * header.length}")
     end
 
     # Run the given block against every constant in the provided namespace.
@@ -111,7 +111,7 @@ class Pry
     # @param [Hash<Module,Boolean>] done The namespaces we've already visited (private)
     # @yieldparam klass Each class/module in the namespace.
     #
-    def recurse_namespace(klass, done={}, &block)
+    def recurse_namespace(klass, done = {}, &block)
       return if !(Module === klass) || done[klass]
 
       done[klass] = true
@@ -142,7 +142,7 @@ class Pry
     # @return [Array<Method>]
     #
     def search_all_methods(namespace)
-      done = Hash.new{ |h,k| h[k] = {} }
+      done = Hash.new { |h,k| h[k] = {} }
       matches = []
 
       recurse_namespace(namespace) do |klass|

--- a/lib/pry/commands/gem_search.rb
+++ b/lib/pry/commands/gem_search.rb
@@ -31,9 +31,9 @@ class Pry::Command::GemSearch < Pry::ClassCommand
 
 private
   def list_as_string(gems, limit = 10)
-    gems[0..limit-1].map do |gem|
+    gems[0..limit - 1].map do |gem|
       name, version, info = gem.values_at 'name', 'version', 'info'
-      "#{bold(name)} #{bold('v'+version)} \n#{info}\n\n"
+      "#{bold(name)} #{bold('v' + version)} \n#{info}\n\n"
     end.join
   end
   Pry::Commands.add_command(self)

--- a/lib/pry/commands/help.rb
+++ b/lib/pry/commands/help.rb
@@ -75,7 +75,7 @@ class Pry
     # @param [Array<Pry::Command>] commands The commands to sort
     # @return [Array<Pry::Command>] commands sorted by listing name.
     def sorted_commands(commands)
-      commands.sort_by{ |command| command.options[:listing].to_s }
+      commands.sort_by { |command| command.options[:listing].to_s }
     end
 
     # Display help for an individual command or group.

--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -81,7 +81,7 @@ class Pry
       mod.number_of_candidates.times do |v|
         candidate = mod.candidate(v)
         begin
-          result << "\nCandidate #{v+1}/#{mod.number_of_candidates}: #{candidate.source_file} @ line #{candidate.source_line}:\n"
+          result << "\nCandidate #{v + 1}/#{mod.number_of_candidates}: #{candidate.source_file} @ line #{candidate.source_line}:\n"
           content = content_for(candidate)
 
           result << "Number of lines: #{content.lines.count}\n\n" << content

--- a/lib/pry/commands/watch_expression.rb
+++ b/lib/pry/commands/watch_expression.rb
@@ -54,8 +54,8 @@ class Pry
 
     def delete(index)
       if index
-        output.puts "Deleting watch expression ##{index}: #{expressions[index-1]}"
-        expressions.delete_at(index-1)
+        output.puts "Deleting watch expression ##{index}: #{expressions[index - 1]}"
+        expressions.delete_at(index - 1)
       else
         output.puts "Deleting all watched expressions"
         expressions.clear
@@ -70,7 +70,7 @@ class Pry
           pager.puts "Listing all watched expressions:"
           pager.puts ""
           expressions.each_with_index do |expr, index|
-            pager.print with_line_numbers(expr.to_s, index+1)
+            pager.print with_line_numbers(expr.to_s, index + 1)
           end
           pager.puts ""
         end

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -164,7 +164,7 @@ class Pry
       def eager_load!
         default = @default
         while default
-          default.memoized_methods.each {|method| self[key] = default.public_send(key)} if default.respond_to?(:memoized_methods)
+          default.memoized_methods.each { |method| self[key] = default.public_send(key) } if default.respond_to?(:memoized_methods)
           default = @default.default
         end
       end
@@ -208,7 +208,7 @@ class Pry
         end
       end
 
-      def respond_to_missing?(key, include_all=false)
+      def respond_to_missing?(key, include_all = false)
         key = key.to_s.chomp(ASSIGNMENT)
         key?(key) or @default.respond_to?(key) or super(key, include_all)
       end

--- a/lib/pry/config/memoization.rb
+++ b/lib/pry/config/memoization.rb
@@ -1,7 +1,7 @@
 class Pry
   class Config < Pry::BasicObject
     module Memoization
-      MEMOIZED_METHODS = Hash.new {|h,k| h[k] = [] }
+      MEMOIZED_METHODS = Hash.new { |h,k| h[k] = [] }
 
       module ClassMethods
         #

--- a/lib/pry/core_extensions.rb
+++ b/lib/pry/core_extensions.rb
@@ -38,7 +38,7 @@ class Object
   #   end
   #   my_method()
   # @see Pry.start
-  def pry(object=nil, hash={})
+  def pry(object = nil, hash = {})
     if object.nil? || Hash === object
       Pry.start(self, object || {})
     else
@@ -81,7 +81,7 @@ class Object
       # This fixes the following two spec failures, at https://travis-ci.org/pry/pry/jobs/274470002
       # 1) ./spec/pry_spec.rb:360:in `block in (root)'
       # 2) ./spec/pry_spec.rb:366:in `block in (root)'
-      return class_eval {binding} if Pry::Helpers::Platform.jruby? and self.name == nil
+      return class_eval { binding } if Pry::Helpers::Platform.jruby? and self.name == nil
 
       # class_eval sets both self and the default definee to this class.
       return class_eval("binding")

--- a/lib/pry/editor.rb
+++ b/lib/pry/editor.rb
@@ -8,7 +8,7 @@ class Pry
       @_pry_ = _pry_
     end
 
-    def edit_tempfile_with_content(initial_content, line=1)
+    def edit_tempfile_with_content(initial_content, line = 1)
       temp_file do |f|
         f.puts(initial_content)
         f.flush
@@ -18,7 +18,7 @@ class Pry
       end
     end
 
-    def invoke_editor(file, line, blocking=true)
+    def invoke_editor(file, line, blocking = true)
       raise CommandError, "Please set Pry.config.editor or export $VISUAL or $EDITOR" unless _pry_.config.editor
 
       editor_invocation = build_editor_invocation_string(file, line, blocking)

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -176,7 +176,7 @@ module Pry::Helpers::BaseHelpers
     CodeRay.scan(code, :ruby).term
   end
 
-  def highlight(string, regexp, highlight_color=:bright_yellow)
+  def highlight(string, regexp, highlight_color = :bright_yellow)
     string.gsub(regexp) { |match| "<#{highlight_color}>#{match}</#{highlight_color}>" }
   end
 

--- a/lib/pry/helpers/command_helpers.rb
+++ b/lib/pry/helpers/command_helpers.rb
@@ -8,7 +8,7 @@ class Pry
 
       # Open a temp file and yield it to the block, closing it after
       # @return [String] The path of the temp file
-      def temp_file(ext='.rb')
+      def temp_file(ext = '.rb')
         file = Tempfile.new(['pry', ext])
         yield file
       ensure
@@ -21,7 +21,7 @@ class Pry
         ["__binding__", "__pry__", "class_eval"].include?(m)
       end
 
-      def get_method_or_raise(name, target, opts={}, omit_help=false)
+      def get_method_or_raise(name, target, opts = {}, omit_help = false)
         meth = Pry::Method.from_str(name, target, opts)
 
         if name && !meth
@@ -44,7 +44,7 @@ class Pry
         meth
       end
 
-      def command_error(message, omit_help, klass=CommandError)
+      def command_error(message, omit_help, klass = CommandError)
         message += " Type `#{command_name} --help` for help." unless omit_help
         raise klass, message
       end
@@ -142,7 +142,7 @@ class Pry
         Range.new(a, b)
       end
 
-      def set_file_and_dir_locals(file_name, _pry_=_pry_(), target=target())
+      def set_file_and_dir_locals(file_name, _pry_ = _pry_(), target = target())
         return if !target or !file_name
 
         _pry_.last_file = File.expand_path(file_name)

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -41,7 +41,7 @@ class Pry
       end
 
       def rows_to_s style = :color_on
-        widths = columns.map{|e| _max_width(e)}
+        widths = columns.map { |e| _max_width(e) }
         @rows_without_colors.map do |r|
           padded = []
           r.each_with_index do |e,i|
@@ -98,10 +98,10 @@ class Pry
         @rows_without_colors = []
         return if items.size.zero?
 
-        row_count = (items.size.to_f/column_count).ceil
+        row_count = (items.size.to_f / column_count).ceil
         row_count.times do |i|
-          row_indices = (0...column_count).map{|e| row_count*e+i}
-          @rows_without_colors << row_indices.map{|e| @plain_items[e]}
+          row_indices = (0...column_count).map { |e| row_count * e + i }
+          @rows_without_colors << row_indices.map { |e| @plain_items[e] }
         end
       end
 

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -18,11 +18,11 @@ class Pry
 
       COLORS.each_pair do |color, value|
         define_method color do |text|
-          "\033[0;#{30+value}m#{text}\033[0m"
+          "\033[0;#{30 + value}m#{text}\033[0m"
         end
 
         define_method "bright_#{color}" do |text|
-          "\033[1;#{30+value}m#{text}\033[0m"
+          "\033[1;#{30 + value}m#{text}\033[0m"
         end
 
         COLORS.each_pair do |bg_color, bg_value|
@@ -94,7 +94,7 @@ class Pry
       # @param  [#each_line] text
       # @param  [Fixnum] offset
       # @return [String]
-      def with_line_numbers(text, offset, color=:blue)
+      def with_line_numbers(text, offset, color = :blue)
         lines = text.each_line.to_a
         max_width = (offset + lines.count).to_s.length
         lines.each_with_index.map do |line, index|

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -7,7 +7,7 @@ class Pry
     # @return [Fixnum] Number of lines in history when Pry first loaded.
     attr_reader :original_lines
 
-    def initialize(options={})
+    def initialize(options = {})
       @history = []
       @original_lines = 0
       @file_path = options[:file_path]
@@ -25,8 +25,8 @@ class Pry
         @pusher  = method(:push_to_readline)
         @clearer = method(:clear_readline)
       else
-        @pusher  = proc { }
-        @clearer = proc { }
+        @pusher  = proc {}
+        @clearer = proc {}
       end
     end
 

--- a/lib/pry/hooks.rb
+++ b/lib/pry/hooks.rb
@@ -65,7 +65,7 @@ class Pry
     # @param [#call] callable The callable.
     # @yield The block to use as the callable (if no `callable` provided).
     # @return [Pry:Hooks] The receiver.
-    def add_hook(event_name, hook_name, callable=nil, &block)
+    def add_hook(event_name, hook_name, callable = nil, &block)
       event_name = event_name.to_s
 
       # do not allow duplicates, but allow multiple `nil` hooks

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -145,7 +145,7 @@ class Pry
       input.lines.each do |line|
         if in_string?
           tokens = tokenize("#{open_delimiters_line}\n#{line}")
-          tokens = tokens.drop_while{ |token, type| !(String === token && token.include?("\n")) }
+          tokens = tokens.drop_while { |token, type| !(String === token && token.include?("\n")) }
           previously_in_string = true
         else
           tokens = tokenize(line)
@@ -154,7 +154,7 @@ class Pry
 
         before, after = indentation_delta(tokens)
 
-        before.times{ prefix.sub! SPACES, '' }
+        before.times { prefix.sub! SPACES, '' }
         new_prefix = prefix + SPACES * after
 
         line = prefix + line.lstrip unless previously_in_string
@@ -357,7 +357,7 @@ class Pry
     #
     # @param [String] token  a token from Coderay
     # @param [Symbol] kind  the kind of that token
-    def track_module_nesting_end(token, kind=:keyword)
+    def track_module_nesting_end(token, kind = :keyword)
       if kind == :keyword && (token == "class" || token == "module")
         @module_nesting.pop
       end

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -92,7 +92,7 @@ class Pry::InputCompleter
       when SYMBOL_REGEXP # Symbol
         if Symbol.respond_to?(:all_symbols)
           sym        = Regexp.quote($1)
-          candidates = Symbol.all_symbols.collect{|s| ":" << s.id2name}
+          candidates = Symbol.all_symbols.collect { |s| ":" << s.id2name }
           candidates.grep(/^#{sym}/)
         else
           []
@@ -100,7 +100,7 @@ class Pry::InputCompleter
       when TOPLEVEL_LOOKUP_REGEXP # Absolute Constant or class methods
         receiver = $1
         candidates = Object.constants.collect(&:to_s)
-        candidates.grep(/^#{receiver}/).collect{|e| "::" << e}
+        candidates.grep(/^#{receiver}/).collect { |e| "::" << e }
       when CONSTANT_REGEXP # Constant
         message = $1
         begin
@@ -120,7 +120,7 @@ class Pry::InputCompleter
         rescue Pry::RescuableException
           candidates = []
         end
-        candidates.grep(/^#{message}/).collect{|e| receiver + "::" + e}
+        candidates.grep(/^#{message}/).collect { |e| receiver + "::" + e }
       when SYMBOL_METHOD_CALL_REGEXP # method call on a Symbol
         receiver = $1
         message = Regexp.quote($2)
@@ -170,7 +170,7 @@ class Pry::InputCompleter
           require 'set'
           candidates = Set.new
           to_ignore = ignored_modules
-          ObjectSpace.each_object(Module){|m|
+          ObjectSpace.each_object(Module) { |m|
             next if (to_ignore.include?(m) rescue true)
 
             # jruby doesn't always provide #instance_methods() on each
@@ -197,7 +197,7 @@ class Pry::InputCompleter
         if eval("respond_to?(:class_variables)", bind)
           candidates += eval("class_variables", bind).collect(&:to_s)
         end
-        candidates = (candidates|ReservedWords|custom_completions).grep(/^#{Regexp.quote(input)}/)
+        candidates = (candidates | ReservedWords | custom_completions).grep(/^#{Regexp.quote(input)}/)
         candidates.collect(&path)
       end
     rescue Pry::RescuableException
@@ -222,7 +222,7 @@ class Pry::InputCompleter
   # path is a proc that takes an input and builds a full path.
   def build_path(input)
     # check to see if the input is a regex
-    return proc {|i| i.to_s }, input if input[/\/\./]
+    return proc { |i| i.to_s }, input if input[/\/\./]
 
     trailing_slash = input.end_with?('/')
     contexts = input.chomp('/').split(/\//)

--- a/lib/pry/last_exception.rb
+++ b/lib/pry/last_exception.rb
@@ -23,7 +23,7 @@ class Pry::LastException < BasicObject
     end
   end
 
-  def respond_to_missing?(name, include_all=false)
+  def respond_to_missing?(name, include_all = false)
     @e.respond_to?(name, include_all)
   end
 

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -39,7 +39,7 @@ class Pry
       #   contain any context.
       # @return [Pry::Method, nil] A `Pry::Method` instance containing the requested
       #   method, or `nil` if name is `nil` or no method could be located matching the parameters.
-      def from_str(name, target=TOPLEVEL_BINDING, options={})
+      def from_str(name, target = TOPLEVEL_BINDING, options = {})
         if name.nil?
           nil
         elsif name.to_s =~ /(.+)\#(\S+)\Z/
@@ -101,7 +101,7 @@ class Pry
       # @param [Symbol] method_type The type of method: :method or :instance_method
       # @param [Binding] target The binding where the method is looked up.
       # @return [Method, UnboundMethod] The 'refined' method object.
-      def lookup_method_via_binding(obj, method_name, method_type, target=TOPLEVEL_BINDING)
+      def lookup_method_via_binding(obj, method_name, method_type, target = TOPLEVEL_BINDING)
         Pry.current[:obj] = obj
         Pry.current[:name] = method_name
         receiver = obj.is_a?(Module) ? "Module" : "Kernel"
@@ -118,7 +118,7 @@ class Pry
       # @param [String] name
       # @param [Binding] target The binding where the method is looked up.
       # @return [Pry::Method, nil]
-      def from_class(klass, name, target=TOPLEVEL_BINDING)
+      def from_class(klass, name, target = TOPLEVEL_BINDING)
         new(lookup_method_via_binding(klass, name, :instance_method, target)) rescue nil
       end
       alias from_module from_class
@@ -131,7 +131,7 @@ class Pry
       # @param [String] name
       # @param [Binding] target The binding where the method is looked up.
       # @return [Pry::Method, nil]
-      def from_obj(obj, name, target=TOPLEVEL_BINDING)
+      def from_obj(obj, name, target = TOPLEVEL_BINDING)
         new(lookup_method_via_binding(obj, name, :method, target)) rescue nil
       end
 
@@ -139,7 +139,7 @@ class Pry
       # @param [Class,Module] klass
       # @param [Boolean] include_super Whether to include methods from ancestors.
       # @return [Array[Pry::Method]]
-      def all_from_class(klass, include_super=true)
+      def all_from_class(klass, include_super = true)
         %w(public protected private).flat_map do |visibility|
           safe_send(klass, :"#{visibility}_instance_methods", include_super).map do |method_name|
             new(safe_send(klass, :instance_method, method_name), visibility: visibility.to_sym)
@@ -157,7 +157,7 @@ class Pry
       #
       # @return [Array[Pry::Method]]
       #
-      def all_from_obj(obj, include_super=true)
+      def all_from_obj(obj, include_super = true)
         all_from_class(singleton_class_of(obj), include_super)
       end
 
@@ -166,7 +166,7 @@ class Pry
       #  please use {all_from_obj} instead.
       #  the `method_type` argument is ignored.
       #
-      def all_from_common(obj, _method_type = nil, include_super=true)
+      def all_from_common(obj, _method_type = nil, include_super = true)
         all_from_obj(obj, include_super)
       end
 
@@ -233,7 +233,7 @@ class Pry
     # @param [::Method, UnboundMethod, Proc] method
     # @param [Hash] known_info Can be used to pre-cache expensive to compute stuff.
     # @return [Pry::Method]
-    def initialize(method, known_info={})
+    def initialize(method, known_info = {})
       @method = method
       @visibility = known_info[:visibility]
     end
@@ -384,7 +384,7 @@ class Pry
 
     # @return [Pry::Method, nil] The wrapped method that is called when you
     #   use "super" in the body of this method.
-    def super(times=1)
+    def super(times = 1)
       if UnboundMethod === @method
         sup = super_using_ancestors(Pry::Method.instance_resolution_order(owner), times)
       else
@@ -467,7 +467,7 @@ class Pry
 
     # @param [String, Symbol] method_name
     # @return [Boolean]
-    def respond_to?(method_name, include_all=false)
+    def respond_to?(method_name, include_all = false)
       super or @method.respond_to?(method_name, include_all)
     end
 
@@ -498,7 +498,7 @@ class Pry
 
     # @param [Class, Module] ancestors The ancestors to investigate
     # @return [Method] The unwrapped super-method
-    def super_using_ancestors(ancestors, times=1)
+    def super_using_ancestors(ancestors, times = 1)
       next_owner = self.owner
       times.times do
         i = ancestors.index(next_owner) + 1

--- a/lib/pry/method/patcher.rb
+++ b/lib/pry/method/patcher.rb
@@ -113,7 +113,7 @@ class Pry
       def wrap_for_nesting(source)
         nesting = Pry::Code.from_file(method.source_file).nesting_at(method.source_line)
 
-        (nesting + [source] + nesting.map{ "end" } + [""]).join(";")
+        (nesting + [source] + nesting.map { "end" } + [""]).join(";")
       rescue Pry::Indent::UnparseableNestingError
         source
       end

--- a/lib/pry/method/weird_method_locator.rb
+++ b/lib/pry/method/weird_method_locator.rb
@@ -65,7 +65,7 @@ class Pry
 
       def skip_superclass_search?
         target_mod = @target.eval('self').class
-        target_mod.ancestors.take_while {|mod| mod != target_mod }.any?
+        target_mod.ancestors.take_while { |mod| mod != target_mod }.any?
       end
 
       def normal_method?(method)

--- a/lib/pry/output.rb
+++ b/lib/pry/output.rb
@@ -36,7 +36,7 @@ class Pry::Output
     @boxed_io.__send__(name, *args, &block)
   end
 
-  def respond_to_missing?(m, include_all=false)
+  def respond_to_missing?(m, include_all = false)
     @boxed_io.respond_to?(m, include_all)
   end
 

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -117,7 +117,7 @@ class Pry
   # Trap interrupts on jruby, and make them behave like MRI so we can
   # catch them.
   def self.load_traps
-    trap('INT'){ raise Interrupt }
+    trap('INT') { raise Interrupt }
   end
 
   def self.load_win32console
@@ -166,7 +166,7 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
   # @option options (see Pry#initialize)
   # @example
   #   Pry.start(Object.new, :input => MyInput.new)
-  def self.start(target=nil, options={})
+  def self.start(target = nil, options = {})
     return if ENV['DISABLE_PRY']
     if ENV['FAIL_PRY']
       raise 'You have FAIL_PRY set to true, which results in Pry calls failing'
@@ -275,7 +275,7 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
   #   Pry.run_command "ls -m", :target => Pry
   # @example Display command output.
   #   Pry.run_command "ls -av", :show_output => true
-  def self.run_command(command_string, options={})
+  def self.run_command(command_string, options = {})
     options = {
       target: TOPLEVEL_BINDING,
       show_output: true,

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -68,7 +68,7 @@ class Pry
   #   The backtrace of the session's `binding.pry` line, if applicable.
   # @option options [Object] :target
   #   The initial context for this session.
-  def initialize(options={})
+  def initialize(options = {})
     @binding_stack = []
     @indent        = Pry::Indent.new
     @command_state = {}
@@ -133,7 +133,7 @@ class Pry
 
   # Initialize this instance by pushing its initial context into the binding
   # stack. If no target is given, start at the top level.
-  def push_initial_binding(target=nil)
+  def push_initial_binding(target = nil)
     push_binding(target || Pry.toplevel_binding)
   end
 
@@ -265,7 +265,7 @@ class Pry
   # @return [Boolean] Is Pry ready to accept more input?
   # @raise [Exception] If the user uses the `raise-up` command, this method
   #   will raise that exception.
-  def eval(line, options={})
+  def eval(line, options = {})
     return false if @stopped
 
     exit_value = nil
@@ -511,7 +511,7 @@ class Pry
   # This method should not need to be invoked directly.
   # @param [Object] result The result.
   # @param [String] code The code that was run.
-  def set_last_result(result, code="")
+  def set_last_result(result, code = "")
     @last_result_is_exception = false
     @output_ring << result
 

--- a/lib/pry/rubygem.rb
+++ b/lib/pry/rubygem.rb
@@ -23,7 +23,7 @@ class Pry
                   Gem.source_index.find_name(name)
                 end
 
-        first_spec = specs.sort_by{ |spec| Gem::Version.new(spec.version) }.last
+        first_spec = specs.sort_by { |spec| Gem::Version.new(spec.version) }.last
 
         first_spec or raise CommandError, "Gem `#{name}` not found"
       end
@@ -34,9 +34,9 @@ class Pry
       # @return [Array<Gem::Specification>]
       def list(pattern = /.*/)
         if Gem::Specification.respond_to?(:each)
-          Gem::Specification.select{|spec| spec.name =~ pattern }
+          Gem::Specification.select { |spec| spec.name =~ pattern }
         else
-          Gem.source_index.gems.values.select{|spec| spec.name =~ pattern }
+          Gem.source_index.gems.values.select { |spec| spec.name =~ pattern }
         end
       end
 

--- a/lib/pry/slop.rb
+++ b/lib/pry/slop.rb
@@ -330,7 +330,7 @@ class Pry::Slop
   # Override this method so we can check if an option? method exists.
   #
   # Returns true if this option key exists in our list of options.
-  def respond_to_missing?(method_name, include_all=false)
+  def respond_to_missing?(method_name, include_all = false)
     options.any? { |o| o.key == method_name.to_s.chop } || super
   end
 

--- a/lib/pry/testable/mockable.rb
+++ b/lib/pry/testable/mockable.rb
@@ -1,5 +1,5 @@
 module Pry::Testable::Mockable
-  def mock_command(cmd, args=[], opts={})
+  def mock_command(cmd, args = [], opts = {})
     output = StringIO.new
     pry = Pry.new(output: output)
     ret = cmd.new(opts.merge(pry_instance: pry, output: output)).call_safely(*args)

--- a/lib/pry/testable/utility.rb
+++ b/lib/pry/testable/utility.rb
@@ -7,7 +7,7 @@ module Pry::Testable::Utility
   #
   # @return [void]
   #
-  def temp_file(ext='.rb')
+  def temp_file(ext = '.rb')
     file = Tempfile.open(['pry', ext])
     yield file
   ensure
@@ -20,7 +20,7 @@ module Pry::Testable::Utility
 
   def inner_scope
     catch(:inner_scope) do
-      yield ->{ throw(:inner_scope, self) }
+      yield -> { throw(:inner_scope, self) }
     end
   end
 end

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -26,7 +26,7 @@ class Pry
     # @return [Module, nil] The module or `nil` (if conversion failed).
     # @example
     #   Pry::WrappedModule.from_str("Pry::Code")
-    def self.from_str(mod_name, target=TOPLEVEL_BINDING)
+    def self.from_str(mod_name, target = TOPLEVEL_BINDING)
       if safe_to_evaluate?(mod_name, target)
         Pry::WrappedModule.new(target.eval(mod_name))
       else
@@ -139,7 +139,7 @@ class Pry
       if Helpers::Platform.jruby?
         wrapped.to_java.attached
       else
-        @singleton_instance ||= ObjectSpace.each_object(wrapped).detect{ |x| (class << x; self; end) == wrapped }
+        @singleton_instance ||= ObjectSpace.each_object(wrapped).detect { |x| (class << x; self; end) == wrapped }
       end
     end
 
@@ -148,7 +148,7 @@ class Pry
       wrapped.send(method_name, *args, &block)
     end
 
-    def respond_to?(method_name, include_all=false)
+    def respond_to?(method_name, include_all = false)
       super || wrapped.respond_to?(method_name, include_all)
     end
 
@@ -265,7 +265,7 @@ class Pry
     #   When `self` is a `Module` then return the
     #   nth ancestor, otherwise (in the case of classes) return the
     #   nth ancestor that is a class.
-    def super(times=1)
+    def super(times = 1)
       return self if times.zero?
 
       if wrapped.is_a?(Class)
@@ -313,7 +313,7 @@ class Pry
       @all_source_locations_by_popularity = ims.group_by { |v| Array(v.source_location).first }.
         sort_by do |path, methods|
           expanded = File.expand_path(path)
-          load_order = $LOADED_FEATURES.index{ |file| expanded.end_with?(file) }
+          load_order = $LOADED_FEATURES.index { |file| expanded.end_with?(file) }
 
           [-methods.size, load_order || (1.0 / 0.0)]
         end

--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -10,7 +10,7 @@ describe "commands" do
     @bs2 = "Pad.bs2 = _pry_.binding_stack.dup"
     @bs3 = "Pad.bs3 = _pry_.binding_stack.dup"
 
-    @self  = "Pad.self = self"
+    @self = "Pad.self = self"
 
     @command_tester = Pry::CommandSet.new do
       command "command1", "command 1 test" do

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -371,7 +371,7 @@ describe Pry::CommandSet do
     end
 
     it 'should make old command name inaccessible' do
-      @set.command('foo') { }
+      @set.command('foo') {}
       @set.rename_command('bar', 'foo')
       expect { @set.run_command(@ctx, 'foo') }.to raise_error Pry::NoCommandError
     end
@@ -379,7 +379,7 @@ describe Pry::CommandSet do
     it 'should be able to pass in options when renaming command' do
       desc    = "hello"
       listing = "bing"
-      @set.command('foo') { }
+      @set.command('foo') {}
       @set.rename_command('bar', 'foo', description: desc, listing: listing, keep_retval: true)
       expect(@set['bar'].description).to           eq desc
       expect(@set['bar'].options[:listing]).to     eq listing
@@ -495,44 +495,44 @@ describe Pry::CommandSet do
 
   describe 'find_command' do
     it 'should find commands with the right string' do
-      cmd = @set.command('rincewind'){ }
+      cmd = @set.command('rincewind') {}
       expect(@set.find_command('rincewind')).to eq cmd
     end
 
     it 'should not find commands with spaces before' do
-      @set.command('luggage'){ }
+      @set.command('luggage') {}
       expect(@set.find_command(' luggage')).to eq nil
     end
 
     it 'should find commands with arguments after' do
-      cmd = @set.command('vetinari'){ }
+      cmd = @set.command('vetinari') {}
       expect(@set.find_command('vetinari --knock 3')).to eq cmd
     end
 
     it 'should find commands with names containing spaces' do
-      cmd = @set.command('nobby nobbs'){ }
+      cmd = @set.command('nobby nobbs') {}
       expect(@set.find_command('nobby nobbs --steal petty-cash')).to eq cmd
     end
 
     it 'should find command defined by regex' do
-      cmd = @set.command(/(capt|captain) vimes/i){ }
+      cmd = @set.command(/(capt|captain) vimes/i) {}
       expect(@set.find_command('Capt Vimes')).to eq cmd
     end
 
     it 'should find commands defined by regex with arguments' do
-      cmd = @set.command(/(cpl|corporal) Carrot/i){ }
+      cmd = @set.command(/(cpl|corporal) Carrot/i) {}
       expect(@set.find_command('cpl carrot --write-home')).to eq cmd
     end
 
     it 'should not find commands by listing' do
-      @set.command(/werewol(f|ve)s?/, 'only once a month', listing: "angua"){ }
+      @set.command(/werewol(f|ve)s?/, 'only once a month', listing: "angua") {}
       expect(@set.find_command('angua')).to eq nil
     end
 
     it 'should not find commands without command_prefix' do
       begin
         Pry.config.command_prefix = '%'
-        @set.command('detritus'){ }
+        @set.command('detritus') {}
         expect(@set.find_command('detritus')).to eq nil
       ensure
         Pry.config.command_prefix = ''
@@ -542,7 +542,7 @@ describe Pry::CommandSet do
     it "should find commands that don't use the prefix" do
       begin
         Pry.config.command_prefix = '%'
-        cmd = @set.command('colon', 'Sergeant Fred', use_prefix: false){ }
+        cmd = @set.command('colon', 'Sergeant Fred', use_prefix: false) {}
         expect(@set.find_command('colon')).to eq cmd
       ensure
         Pry.config.command_prefix = ''
@@ -550,14 +550,14 @@ describe Pry::CommandSet do
     end
 
     it "should find the command that has the longest match" do
-      @set.command(/\.(.*)/){ }
-      cmd2 = @set.command(/\.\|\|(.*)/){ }
+      @set.command(/\.(.*)/) {}
+      cmd2 = @set.command(/\.\|\|(.*)/) {}
       expect(@set.find_command('.||')).to eq cmd2
     end
 
     it "should find the command that has the longest name" do
-      @set.command(/\.(.*)/){ }
-      cmd2 = @set.command('.||'){ }
+      @set.command(/\.(.*)/) {}
+      cmd2 = @set.command('.||') {}
       expect(@set.find_command('.||')).to eq cmd2
     end
   end
@@ -646,12 +646,12 @@ describe Pry::CommandSet do
   if defined?(Bond)
     describe '.complete' do
       it "should list all command names" do
-        @set.create_command('susan'){ }
+        @set.create_command('susan') {}
         expect(@set.complete('sus')).to.include 'susan '
       end
 
       it "should delegate to commands" do
-        @set.create_command('susan'){ def complete(_search); ['--foo']; end }
+        @set.create_command('susan') { def complete(_search); ['--foo']; end }
         expect(@set.complete('susan ')).to eq ['--foo']
       end
     end

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -75,8 +75,8 @@ describe "edit" do
     if respond_to?(:require_relative, true)
       it "should work with require relative" do
         Pry.config.editor = lambda { |file, line|
-          File.open(file, 'w'){ |f| f << 'require_relative "baz.rb"' }
-          File.open(file.gsub('bar.rb', 'baz.rb'), 'w'){ |f| f << "Pad.required = true; FileUtils.rm(__FILE__)" }
+          File.open(file, 'w') { |f| f << 'require_relative "baz.rb"' }
+          File.open(file.gsub('bar.rb', 'baz.rb'), 'w') { |f| f << "Pad.required = true; FileUtils.rm(__FILE__)" }
           nil
         }
         pry_eval "edit #@tf_path"
@@ -186,8 +186,8 @@ describe "edit" do
       end
 
       it "should reload the file" do
-        Pry.config.editor = lambda {|file, line|
-          File.open(file, 'w'){|f| f << "FOO = 'BAR'" }
+        Pry.config.editor = lambda { |file, line|
+          File.open(file, 'w') { |f| f << "FOO = 'BAR'" }
           nil
         }
 
@@ -202,7 +202,7 @@ describe "edit" do
       # of the exception)
       it 'edits the exception even when in a patched method context' do
         source_location = nil
-        Pry.config.editor = lambda {|file, line|
+        Pry.config.editor = lambda { |file, line|
           source_location = [file, line]
           nil
         }
@@ -220,8 +220,8 @@ describe "edit" do
       end
 
       it "should not reload the file if -n is passed" do
-        Pry.config.editor = lambda {|file, line|
-          File.open(file, 'w'){|f| f << "FOO2 = 'BAZ'" }
+        Pry.config.editor = lambda { |file, line|
+          File.open(file, 'w') { |f| f << "FOO2 = 'BAZ'" }
           nil
         }
 
@@ -235,8 +235,8 @@ describe "edit" do
       describe "with --patch" do
         # Original source code must be untouched.
         it "should apply changes only in memory (monkey patching)" do
-          Pry.config.editor = lambda {|file, line|
-            File.open(file, 'w'){|f| f << "FOO3 = 'PIYO'" }
+          Pry.config.editor = lambda { |file, line|
+            File.open(file, 'w') { |f| f << "FOO3 = 'PIYO'" }
             @patched_def = File.open(file, 'r').read
             nil
           }
@@ -332,8 +332,8 @@ describe "edit" do
     end
 
     it "should evaluate the expression" do
-      Pry.config.editor = lambda {|file, line|
-        File.open(file, 'w'){|f| f << "'FOO'\n" }
+      Pry.config.editor = lambda { |file, line|
+        File.open(file, 'w') { |f| f << "'FOO'\n" }
         nil
       }
       @t.process_command 'edit'
@@ -341,8 +341,8 @@ describe "edit" do
     end
 
     it "should ignore -n for tempfiles" do
-      Pry.config.editor = lambda {|file, line|
-        File.open(file, 'w'){|f| f << "'FOO'\n" }
+      Pry.config.editor = lambda { |file, line|
+        File.open(file, 'w') { |f| f << "'FOO'\n" }
         nil
       }
       @t.process_command "edit -n"
@@ -350,8 +350,8 @@ describe "edit" do
     end
 
     it "should not evaluate a file with -n" do
-      Pry.config.editor = lambda {|file, line|
-        File.open(file, 'w'){|f| f << "'FOO'\n" }
+      Pry.config.editor = lambda { |file, line|
+        File.open(file, 'w') { |f| f << "'FOO'\n" }
         nil
       }
       begin
@@ -365,7 +365,7 @@ describe "edit" do
 
     it "should write the evaluated command to history" do
       quote = 'history repeats itself, first as tradegy...'
-      Pry.config.editor = lambda {|file, line|
+      Pry.config.editor = lambda { |file, line|
         File.open(file, 'w') { |f|
           f << quote
         }
@@ -434,7 +434,7 @@ describe "edit" do
       expect(klass.new.m).to eq 3
 
       # original file is unchanged
-      expect(File.readlines(filename)[line-1].strip).to eq 'def m; 1; end'
+      expect(File.readlines(filename)[line - 1].strip).to eq 'def m; 1; end'
     end
 
     it 'can repeatedly edit methods that were defined in the console' do

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -45,7 +45,7 @@ describe "hist" do
 
     @t.eval("hist --replay 0..2")
     stack = @t.eval("Pad.stack = _pry_.binding_stack.dup")
-    expect(stack.map{ |b| b.eval("self") }).to eq [TOPLEVEL_BINDING.eval("self"), 1, 2]
+    expect(stack.map { |b| b.eval("self") }).to eq [TOPLEVEL_BINDING.eval("self"), 1, 2]
   end
 
   it 'should grep for correct lines in history' do

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -127,7 +127,7 @@ describe "show-doc" do
 
   describe "rdoc highlighting" do
     it "should syntax highlight code in rdoc" do
-      _c = Class.new{
+      _c = Class.new {
         # This can initialize your class:
         #
         #   a = _c.new :foo
@@ -144,7 +144,7 @@ describe "show-doc" do
     end
 
     it "should syntax highlight `code` in rdoc" do
-      _c = Class.new{
+      _c = Class.new {
         # After initializing your class with `_c.new(:foo)`, go have fun!
         #
         # @param foo
@@ -160,7 +160,7 @@ describe "show-doc" do
     end
 
     it "should not syntax highlight `` inside code" do
-      _c = Class.new{
+      _c = Class.new {
         # Convert aligned output (from many shell commands) into nested arrays:
         #
         #   a = decolumnize `ls -l $HOME`

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -57,7 +57,7 @@ describe "show-source" do
   end
 
   it "should find methods even if the object overrides method method" do
-    _c = Class.new{
+    _c = Class.new {
       def method;
         98
       end
@@ -67,7 +67,7 @@ describe "show-source" do
   end
 
   it "should not show the source when a non-extant method is requested" do
-    _c = Class.new{ def method; 98; end }
+    _c = Class.new { def method; 98; end }
     expect(mock_pry(binding, "show-source _c#wrongmethod")).to match(/Couldn't locate/)
   end
 
@@ -78,7 +78,7 @@ describe "show-source" do
   end
 
   it "should find instance_methods if the class overrides instance_method" do
-    _c = Class.new{
+    _c = Class.new {
       def method;
         98
       end
@@ -90,37 +90,37 @@ describe "show-source" do
   end
 
   it "should find instance methods with self#moo" do
-    _c = Class.new{ def moo; "ve over!"; end }
+    _c = Class.new { def moo; "ve over!"; end }
 
     expect(pry_eval(binding, "cd _c", "show-source self#moo")).to match(/ve over/)
   end
 
   it "should not find instance methods with self.moo" do
-    _c = Class.new{ def moo; "ve over!"; end }
+    _c = Class.new { def moo; "ve over!"; end }
 
     expect { pry_eval(binding, 'cd _c', 'show-source self.moo') }.to raise_error(Pry::CommandError, /Couldn't locate/)
   end
 
   it "should find normal methods with self.moo" do
-    _c = Class.new{ def self.moo; "ve over!"; end }
+    _c = Class.new { def self.moo; "ve over!"; end }
 
     expect(pry_eval(binding, 'cd _c', 'show-source self.moo')).to match(/ve over/)
   end
 
   it "should not find normal methods with self#moo" do
-    _c = Class.new{ def self.moo; "ve over!"; end }
+    _c = Class.new { def self.moo; "ve over!"; end }
 
     expect { pry_eval(binding, 'cd _c', 'show-source self#moo') }.to raise_error(Pry::CommandError, /Couldn't locate/)
   end
 
   it "should find normal methods (i.e non-instance methods) by default" do
-    _c = Class.new{ def self.moo; "ve over!"; end }
+    _c = Class.new { def self.moo; "ve over!"; end }
 
     expect(pry_eval(binding, "cd _c", "show-source moo")).to match(/ve over/)
   end
 
   it "should find instance methods if no normal methods available" do
-    _c = Class.new{ def moo; "ve over!"; end }
+    _c = Class.new { def moo; "ve over!"; end }
 
     expect(pry_eval(binding, "cd _c", "show-source moo")).to match(/ve over/)
   end
@@ -351,7 +351,7 @@ describe "show-source" do
           end
         end
 
-        class ShowSourceTestClass<ShowSourceTestSuperClass
+        class ShowSourceTestClass < ShowSourceTestSuperClass
           def alpha
           end
         end

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -2,10 +2,10 @@ require_relative 'helper'
 require "readline" unless defined?(Readline)
 require "pry/input_completer"
 
-def completer_test(bind, pry=nil, assert_flag=true)
-  test = proc {|symbol|
+def completer_test(bind, pry = nil, assert_flag = true)
+  test = proc { |symbol|
     expect(Pry::InputCompleter.new(pry || Readline, pry).call(symbol[0..-2], target: Pry.binding_for(bind)).include?(symbol)).to eq(assert_flag)}
-  return proc {|*symbols| symbols.each(&test) }
+  return proc { |*symbols| symbols.each(&test) }
 end
 
 describe Pry::InputCompleter do

--- a/spec/config/memoization_spec.rb
+++ b/spec/config/memoization_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Pry::Config::Memoization do
   let(:config) do
     Class.new do
       include Pry::Config::Memoization
-      def_memoized({foo: proc {"foo"}, bar: proc {"bar"}})
+      def_memoized({foo: proc { "foo" }, bar: proc { "bar" }})
     end.new
   end
 

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -41,7 +41,7 @@ describe Pry::Editor do
 
   describe 'invoke_editor with a proc' do
     it 'should not shell-escape files' do
-      editor = Pry::Editor.new(Pry.new(editor: proc{ |file, line, blocking|
+      editor = Pry::Editor.new(Pry.new(editor: proc { |file, line, blocking|
         @file = file
         nil
       }))

--- a/spec/helpers/table_spec.rb
+++ b/spec/helpers/table_spec.rb
@@ -25,13 +25,13 @@ describe 'Formatting Table' do
     def try_round_trip(expected)
       things = expected.split(/\s+/).sort
       actual = Pry::Helpers.tablify(things, FAKE_COLUMNS).to_s.strip
-      [expected, actual].each{|e| e.gsub!(/\s+$/, '')}
+      [expected, actual].each { |e| e.gsub!(/\s+$/, '') }
       if actual != expected
-        bar = '-'*25
+        bar = '-' * 25
         puts \
-          bar+'expected'+bar,
+          bar + 'expected' + bar,
           expected,
-          bar+'actual'+bar,
+          bar + 'actual' + bar,
           actual
       end
       expect(actual).to eq expected

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -137,7 +137,7 @@ describe Pry do
       @histfile = Tempfile.new(["pryhistory", "txt"])
       @history = Pry::History.new(file_path: @histfile.path)
       Pry.config.history.should_save = true
-      @history.pusher = proc{ }
+      @history.pusher = proc {}
     end
 
     after do
@@ -152,7 +152,7 @@ describe Pry do
 
     it "interleaves lines from many places" do
       @history.push "5"
-      File.open(@histfile.path, 'a'){ |f| f.puts "6" }
+      File.open(@histfile.path, 'a') { |f| f.puts "6" }
       @history.push "7"
 
       expect(File.read(@histfile.path)).to eq "5\n6\n7\n"

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -19,12 +19,12 @@ describe Pry::Hooks do
     end
 
     it 'should create a new hook with a block' do
-      @hooks.add_hook(:test_hook, :my_name) { }
+      @hooks.add_hook(:test_hook, :my_name) {}
       expect(@hooks.hook_count(:test_hook)).to eq 1
     end
 
     it 'should create a new hook with a callable' do
-      @hooks.add_hook(:test_hook, :my_name, proc { })
+      @hooks.add_hook(:test_hook, :my_name, proc {})
       expect(@hooks.hook_count(:test_hook)).to eq 1
     end
 
@@ -207,9 +207,9 @@ describe Pry::Hooks do
 
   describe "clearing all hooks for an event" do
     it 'should clear all hooks' do
-      @hooks.add_hook(:test_hook, :my_name) { }
-      @hooks.add_hook(:test_hook, :my_name2) { }
-      @hooks.add_hook(:test_hook, :my_name3) { }
+      @hooks.add_hook(:test_hook, :my_name) {}
+      @hooks.add_hook(:test_hook, :my_name2) {}
+      @hooks.add_hook(:test_hook, :my_name3) {}
       @hooks.clear_event_hooks(:test_hook)
       expect(@hooks.hook_count(:test_hook)).to eq 0
     end
@@ -423,8 +423,8 @@ describe Pry::Hooks do
 
       describe "exceptions" do
         before do
-          Pry.config.hooks.add_hook(:after_eval, :baddums){ raise "Baddums" }
-          Pry.config.hooks.add_hook(:after_eval, :simbads){ raise "Simbads" }
+          Pry.config.hooks.add_hook(:after_eval, :baddums) { raise "Baddums" }
+          Pry.config.hooks.add_hook(:after_eval, :simbads) { raise "Simbads" }
         end
 
         after do
@@ -449,8 +449,8 @@ describe Pry::Hooks do
     end
 
     it 'should only allow one anonymous hook to exist' do
-      @hooks.add_hook(:test_hook, nil) {  }
-      @hooks.add_hook(:test_hook, nil) {  }
+      @hooks.add_hook(:test_hook, nil) {}
+      @hooks.add_hook(:test_hook, nil) {}
       expect(@hooks.hook_count(:test_hook)).to eq 1
     end
 

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -107,7 +107,7 @@ describe Pry::Method do
     end
 
     it 'should look up methods using instance::bar syntax' do
-      _klass = Class.new{ def self.meth; Class.new; end }
+      _klass = Class.new { def self.meth; Class.new; end }
       meth = Pry::Method.from_str("_klass::meth", Pry.binding_for(binding))
       expect(meth.name).to eq "meth"
     end
@@ -119,7 +119,7 @@ describe Pry::Method do
 
   describe '.from_binding' do
     it 'should be able to pick a method out of a binding' do
-      expect(Pry::Method.from_binding(Class.new{ def self.foo; binding; end }.foo).name).to eq "foo"
+      expect(Pry::Method.from_binding(Class.new { def self.foo; binding; end }.foo).name).to eq "foo"
     end
 
     it 'should NOT find a method from the toplevel binding' do
@@ -143,7 +143,7 @@ describe Pry::Method do
       a = Class.new { def gag33; binding; end; def self.line; __LINE__; end }
       # rubocop:enable Layout/EmptyLineBetweenDefs
 
-      b = Class.new(a){ def gag33; super; end }
+      b = Class.new(a) { def gag33; super; end }
 
       g = b.new.gag33
       m = Pry::Method.from_binding(g)
@@ -154,7 +154,7 @@ describe Pry::Method do
     end
 
     it 'should find the right method if a super method exists' do
-      a = Class.new{ def gag; binding; end; }
+      a = Class.new { def gag; binding; end; }
 
       # rubocop:disable Layout/EmptyLineBetweenDefs
       b = Class.new(a) { def gag; super; binding; end; def self.line; __LINE__; end }
@@ -198,8 +198,8 @@ describe Pry::Method do
 
   describe 'super' do
     it 'should be able to find the super method on a bound method' do
-      a = Class.new{ def rar; 4; end }
-      b = Class.new(a){ def rar; super; end }
+      a = Class.new { def rar; 4; end }
+      b = Class.new(a) { def rar; super; end }
 
       obj = b.new
 
@@ -209,40 +209,40 @@ describe Pry::Method do
     end
 
     it 'should be able to find the super method of an unbound method' do
-      a = Class.new{ def rar; 4; end }
-      b = Class.new(a){ def rar; super; end }
+      a = Class.new { def rar; 4; end }
+      b = Class.new(a) { def rar; super; end }
 
       zuper = Pry::Method(b.instance_method(:rar)).super
       expect(zuper.owner).to eq a
     end
 
     it 'should return nil if no super method exists' do
-      a = Class.new{ def rar; super; end }
+      a = Class.new { def rar; super; end }
 
       expect(Pry::Method(a.instance_method(:rar)).super).to eq nil
     end
 
     it 'should be able to find super methods defined on modules' do
-      m = Module.new{ def rar; 4; end }
-      a = Class.new{ def rar; super; end; include m }
+      m = Module.new { def rar; 4; end }
+      a = Class.new { def rar; super; end; include m }
 
       zuper = Pry::Method(a.new.method(:rar)).super
       expect(zuper.owner).to eq m
     end
 
     it 'should be able to find super methods defined on super-classes when there are modules in the way' do
-      a = Class.new{ def rar; 4; end }
-      m = Module.new{ def mooo; 4; end }
-      b = Class.new(a){ def rar; super; end; include m }
+      a = Class.new { def rar; 4; end }
+      m = Module.new { def mooo; 4; end }
+      b = Class.new(a) { def rar; super; end; include m }
 
       zuper = Pry::Method(b.new.method(:rar)).super
       expect(zuper.owner).to eq a
     end
 
     it 'should be able to jump up multiple levels of bound method, even through modules' do
-      a = Class.new{ def rar; 4; end }
-      m = Module.new{ def rar; 4; end }
-      b = Class.new(a){ def rar; super; end; include m }
+      a = Class.new { def rar; 4; end }
+      m = Module.new { def rar; 4; end }
+      b = Class.new(a) { def rar; super; end; include m }
 
       zuper = Pry::Method(b.new.method(:rar)).super
       expect(zuper.owner).to eq m
@@ -256,7 +256,7 @@ describe Pry::Method do
     end
 
     it 'should be able to find public instance methods defined in a class' do
-      @class = Class.new{ def meth; 1; end }
+      @class = Class.new { def meth; 1; end }
       should_find_method('meth')
     end
 
@@ -272,7 +272,7 @@ describe Pry::Method do
     end
 
     it 'should be able to find instance methods defined in a super-class' do
-      @class = Class.new(Class.new{ def meth; 1; end }) {}
+      @class = Class.new(Class.new { def meth; 1; end }) {}
       should_find_method('meth')
     end
 
@@ -296,7 +296,7 @@ describe Pry::Method do
         include(Module.new { def meth; 1; end })
       end
       @class = Class.new(super_class) { def meth; 2; end }
-      expect(Pry::Method.all_from_class(@class).detect{ |x| x.name == 'meth' }.owner).to eq @class
+      expect(Pry::Method.all_from_class(@class).detect { |x| x.name == 'meth' }.owner).to eq @class
     end
 
     it 'should be able to find methods defined on a singleton class' do
@@ -305,7 +305,7 @@ describe Pry::Method do
     end
 
     it 'should be able to find methods on super-classes when given a singleton class' do
-      @class = (class << Class.new{ def meth; 1; end}.new; self; end)
+      @class = (class << Class.new { def meth; 1; end }.new; self; end)
       should_find_method('meth')
     end
   end
@@ -317,7 +317,7 @@ describe Pry::Method do
       end
 
       it "should find methods defined in the object's class" do
-        @obj = Class.new{ def meth; 1; end }.new
+        @obj = Class.new { def meth; 1; end }.new
         should_find_method('meth')
       end
 
@@ -346,7 +346,7 @@ describe Pry::Method do
       end
 
       it "should not find methods defined on the classes singleton class" do
-        @obj = Class.new{ class << self; def meth; 1; end; end }.new
+        @obj = Class.new { class << self; def meth; 1; end; end }.new
         expect(Pry::Method.all_from_obj(@obj).map(&:name)).not_to include 'meth'
       end
 
@@ -366,7 +366,7 @@ describe Pry::Method do
       end
 
       it "should find methods defined in the class' singleton class" do
-        @class = Class.new{ class << self; def meth; 1; end; end }
+        @class = Class.new { class << self; def meth; 1; end; end }
         should_find_method('meth')
       end
 
@@ -378,12 +378,12 @@ describe Pry::Method do
       end
 
       it "should find methods defined on the singleton class of super-classes" do
-        @class = Class.new(Class.new{ class << self; def meth; 1; end; end })
+        @class = Class.new(Class.new { class << self; def meth; 1; end; end })
         should_find_method('meth')
       end
 
       it "should not find methods defined within the class" do
-        @class = Class.new{ def meth; 1; end }
+        @class = Class.new { def meth; 1; end }
         expect(Pry::Method.all_from_obj(@class).map(&:name)).not_to include 'meth'
       end
 
@@ -398,8 +398,8 @@ describe Pry::Method do
       end
 
       it "should attribute overridden methods to the sub-class' singleton class" do
-        @class = Class.new(Class.new{ class << self; def meth; 1; end; end }) { class << self; def meth; 1; end; end }
-        expect(Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner).to eq(class << @class; self; end)
+        @class = Class.new(Class.new { class << self; def meth; 1; end; end }) { class << self; def meth; 1; end; end }
+        expect(Pry::Method.all_from_obj(@class).detect { |x| x.name == 'meth' }.owner).to eq(class << @class; self; end)
       end
 
       it "should attrbute overridden methods to the class not the module" do
@@ -409,12 +409,12 @@ describe Pry::Method do
           end
           extend(Module.new { def meth; 1; end })
         end
-        expect(Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'meth' }.owner).to eq(class << @class; self; end)
+        expect(Pry::Method.all_from_obj(@class).detect { |x| x.name == 'meth' }.owner).to eq(class << @class; self; end)
       end
 
       it "should attribute overridden methods to the relevant singleton class in preference to Class" do
         @class = Class.new { class << self; def allocate; 1; end; end }
-        expect(Pry::Method.all_from_obj(@class).detect{ |x| x.name == 'allocate' }.owner).to eq(class << @class; self; end)
+        expect(Pry::Method.all_from_obj(@class).detect { |x| x.name == 'allocate' }.owner).to eq(class << @class; self; end)
       end
     end
 
@@ -561,7 +561,7 @@ describe Pry::Method do
 
         def self.rest(*splat) end
 
-        def self.optional(option=nil) end
+        def self.optional(option = nil) end
       }
     end
 

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -71,7 +71,7 @@ describe Pry::Prompt do
       config = nil
       h = {}
       redirect_pry_io(InputTester.new("exit-all")) do
-        Pry.start(h, prompt: proc{|v| config = v })
+        Pry.start(h, prompt: proc { |v| config = v })
       end
       expect(config.object).to be(h)
     end

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -177,7 +177,7 @@ describe "test Pry defaults" do
     describe 'storing and restoring the prompt' do
       before do
         make = lambda do |name,i|
-          prompt = [ proc { "#{i}>" } , proc { "#{i+1}>" } ]
+          prompt = [ proc { "#{i}>" } , proc { "#{i + 1}>" } ]
           (class << prompt; self; end).send(:define_method, :inspect) { "<Prompt-#{name}>" }
           prompt
         end

--- a/spec/pry_repl_spec.rb
+++ b/spec/pry_repl_spec.rb
@@ -125,7 +125,7 @@ describe Pry::REPL do
   describe "autoindent" do
     it "should raise no exception when indented with a tab" do
       ReplTester.start(correct_indent: true, auto_indent: true) do
-        output=@pry.config.output
+        output = @pry.config.output
         def output.tty?; true; end
         input <<EOS
 loop do

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -52,11 +52,11 @@ describe Pry do
     end
 
     it 'should raise an error for binding.pry' do
-      expect{binding.pry}.to raise_error(RuntimeError)
+      expect { binding.pry }.to raise_error(RuntimeError)
     end
 
     it 'should raise an error for Pry.start' do
-      expect{Pry.start}.to raise_error(RuntimeError)
+      expect { Pry.start }.to raise_error(RuntimeError)
     end
   end
 
@@ -170,13 +170,13 @@ describe Pry do
 
       it 'should be able to evaluate exceptions normally' do
         was_called = false
-        mock_pry("RuntimeError.new", exception_handler: proc{ was_called = true })
+        mock_pry("RuntimeError.new", exception_handler: proc { was_called = true })
         expect(was_called).to eq false
       end
 
       it 'should notice when exceptions are raised' do
         was_called = false
-        mock_pry("raise RuntimeError", exception_handler: proc{ was_called = true })
+        mock_pry("raise RuntimeError", exception_handler: proc { was_called = true })
         expect(was_called).to eq true
       end
 

--- a/spec/pryrc_spec.rb
+++ b/spec/pryrc_spec.rb
@@ -76,7 +76,7 @@ describe Pry do
           putsed = str
         }
 
-        @doing_it = lambda{
+        @doing_it = lambda {
           Pry.start(self, input: StringIO.new("Object::TEST_AFTER_RAISE=1\nexit-all\n"), output: StringIO.new)
           putsed
         }


### PR DESCRIPTION
Fixes offences of the following cops:

* Layout/SpaceAroundEqualsInParameterDefault
* Layout/SpaceAroundOperators
* Layout/SpaceBeforeBlockBraces
* Layout/SpaceInsideBlockBraces