### PR TITLE
add Pry::Testable::ReplTester

### DIFF
--- a/lib/pry/testable.rb
+++ b/lib/pry/testable.rb
@@ -2,8 +2,18 @@
 # if you're testing pry plugin you should require pry by yourself, no?
 require 'pry' if not defined?(Pry)
 
+#
+# Provides helper methods for testing Pry.
+#
+# @example
+#   # RSpec
+#   RSpec.configure do |config|
+#     config.include Pry::Testable
+#   end
+#
 module Pry::Testable
   extend self
+  require_relative "testable/repl_tester"
   require_relative "testable/pry_tester"
   require_relative "testable/evalable"
   require_relative "testable/mockable"

--- a/lib/pry/testable.rb
+++ b/lib/pry/testable.rb
@@ -11,6 +11,16 @@ require 'pry' if not defined?(Pry)
 #     config.include Pry::Testable
 #   end
 #
+# @example
+#   # Minitest
+#   class TestCase < Minitest::Test
+#     include Pry::Testable
+#   end
+#
+# The methods provided are the instance methods of the following
+# modules: {Pry::Testable::Evalable}, {Pry::Testable::Mockable},
+# {Pry::Testable::Variables}, and {Pry::Testable::Utility}.
+#
 module Pry::Testable
   extend self
   require_relative "testable/repl_tester"

--- a/lib/pry/testable/evalable.rb
+++ b/lib/pry/testable/evalable.rb
@@ -16,7 +16,7 @@ module Pry::Testable::Evalable
   # @example
   #   pry_repl_tester do |repl|
   #     repl.enter_input '_pry_.config.prompt_name = "foobar"'
-  #     expect(repl.last_prompt).to match('foobar')
+  #     expect(repl.last_prompt).to match(/foobar/)
   #   end
   #
   def pry_repl_tester(&b)

--- a/lib/pry/testable/evalable.rb
+++ b/lib/pry/testable/evalable.rb
@@ -8,6 +8,21 @@ module Pry::Testable::Evalable
     end
   end
 
+  #
+  # For super-high-level integration testing.
+  #
+  # @see Pry::Testable::ReplTester
+  #
+  # @example
+  #   pry_repl_tester do |repl|
+  #     repl.enter_input '_pry_.config.prompt_name = "foobar"'
+  #     expect(repl.last_prompt).to match('foobar')
+  #   end
+  #
+  def pry_repl_tester(&b)
+    Pry::Testable::ReplTester.start(&b)
+  end
+
   def pry_eval(*eval_strs)
     b = String === eval_strs.first ? Pry.toplevel_binding : Pry.binding_for(eval_strs.shift)
     pry_tester(b).eval(*eval_strs)

--- a/lib/pry/testable/evalable.rb
+++ b/lib/pry/testable/evalable.rb
@@ -11,7 +11,7 @@ module Pry::Testable::Evalable
   #
   # For super-high-level integration testing.
   #
-  # @see Pry::Testable::ReplTester
+  # @see Pry::Testable::ReplTester.start
   #
   # @example
   #   pry_repl_tester do |repl|

