### PR TITLE
Add .rspec and require 'helper' from there

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require helper

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry::Hooks do
   before do
     Pry::CLI.reset

--- a/spec/code_object_spec.rb
+++ b/spec/code_object_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry::CodeObject do
   describe "basic lookups" do
     before do

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry::Code do
   describe '.from_file' do
     specify 'read lines from a file on disk' do

--- a/spec/color_printer_spec.rb
+++ b/spec/color_printer_spec.rb
@@ -1,9 +1,8 @@
-require 'helper'
-describe Pry::ColorPrinter do    
+describe Pry::ColorPrinter do
   include Pry::Helpers::Text
   let(:io) { StringIO.new }
   let(:str) { strip_color(io.string.chomp) }
-  
+
   describe '.pp' do
     describe 'Object' do
       it 'prints a string' do
@@ -12,32 +11,32 @@ describe Pry::ColorPrinter do
       end
     end
 
-    describe 'Object subclass' do 
+    describe 'Object subclass' do
       before do
-        class ObjectF < Object 
+        class ObjectF < Object
           def inspect
             'foo'
           end
         end
 
         class ObjectG < Object
-          def inspect 
-            raise 
+          def inspect
+            raise
           end
         end
       end
 
-      after do 
+      after do
         Object.send :remove_const, :ObjectF
         Object.send :remove_const, :ObjectG
-      end 
+      end
 
       it 'prints a string' do
         Pry::ColorPrinter.pp(ObjectF.new, io)
         expect(str).to eq('foo')
-      end 
+      end
 
