### PR TITLE
fix syntax highlighting of prompt.rb on Github & multiple editors

### DIFF
--- a/lib/pry/commands/change_prompt.rb
+++ b/lib/pry/commands/change_prompt.rb
@@ -28,7 +28,7 @@ class Pry::Command::ChangePrompt < Pry::ClassCommand
       "#{bold(name)}#{red(' (selected)') if _pry_.prompt == prompt[:value]}\n" +
         prompt[:description]
     end
-    output.puts(prompts.join("\n"))
+    output.puts(prompts.join("\n" * 2))
   end
 
   def change_prompt(prompt)

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -94,11 +94,10 @@ class Pry
       end
     end
 
-    add(:default, <<DESC) do |context, nesting, _pry_, sep|
-The default Pry prompt. Includes information about the current expression
-number, evaluation context, and nesting level, plus a reminder that you're
-using Pry.
-DESC
+    add 'default',
+        "The default Pry prompt. Includes information about the current expression \n" \
+        "number, evaluation context, and nesting level, plus a reminder that you're \n" \
+        'using Pry.' do |context, nesting, _pry_, sep|
       format(
         "[%<in_count>s] %<name>s(%<context>s)%<nesting>s%<separator>s ",
         in_count: _pry_.input_ring.count,
@@ -109,14 +108,20 @@ DESC
       )
     end
 
-    add(:simple, "A simple `>>`.\n", ['>> ', ' | ']) do |_, _, _, sep|
+    add(
+      'simple',
+      "A simple `>>`.",
+      ['>> ', ' | ']
+    ) do |_, _, _, sep|
       sep
     end
 
-    add(:nav, <<DESC, %w[> *]) do |context, nesting, _pry_, sep|
-A prompt that displays the binding stack as a path and includes information
-about #{Helpers::Text.bold('_in_')} and #{Helpers::Text.bold('_out_')}.
-DESC
+    add(
+      'nav',
+      "A prompt that displays the binding stack as a path and includes information \n" \
+      "about #{Helpers::Text.bold('_in_')} and #{Helpers::Text.bold('_out_')}.",
+      %w[> *]
+    ) do |context, nesting, _pry_, sep|
       tree = _pry_.binding_stack.map { |b| Pry.view_clip(b.eval('self')) }
       format(
         "[%<in_count>s] (%<name>s) %<tree>s: %<stack_size>s%<separator>s ",
@@ -128,9 +133,11 @@ DESC
       )
     end
 
-    add(:shell, <<DESC, %w[$ *]) do |context, nesting, _pry_, sep|
-A prompt that displays `$PWD` as you change it.
-DESC
+    add(
+      'shell',
+      'A prompt that displays `$PWD` as you change it.',
+      %w[$ *]
+    ) do |context, nesting, _pry_, sep|
       format(
         "%<name>s %<context>s:%<pwd>s %<separator>s ",
         name: prompt_name(_pry_.config.prompt_name),
@@ -140,6 +147,10 @@ DESC
       )
     end
 
-    add(:none, 'Wave goodbye to the Pry prompt.', Array.new(2)) { '' }
+    add(
+      'none',
+      'Wave goodbye to the Pry prompt.',
+      Array.new(2)
+    ) { '' }
   end
 end


### PR DESCRIPTION
__edit: in the end this PR just fixes the syntax highlighting issue__

improvements as follows:

* GitHub, Visual Studio Code, Sublime Text Editor 2, and probably
  other editors can syntax highlight prompt.rb properly now.

* Remove excessive indentation due to how we opened an module and
  its singleton class (using 'class << self').