### PR TITLE
Update terminology in test description from completion spec

### DIFF
--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -213,7 +213,7 @@ describe Pry::InputCompleter do
     completer_test(self).call("[].size.chars")
   end
 
-  it 'does not offer methods from blacklisted modules' do
+  it 'does not offer methods from restricted modules' do
     require 'irb'
     completer_test(self, nil, false).call("[].size.parse_printf_format")
   end


### PR DESCRIPTION
This Pull Request updates terminology in the codebase: restricted is easier to understand and less offensive. 

[Original motivation](https://github.com/rails/rails/issues/33677), other community efforts examples:

- https://github.com/rails/rails/pull/33681
- https://github.com/graphiti-api/graphiti/pull/10
- https://github.com/rails/rails/pull/33718
- https://github.com/ruby/psych/pull/378
- https://github.com/ruby/ruby/pull/2008
- https://github.com/ruby/ruby/pull/2009
- https://github.com/rubocop-hq/rubocop/pull/6464
- https://github.com/rubygems/rubygems/pull/2463
- https://github.com/dtao/safe_yaml/pull/93
- https://github.com/rack/rack/pull/1314
- https://github.com/rubocop-hq/rubocop/pull/6466
- https://github.com/rubocop-hq/rubocop/pull/6467
- https://github.com/rspec/rspec-core/pull/2576
- https://github.com/rspec/rspec-expectations/pull/1083
- https://github.com/rspec/rspec-mocks/pull/1246
- https://github.com/rspec/rspec-support/pull/356
- https://github.com/flavorjones/loofah/pull/158
- https://github.com/pry/pry/pull/1874