-      it 'prints a string, even when an exception is raised' do 
+      it 'prints a string, even when an exception is raised' do
         Pry::ColorPrinter.pp(ObjectG.new, io)
         expect(str).to match(/\A#<ObjectG:0x\w+>\z/)
       end

--- a/spec/command_helpers_spec.rb
+++ b/spec/command_helpers_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry::Helpers::CommandHelpers do
   before do
     @helper = Pry::Helpers::CommandHelpers

--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe "commands" do
   before do
     @str_output = StringIO.new

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry::CommandSet do
   before do
     @set = Pry::CommandSet.new do

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe "Pry::Command" do
   before do
     @set = Pry::CommandSet.new

--- a/spec/commands/amend_line_spec.rb
+++ b/spec/commands/amend_line_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "amend-line" do
   before do
     @t = pry_tester

--- a/spec/commands/bang_spec.rb
+++ b/spec/commands/bang_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "!" do
   before do
     @t = pry_tester

--- a/spec/commands/cat/file_formatter_spec.rb
+++ b/spec/commands/cat/file_formatter_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../../helper'
-
 describe Pry::Command::Cat::FileFormatter do
   before do
     @p   = Pry.new

--- a/spec/commands/cat_spec.rb
+++ b/spec/commands/cat_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "cat" do
   before do
     @str_output = StringIO.new

--- a/spec/commands/cd_spec.rb
+++ b/spec/commands/cd_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe 'cd' do
   before do
     @o, @obj = Object.new, Object.new

--- a/spec/commands/disable_pry_spec.rb
+++ b/spec/commands/disable_pry_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "disable-pry" do
   before do
     @t = pry_tester

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -1,5 +1,4 @@
 require 'pathname'
-require_relative '../helper'
 
 describe "edit" do
   before do

--- a/spec/commands/exit_all_spec.rb
+++ b/spec/commands/exit_all_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "exit-all" do
   before { @pry = Pry.new }
 

--- a/spec/commands/exit_program_spec.rb
+++ b/spec/commands/exit_program_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "exit-program" do
   it 'should raise SystemExit' do
     expect { pry_eval('exit-program') }.to raise_error SystemExit

--- a/spec/commands/exit_spec.rb
+++ b/spec/commands/exit_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "exit" do
   before { @pry = Pry.new(target: :outer, output: StringIO.new) }
 

--- a/spec/commands/find_method_spec.rb
+++ b/spec/commands/find_method_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "find-method" do
   MyKlass = Class.new do
     def hello

--- a/spec/commands/gem_list_spec.rb
+++ b/spec/commands/gem_list_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "gem-list" do
   it 'should not raise when invoked' do
     expect { pry_eval(self, 'gem-list') }.to_not raise_error

--- a/spec/commands/gist_spec.rb
+++ b/spec/commands/gist_spec.rb
@@ -1,9 +1,6 @@
 # These tests are out of date.
 # They need to be updated for the new 'gist' API, but im too sleepy to
 # do that now.
-
-require_relative '../helper'
-
 describe 'gist' do
   it 'has a dependency on the jist gem' do
     expect(Pry::Command::Gist.command_options[:requires_gem]).to eq("gist")

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "help" do
   before do
     @oldset = Pry.config.commands

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "hist" do
   before do
     Pry.history.clear

--- a/spec/commands/jump_to_spec.rb
+++ b/spec/commands/jump_to_spec.rb
@@ -1,5 +1,3 @@
-require 'helper'
-
 RSpec.describe "jump-to" do
   let(:obj) { Object.new }
 

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "ls" do
   describe "bug #1407" do
     it "behaves as usual when a method of the same name exists." do

--- a/spec/commands/play_spec.rb
+++ b/spec/commands/play_spec.rb
@@ -1,9 +1,6 @@
 # This command needs a TONNE more tests for it, but i can't figure out
 # how to do them yet, and i really want to release. Sorry. Someone
 # come along and do a better job.
-
-require_relative '../helper'
-
 describe "play" do
   before do
     @o = Object.new

--- a/spec/commands/raise_up_spec.rb
+++ b/spec/commands/raise_up_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "raise-up" do
   before do
     @self  = "Pad.self = self"

--- a/spec/commands/reload_code_spec.rb
+++ b/spec/commands/reload_code_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "reload_code" do
   describe "reload_current_file" do
     it 'raises an error source code not found' do

--- a/spec/commands/ri_command_spec.rb
+++ b/spec/commands/ri_command_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../helper'
 describe "ri" do
   it "prints an error message without an argument" do
     expect(pry_eval("ri")).to include("Please provide a class, module, or method name (e.g: ri Array#push)")

--- a/spec/commands/save_file_spec.rb
+++ b/spec/commands/save_file_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "save-file" do
   before do
     @tf = Tempfile.new(["pry", ".py"])

--- a/spec/commands/shell_command_spec.rb
+++ b/spec/commands/shell_command_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe Pry::Command::ShellCommand do
   describe 'cd' do
     before do

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../helper'
 require "fixtures/show_source_doc_examples"
 
 describe "show-doc" do

--- a/spec/commands/show_input_spec.rb
+++ b/spec/commands/show_input_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "show-input" do
   before do
     @t = pry_tester

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -1,4 +1,3 @@
-require_relative '../helper'
 require "fixtures/show_source_doc_examples"
 
 describe "show-source" do

--- a/spec/commands/watch_expression_spec.rb
+++ b/spec/commands/watch_expression_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "watch expression" do
   # Custom eval that will:
   # 1) Create an instance of pry that can use for multiple calls

--- a/spec/commands/whereami_spec.rb
+++ b/spec/commands/whereami_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "whereami" do
   it 'should work with methods that have been undefined' do
     class Cor

--- a/spec/commands/wtf_spec.rb
+++ b/spec/commands/wtf_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe "wtf?!" do
   let(:tester) do
     pry_tester do

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -1,4 +1,3 @@
-require_relative 'helper'
 require "readline" unless defined?(Readline)
 require "pry/input_completer"
 

--- a/spec/config/behavior_spec.rb
+++ b/spec/config/behavior_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 RSpec.describe Pry::Config::Behavior do
   let(:behavior) do
     Class.new do

--- a/spec/config/memoization_spec.rb
+++ b/spec/config/memoization_spec.rb
@@ -1,4 +1,3 @@
-require 'helper'
 RSpec.describe Pry::Config::Memoization do
   let(:config) do
     Class.new do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,4 +1,3 @@
-require_relative 'helper'
 describe Pry::Config do
   describe "bug #1552" do
     specify "a local key has precendence over its default when the stored value is false" do

--- a/spec/control_d_handler_spec.rb
+++ b/spec/control_d_handler_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry::DEFAULT_CONTROL_D_HANDLER do
   describe "control-d press" do
     before do

--- a/spec/documentation_helper_spec.rb
+++ b/spec/documentation_helper_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry::Helpers::DocumentationHelpers do
   before do
     @helper = Pry::Helpers::DocumentationHelpers

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -1,5 +1,4 @@
 require 'pathname'
-require_relative 'helper'
 
 describe Pry::Editor do
   class Pry::Editor

--- a/spec/helpers/table_spec.rb
+++ b/spec/helpers/table_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe 'Formatting Table' do
   it 'knows about colorized fitting' do
     t = Pry::Helpers::Table.new %w(hihi), column_count: 1

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -1,4 +1,3 @@
-require_relative 'helper'
 require 'tempfile'
 
 describe Pry do

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry::Hooks do
   before do
     @hooks = Pry::Hooks.new

--- a/spec/indent_spec.rb
+++ b/spec/indent_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 # Please keep in mind that any hash signs ("#") in the heredoc strings are
 # placed on purpose. Without these editors might remove the whitespace on empty
 # lines.
@@ -249,7 +247,7 @@ def test
   puts "something" rescue "whatever"
 end
 INPUT
-    
+
     expect(@indent.indent(input)).to eq input
   end
 

--- a/spec/integration/hanami_spec.rb
+++ b/spec/integration/hanami_spec.rb
@@ -1,4 +1,3 @@
-require "helper"
 require "shellwords"
 
 RSpec.describe "Hanami integration" do

--- a/spec/integration/readline_spec.rb
+++ b/spec/integration/readline_spec.rb
@@ -1,7 +1,6 @@
 # These specs ensure that Pry doesn't require readline until the first time a
 # REPL is started.
 
-require "helper"
 require "shellwords"
 
 RSpec.describe "Readline" do

--- a/spec/method/patcher_spec.rb
+++ b/spec/method/patcher_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../helper'
-
 describe Pry::Method::Patcher do
   before do
     @x = Object.new

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -1,4 +1,3 @@
-require_relative 'helper'
 require 'set'
 
 describe Pry::Method do

--- a/spec/pager_spec.rb
+++ b/spec/pager_spec.rb
@@ -1,4 +1,3 @@
-require_relative "helper"
 describe "Pry::Pager" do
   describe "PageTracker" do
     before do

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry::Prompt do
   describe ".[]" do
     it "accesses prompts" do

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 _version = 1
 
 describe "test Pry defaults" do

--- a/spec/pry_output_spec.rb
+++ b/spec/pry_output_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry do
   describe "output failsafe" do
     after do

--- a/spec/pry_repl_spec.rb
+++ b/spec/pry_repl_spec.rb
@@ -1,4 +1,3 @@
-require_relative 'helper'
 describe Pry::REPL do
   it "should let you run commands in the middle of multiline expressions" do
     ReplTester.start do

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry do
   before do
     @str_output = StringIO.new

--- a/spec/pryrc_spec.rb
+++ b/spec/pryrc_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry do
   describe 'loading rc files' do
     before do

--- a/spec/run_command_spec.rb
+++ b/spec/run_command_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe "Pry.run_command" do
   before do
     o = Object.new

--- a/spec/sticky_locals_spec.rb
+++ b/spec/sticky_locals_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe "Sticky locals (_file_ and friends)" do
   it 'locals should all exist upon initialization' do
     expect { pry_eval '_file_', '_dir_', '_ex_', '_pry_', '_' }.to_not raise_error

--- a/spec/syntax_checking_spec.rb
+++ b/spec/syntax_checking_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry do
   before do
     @str_output = StringIO.new

--- a/spec/unrescued_exceptions_spec.rb
+++ b/spec/unrescued_exceptions_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe "Pry.config.unrescued_exceptions" do
   before do
     @str_output = StringIO.new

--- a/spec/wrapped_module_spec.rb
+++ b/spec/wrapped_module_spec.rb
@@ -1,5 +1,3 @@
-require_relative 'helper'
-
 describe Pry::WrappedModule do
   describe "#initialize" do
     it "should raise an exception when a non-module is passed" do


### PR DESCRIPTION
Just discovered this nice feature of RSpec where it can load all files for
us. Works with `bundle exec rake` and `bundle exec rspec spec/file_spec.rb`,
which covers all use cases.