--- a/lib/pry/testable/repl_tester.rb
+++ b/lib/pry/testable/repl_tester.rb
@@ -1,0 +1,141 @@
+#
+# Pry::Testable::ReplTester is for super-high-level integration testing.
+#
+class Pry
+  module Testable
+    class ReplTester
+      class Input
+        def initialize(tester_mailbox)
+          @tester_mailbox = tester_mailbox
+        end
+
+        def readline(prompt)
+          @tester_mailbox.push prompt
+          mailbox.pop
+        end
+
+        def mailbox
+          Thread.current[:mailbox]
+        end
+      end
+
+      require 'delegate'
+      class Output < SimpleDelegator
+        def clear
+          __setobj__(StringIO.new)
+        end
+      end
+
+      #
+      # @example
+      #   Pry::Testable::ReplTester.start do |repl|
+      #     repl.enter_input '_pry_.config.prompt_name = "foo"'
+      #     expect(repl.last_prompt).to match('foo')
+      #   end
+      #
+      # @param [Hash] options
+      #   A hash that is passed to {Pry#initialize}.
+      #
+      def self.start(options = {})
+        Thread.current[:mailbox] = Queue.new
+        repl_tester = new({
+          input: Input.new(Thread.current[:mailbox]),
+          output: Output.new(StringIO.new),
+          color: false
+        }.merge!(options))
+        yield repl_tester
+        repl_tester.ensure_exit
+      ensure
+        if repl_tester && repl_tester.thread && repl_tester.thread.alive?
+          repl_tester.thread.kill
+        end
+      end
+
+      attr_accessor :thread, :mailbox, :last_prompt
+
+      def initialize(options = {})
+        @pry     = Pry.new(options)
+        @repl    = Pry::REPL.new(@pry)
+        @mailbox = Thread.current[:mailbox]
+
+        @thread  = Thread.new do
+          begin
+            Thread.current[:mailbox] = Queue.new
+            @repl.start
+          ensure
+            Thread.current[:session_ended] = true
+            mailbox.push nil
+          end
+        end
+
+        @should_exit_naturally = false
+
+        wait # wait until the instance reaches its first readline
+      end
+
+      #
+      # @param [String] input
+      #   Accept a line of input, as if entered by a user.
+      #
+      # @return [void]
+      #
+      def enter_input(input)
+        reset_output
+        repl_mailbox.push input
+        wait
+        @pry.output.string
+      end
+
+      #
+      # @return [String]
+      #   Returns the last prompt as a string.
+      #
+      def last_prompt
+        @last_prompt
+      end
+
+      #
+      # @return [String]
+      #   Returns the last output written to `Pry#output` as a string.
+      #
+      def last_output
+        @pry.output.string.chomp
+      end
+
+      #
+      # Assert that the Pry session ended naturally after the last input.
+      #
+      # @return [void]
+      #
+      def assert_exited
+        @should_exit_naturally = true
+      end
+
+      #
+      # @api private
+      #
+      def ensure_exit
+        if @should_exit_naturally
+          raise "Session was not ended!" unless @thread[:session_ended].equal?(true)
+        else
+          enter_input "exit-all"
+          raise "REPL didn't die" unless @thread[:session_ended]
+        end
+      end
+
+      private
+
+      def reset_output
+        @pry.output.clear
+      end
+
+      def repl_mailbox
+        @thread[:mailbox]
+      end
+
+      def wait
+        @last_prompt = mailbox.pop
+      end
+    end
+  end
+end

--- a/lib/pry/testable/repl_tester.rb
+++ b/lib/pry/testable/repl_tester.rb
@@ -130,7 +130,7 @@ class Pry
       #
       def ensure_exit
         if @should_exit_naturally
-          raise "Session was not ended!" unless @thread[:session_ended].equal?(true)
+          raise "Session was not ended!" unless @thread[:session_ended]
         else
           enter_input "exit-all"
           raise "REPL didn't die" unless @thread[:session_ended]

--- a/lib/pry/testable/repl_tester.rb
+++ b/lib/pry/testable/repl_tester.rb
@@ -1,9 +1,10 @@
-#
-# Pry::Testable::ReplTester is for super-high-level integration testing.
-#
 class Pry
   module Testable
+    #
+    # Pry::Testable::ReplTester is for super-high-level integration testing.
+    #
     class ReplTester
+      # @api private
       class Input
         def initialize(tester_mailbox)
           @tester_mailbox = tester_mailbox
@@ -20,6 +21,7 @@ class Pry
       end
 
       require 'delegate'
+      # @api private
       class Output < SimpleDelegator
         def clear
           __setobj__(StringIO.new)
@@ -35,6 +37,8 @@ class Pry
       #
       # @param [Hash] options
       #   A hash that is passed to {Pry#initialize}.
+      #
+      # @return [void]
       #
       def self.start(options = {})
         Thread.current[:mailbox] = Queue.new
@@ -56,16 +60,20 @@ class Pry
 
       #
       # @return [String]
-      #   Returns the last prompt as a string.
+      #   The last rendered prompt.
       #
       attr_reader :last_prompt
 
       #
       # @return [Pry]
-      #   Returns the instance of Pry being tested.
+      #   The instance of Pry being tested.
       #
       attr_reader :pry
 
+      #
+      # @param [options] options
+      #   a Hash that is passed to {Pry#initialize}.
+      #
       def initialize(options = {})
         @pry     = Pry.new(options)
         @repl    = Pry::REPL.new(@pry)
