### PR TITLE
do not create a new hash each time a prompt is accessed via Pry::Prom…

### DIFF
--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -45,7 +45,7 @@ class Pry
       # @return [Hash{Symbol=>Object}]
       # @since v0.12.0
       def [](prompt_name)
-        all[prompt_name.to_s]
+        @prompts[prompt_name.to_s]
       end
 
       # @return [Hash{Symbol=>Hash}] the duplicate of the internal prompts hash


### PR DESCRIPTION
…pt[]

currently upon calling Pry::Prompt[:foo] a new Hash is created, and on all
subsequent calls a new Hash is also created. it's wasteful and careless,
so let's fix it.