### PR TITLE
fix syntax highlighting of change_prompt.rb

### DIFF
--- a/lib/pry/commands/change_prompt.rb
+++ b/lib/pry/commands/change_prompt.rb
@@ -35,10 +35,8 @@ class Pry::Command::ChangePrompt < Pry::ClassCommand
     if Pry::Prompt.all.key?(prompt)
       _pry_.prompt = Pry::Prompt.all[prompt][:value]
     else
-      raise(Pry::CommandError, <<MSG)
-'#{prompt}' isn't a known prompt. Run `change-prompt --list` to see
-the list of known prompts.
-MSG
+      raise Pry::CommandError, "'#{prompt}' isn't a known prompt. " \
+                               "Run `change-prompt --list` to see the list of known prompts."
     end
   end
 


### PR DESCRIPTION
let's try to avoid exotic heredoc syntax that GitHub and multiple
editors cannot support, the only confirmed editor that supports
highlighting this syntax so far is 'emacs'.

it is not friendly to non-emacs users to have to deal with broken
syntax highlighting, especially when there is a less exotic and
easier syntax available.