@@ -91,7 +99,7 @@ class Pry
       #   Accept a line of input, as if entered by a user.
       #
       # @return [String]
-      #   Returns the contents of {Pry#output}.
+      #   The contents of {Pry#output}.
       #
       def enter_input(input)
         reset_output
@@ -102,7 +110,7 @@ class Pry
 
       #
       # @return [String]
-      #   Returns the last output written to `Pry#output` as a string.
+      #   The last output written to `Pry#output`.
       #
       def last_output
         @pry.output.string.chomp

--- a/lib/pry/testable/repl_tester.rb
+++ b/lib/pry/testable/repl_tester.rb
@@ -51,7 +51,8 @@ class Pry
         end
       end
 
-      attr_accessor :thread, :mailbox, :last_prompt
+      attr_writer :last_prompt
+      attr_accessor :thread, :mailbox
 
       def initialize(options = {})
         @pry     = Pry.new(options)
@@ -90,9 +91,7 @@ class Pry
       # @return [String]
       #   Returns the last prompt as a string.
       #
-      def last_prompt
-        @last_prompt
-      end
+      attr_reader :last_prompt
 
       #
       # @return [String]

--- a/lib/pry/testable/repl_tester.rb
+++ b/lib/pry/testable/repl_tester.rb
@@ -54,6 +54,18 @@ class Pry
       attr_writer :last_prompt
       attr_accessor :thread, :mailbox
 
+      #
+      # @return [String]
+      #   Returns the last prompt as a string.
+      #
+      attr_reader :last_prompt
+
+      #
+      # @return [Pry]
+      #   Returns the instance of Pry being tested.
+      #
+      attr_reader :pry
+
       def initialize(options = {})
         @pry     = Pry.new(options)
         @repl    = Pry::REPL.new(@pry)
@@ -86,12 +98,6 @@ class Pry
         wait
         @pry.output.string
       end
-
-      #
-      # @return [String]
-      #   Returns the last prompt as a string.
-      #
-      attr_reader :last_prompt
 
       #
       # @return [String]

--- a/lib/pry/testable/repl_tester.rb
+++ b/lib/pry/testable/repl_tester.rb
@@ -90,7 +90,8 @@ class Pry
       # @param [String] input
       #   Accept a line of input, as if entered by a user.
       #
-      # @return [void]
+      # @return [String]
+      #   Returns the contents of {Pry#output}.
       #
       def enter_input(input)
         reset_output

--- a/lib/pry/testable/repl_tester.rb
+++ b/lib/pry/testable/repl_tester.rb
@@ -30,7 +30,7 @@ class Pry
       # @example
       #   Pry::Testable::ReplTester.start do |repl|
       #     repl.enter_input '_pry_.config.prompt_name = "foo"'
-      #     expect(repl.last_prompt).to match('foo')
+      #     expect(repl.last_prompt).to match(/foo/)
       #   end
       #
       # @param [Hash] options


### PR DESCRIPTION
ReplTester has been available for Pry specs for a long time, it provides
the only way i know to test the pry prompt. I thought it would be a good
idea to add a version suitable as a public API.

The main differences between this version and what we already have are:

  * it is test framework agnostic, it doesn't make assertions but allows
      you to make them yourself using whatever framework you are using.

  * To aid with being framework agnostic, ReplTester.start yields a block
      with self as an argument rather than using instance_eval.

  * 'input' is renamed to 'enter_input'

  * 'output' is renamed to 'last_output'

  * 'prompt' is renamed to 'last_prompt'

  * adds `ReplTester#pry` as a attr_reader, it seems useful for making assertions against after entering input.

Usage example:

```ruby
specify 'a test' do
  Pry::Testable::ReplTester.start do |repl|
    repl.enter_input '_pry_.config.prompt_name = "12345"'
    expect(repl.last_prompt).to match(/12345/)
   end
end
```

```ruby
RSpec.configure do |config|
  config.include Pry::Testable
end

specify 'a test' do 
  pry_repl_tester do |repl|
    repl.enter_input '_pry_.config.prompt_name = "12345"'
    expect(repl.last_prompt).to match(/12345/)
  end
end
```