### PR TITLE
add Pry::Prompt.select_default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Added support for `_pry_.prompt = Pry::Prompt[:simple]`
   ([#1860](https://github.com/pry/pry/pull/1860/))
 
-* Pry::Prompt[] returns an instance of `Pry::Prompt` instead of Hash.
+* Pry::Prompt[], Pry::Prompt.all return `Pry::Prompt` object(s) instead of Hash.
   ([#1860](https://github.com/pry/pry/pull/1860/))
 
 * By default `Pry.config.prompt` returns an instance of `Pry::Prompt` instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 ### HEAD
 
-* Added support for `Pry.config.prompt = Pry::Prompt[:nav]` ([#1860](https://github.com/pry/pry/pull/1860/)).
-* Added support for `_pry_.prompt = Pry::Prompt[:simple]` ([#1860](https://github.com/pry/pry/pull/1860/)).
-* By default `Pry.config.prompt` returns a prompt object instead of a two proc array. ([#1860](https://github.com/pry/pry/pull/1860/)).
+* Added support for `Pry.config.prompt = Pry::Prompt[:nav]`
+  ([#1860](https://github.com/pry/pry/pull/1860/))
+
+* Added support for `_pry_.prompt = Pry::Prompt[:simple]`
+  ([#1860](https://github.com/pry/pry/pull/1860/))
+
+* Pry::Prompt[] returns an instance of `Pry::Prompt` instead of Hash.
+  ([#1860](https://github.com/pry/pry/pull/1860/))
+
+* By default `Pry.config.prompt` returns an instance of `Pry::Prompt` instead
+  of a two proc array. ([#1860](https://github.com/pry/pry/pull/1860/)).
 
 ### [v0.12.0][v0.12.0] (November 5, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### HEAD
 
-* Added `Pry::Prompt.select_default` for selecting the default prompt a
-  Pry session will use. It can be called from a `.pryrc` file. ([#1860](https://github.com/pry/pry/pull/1860/files)).
+* Added support for `Pry.config.prompt = Pry::Prompt[:nav]` ([#1860](https://github.com/pry/pry/pull/1860/)).
+* Added support for `_pry_.prompt = Pry::Prompt[:simple]` ([#1860](https://github.com/pry/pry/pull/1860/)).
+* By default `Pry.config.prompt` returns a prompt object instead of a two proc array. ([#1860](https://github.com/pry/pry/pull/1860/)).
 
 ### [v0.12.0][v0.12.0] (November 5, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### HEAD
 
+* Added `Pry::Prompt.select_default` for selecting the default prompt a
+  Pry session will use. It can be called from a `.pryrc` file. ([#1860](https://github.com/pry/pry/pull/1860/files)).
+
 ### [v0.12.0][v0.12.0] (November 5, 2018)
 
 #### Major changes

--- a/lib/pry/commands/change_prompt.rb
+++ b/lib/pry/commands/change_prompt.rb
@@ -32,8 +32,8 @@ class Pry::Command::ChangePrompt < Pry::ClassCommand
   end
 
   def change_prompt(prompt)
-    if Pry::Prompt.all.key?(prompt)
-      _pry_.prompt = Pry::Prompt.all[prompt][:value]
+    if Pry::Prompt[prompt]
+      _pry_.prompt = Pry::Prompt[prompt]
     else
       raise(Pry::CommandError, <<MSG)
 '#{prompt}' isn't a known prompt. Run `change-prompt --list` to see

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -31,5 +31,14 @@ class Pry
     def self.shortcuts
       Convenience::SHORTCUTS
     end
+
+    def prompt=(obj)
+      is_prompt_object = lambda do |prompt|
+        ::Hash === prompt and
+        prompt.key?(:description) and
+        prompt.key?(:value)
+      end
+      super(is_prompt_object.call(obj) ? obj[:value] : obj)
+    end
   end
 end

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -31,9 +31,5 @@ class Pry
     def self.shortcuts
       Convenience::SHORTCUTS
     end
-
-    def prompt=(obj)
-      super(Pry::Prompt.prompt_object?(obj) ? obj[:value] : obj)
-    end
   end
 end

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -33,12 +33,7 @@ class Pry
     end
 
     def prompt=(obj)
-      is_prompt_object = lambda do |prompt|
-        ::Hash === prompt and
-        prompt.key?(:description) and
-        prompt.key?(:value)
-      end
-      super(is_prompt_object.call(obj) ? obj[:value] : obj)
+      super(Pry::Prompt.prompt_object?(obj) ? obj[:value] : obj)
     end
   end
 end

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -18,7 +18,7 @@ class Pry
           Pry::Prompt::DEFAULT_NAME
         },
         prompt: proc {
-          Pry::Prompt.default_prompt[:value]
+          Pry::Prompt[:default]
         },
         prompt_safe_contexts: proc {
           Pry::Prompt::SAFE_CONTEXTS

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -18,7 +18,7 @@ class Pry
           Pry::Prompt::DEFAULT_NAME
         },
         prompt: proc {
-          Pry::Prompt[:default][:value]
+          Pry::Prompt.default_prompt[:value]
         },
         prompt_safe_contexts: proc {
           Pry::Prompt::SAFE_CONTEXTS

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -35,46 +35,7 @@ class Pry
     # names, the values are Hash instances of the format {:description, :value}.
     @prompts = {}
 
-    # The name of the current default prompt.
-    @default_prompt = 'default'
-
     class << self
-      #
-      # @return [Hash]
-      #   Returns the current default prompt as a Hash.
-      #
-      def default_prompt
-        self[@default_prompt]
-      end
-
-      #
-      # Sets the default prompt that will be used when a Pry session starts.
-      # It can be used from inside a `.pryrc` file.
-      #
-      # @example
-      #   Pry::Prompt.select_default 'simple'
-      #   Pry::Prompt.select_default 'nav'
-      #   Pry::Prompt.select_default 'rails' # when using pry-rails
-      #
-      # @raise [ArgumentError]
-      #   When the prompt is not known to Pry.
-      #
-      # @param [String] prompt_name
-      #   The name of a prompt.
-      #
-      # @return [void]
-      #
-      # @api public
-      #
-      def select_default(prompt_name)
-        if self[prompt_name]
-          @default_prompt = prompt_name
-          nil
-        else
-          raise ArgumentError, "'#{prompt_name}' is not known to Pry."
-        end
-      end
-
       #
       # @example
       #   Pry::Prompt.prompt_object? Pry::Prompt[:nav] # => true

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -75,6 +75,16 @@ class Pry
         end
       end
 
+      #
+      # @param [Object] obj
+      #
+      # @return [Boolean]
+      #   Returns true when 'obj' is an object created by the {Pry::Prompt.add} method.
+      #
+      def prompt_object?(obj)
+        obj.respond_to?(:keys) and obj.keys == [:description, :value]
+      end
+
       # Retrieves a prompt.
       #
       # @example

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -19,7 +19,8 @@ class Pry
   #   # In [4]:
   # @since v0.11.0
   # @api public
-  module Prompt
+  class Prompt < Struct.new(:name, :description, :value)
+
     # @return [String]
     DEFAULT_NAME = 'pry'.freeze
 
@@ -47,7 +48,7 @@ class Pry
       #   Returns true when 'obj' is an object created by the {Pry::Prompt.add} method.
       #
       def prompt_object?(obj)
-        obj.respond_to?(:keys) and obj.keys == [:description, :value]
+        Pry::Prompt === obj
       end
 
       # Retrieves a prompt.
@@ -89,12 +90,9 @@ class Pry
           raise ArgumentError, "separators size must be 2, given #{separators.size}"
         end
 
-        @prompts[prompt_name.to_s] = {
-          description: description,
-          value: separators.map do |sep|
-            proc { |context, nesting, _pry_| yield(context, nesting, _pry_, sep) }
-          end
-        }.freeze
+        @prompts[prompt_name.to_s] = new(prompt_name, description, separators.map { |sep|
+          proc { |context, nesting, _pry_| yield(context, nesting, _pry_, sep) }
+        })
 
         nil
       end

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -37,20 +37,6 @@ class Pry
     @prompts = {}
 
     class << self
-      #
-      # @example
-      #   Pry::Prompt.prompt_object? Pry::Prompt[:nav] # => true
-      #   Pry::Prompt.prompt_object? 'foobar' # => false
-      #
-      # @param [Object] obj
-      #
-      # @return [Boolean]
-      #   Returns true when 'obj' is an object created by the {Pry::Prompt.add} method.
-      #
-      def prompt_object?(obj)
-        Pry::Prompt === obj
-      end
-
       # Retrieves a prompt.
       #
       # @example

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -76,6 +76,10 @@ class Pry
       end
 
       #
+      # @example
+      #   Pry::Prompt.prompt_object? Pry::Prompt[:nav] # => true
+      #   Pry::Prompt.prompt_object? 'foobar' # => false
+      #
       # @param [Object] obj
       #
       # @return [Boolean]

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -35,7 +35,46 @@ class Pry
     # names, the values are Hash instances of the format {:description, :value}.
     @prompts = {}
 
+    # The name of the current default prompt.
+    @default_prompt = 'default'
+
     class << self
+      #
+      # @return [Hash]
+      #   Returns the current default prompt as a Hash.
+      #
+      def default_prompt
+        self[@default_prompt]
+      end
+
+      #
+      # Sets the default prompt that will be used when a Pry session starts.
+      # It can be used from inside a `.pryrc` file.
+      #
+      # @example
+      #   Pry::Prompt.select_default 'simple'
+      #   Pry::Prompt.select_default 'nav'
+      #   Pry::Prompt.select_default 'rails' # when using pry-rails
+      #
+      # @raise [ArgumentError]
+      #   When the prompt is not known to Pry.
+      #
+      # @param [String] prompt_name
+      #   The name of a prompt.
+      #
+      # @return [void]
+      #
+      # @api public
+      #
+      def select_default(prompt_name)
+        if self[prompt_name]
+          @default_prompt = prompt_name
+          nil
+        else
+          raise ArgumentError, "'#{prompt_name}' is not known to Pry."
+        end
+      end
+
       # Retrieves a prompt.
       #
       # @example
@@ -80,7 +119,7 @@ class Pry
           value: separators.map do |sep|
             proc { |context, nesting, _pry_| yield(context, nesting, _pry_, sep) }
           end
-        }
+        }.freeze
 
         nil
       end

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -124,7 +124,7 @@ class Pry
   end
 
   def prompt=(new_prompt)
-    procs = Pry::Prompt.prompt_object?(new_prompt) ? new_prompt[:value] : new_prompt
+    procs = Pry::Prompt === new_prompt ? new_prompt.value : new_prompt
     if prompt_stack.empty?
       push_prompt procs
     else

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -77,7 +77,7 @@ class Pry
     target = options.delete(:target)
     @config = Pry::Config.new
     config.merge!(options)
-    push_prompt(config.prompt)
+    self.prompt = config.prompt
     @input_ring = Pry::Ring.new(config.memory_size)
     @output_ring = Pry::Ring.new(config.memory_size)
     @custom_completions = config.command_completions

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -124,10 +124,11 @@ class Pry
   end
 
   def prompt=(new_prompt)
+    procs = Pry::Prompt.prompt_object?(new_prompt) ? new_prompt[:value] : new_prompt
     if prompt_stack.empty?
-      push_prompt new_prompt
+      push_prompt procs
     else
-      prompt_stack[-1] = new_prompt
+      prompt_stack[-1] = procs
     end
   end
 


### PR DESCRIPTION
This method can be used to set the default prompt from inside a
.pryrc file, eg:

```ruby
Pry::Prompt.select_default 'nav'
```

or

```ruby
Pry::Prompt.select_default 'rails' # using pry-rails
```