### PR TITLE
prompt: raise ArgumentError when trying to add an existing prompt

### DIFF
--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -37,11 +37,11 @@ class Pry
       # @example
       #   Prompt[:my_prompt][:value]
       #
-      # @param [Symbol] prompt_name The name of the prompt you want to access
+      # @param [Symbol] name The name of the prompt you want to access
       # @return [Hash{Symbol=>Object}]
       # @since v0.12.0
-      def [](prompt_name)
-        @prompts[prompt_name.to_s]
+      def [](name)
+        @prompts[name.to_s]
       end
 
       # @return [Hash{Symbol=>Hash}] the duplicate of the internal prompts hash
@@ -53,7 +53,7 @@ class Pry
 
       # Adds a new prompt to the prompt hash.
       #
-      # @param [Symbol] prompt_name
+      # @param [Symbol] name
       # @param [String] description
       # @param [Array<String>] separators The separators to differentiate
       #   between prompt modes (default mode and class/method definition mode).
@@ -65,13 +65,20 @@ class Pry
       # @yieldparam separator [String] separator string
       # @return [nil]
       # @raise [ArgumentError] if the size of `separators` is not 2
+      # @raise [ArgumentError] if `prompt_name` is already occupied
       # @since v0.12.0
-      def add(prompt_name, description = '', separators = %w[> *])
+      def add(name, description = '', separators = %w[> *])
+        name = name.to_s
+
         unless separators.size == 2
           raise ArgumentError, "separators size must be 2, given #{separators.size}"
         end
 
-        @prompts[prompt_name.to_s] = {
+        if @prompts.key?(name)
+          raise ArgumentError, "the '#{name}' prompt was already added"
+        end
+
+        @prompts[name] = {
           description: description,
           value: separators.map do |sep|
             proc { |context, nesting, _pry_| yield(context, nesting, _pry_, sep) }

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -3,36 +3,42 @@ require_relative 'helper'
 describe Pry::Prompt do
   describe ".[]" do
     it "accesses prompts" do
-      expect(subject[:default]).not_to be_nil
+      expect(described_class[:default]).not_to be_nil
     end
   end
 
   describe ".all" do
     it "returns a hash with prompts" do
-      expect(subject.all).to be_a(Hash)
+      expect(described_class.all).to be_a(Hash)
     end
 
     it "returns a duplicate of original prompts" do
-      subject.all[:foobar] = Object.new
-      expect(subject[:foobar]).to be_nil
+      described_class.all['foobar'] = Object.new
+      expect(described_class['foobar']).to be_nil
     end
   end
 
   describe ".add" do
-    after { described_class.instance_variable_get(:@prompts).delete(:my_prompt) }
+    after { described_class.instance_variable_get(:@prompts).delete('my_prompt') }
 
     it "adds a new prompt" do
-      subject.add(:my_prompt)
-      expect(subject[:my_prompt]).to be_a(Hash)
+      described_class.add(:my_prompt)
+      expect(described_class[:my_prompt]).to be_a(Hash)
     end
 
     it "raises error when separators.size != 2" do
-      expect { subject.add(:my_prompt, '', [1, 2, 3]) }
-        .to raise_error(ArgumentError)
+      expect { described_class.add(:my_prompt, '', [1, 2, 3]) }
+        .to raise_error(ArgumentError, /separators size must be 2/)
+    end
+
+    it "raises error on adding a prompt with the same name" do
+      described_class.add(:my_prompt)
+      expect { described_class.add(:my_prompt) }
+        .to raise_error(ArgumentError, /the 'my_prompt' prompt was already added/)
     end
 
     it "returns nil" do
-      expect(subject.add(:my_prompt)).to be_nil
+      expect(described_class.add(:my_prompt)).to be_nil
     end
   end
 
@@ -115,7 +121,7 @@ describe Pry::Prompt do
     end
     config._pry_.config.prompt_name = Pry.lazy { enum.next }
 
-    proc = subject[:default][:value].first
+    proc = described_class[:default][:value].first
     expect(proc.call(Object.new, 1, config._pry_)).to eq('[1] 101(#<Object>):1> ')
     expect(proc.call(Object.new, 1, config._pry_)).to eq('[1] 102(#<Object>):1> ')
   end


### PR DESCRIPTION
This way we make sure nobody overwrites our default prompts.