### PR TITLE
update from_hash calls to not pass an explicit 'nil' as a second argu…

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -68,7 +68,7 @@ class Pry
     else
       # Otherwise, saves current binding stack as old stack and pops last
       # binding out of binding stack (the old stack still has that binding).
-      _pry_.command_state["cd"] ||= Pry::Config.from_hash({}) # FIXME
+      _pry_.command_state["cd"] ||= Pry::Config.from_hash({})
       _pry_.command_state['cd'].old_stack = _pry_.binding_stack.dup
       _pry_.binding_stack.pop
     end

--- a/lib/pry/commands/gem_stats.rb
+++ b/lib/pry/commands/gem_stats.rb
@@ -48,7 +48,7 @@ FAILWHALE
 
   private
   def format_gem(h)
-    h = Pry::Config.from_hash(h, nil)
+    h = Pry::Config.from_hash(h)
     format_str = unindent <<-FORMAT
     %{name} %{version}
     --

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -43,7 +43,7 @@ class Pry
         def from_hash(attributes, default = nil)
           new(default).tap do |config|
             attributes.each do |key,value|
-              config[key] = Hash === value ? from_hash(value, nil) : value
+              config[key] = Hash === value ? from_hash(value) : value
             end
           end
         end

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -119,10 +119,10 @@ class Pry
           Pry::InputCompleter
         },
         gist: proc {
-          Pry::Config.from_hash({inspecter: proc(&:pretty_inspect)}, nil)
+          Pry::Config.from_hash({inspecter: proc(&:pretty_inspect)})
         },
         history: proc {
-          Pry::Config.from_hash({should_save: true, should_load: true}, nil).tap do |history|
+          Pry::Config.from_hash({should_save: true, should_load: true}).tap do |history|
             history_file =
               if File.exist?(File.expand_path('~/.pry_history'))
                 '~/.pry_history'

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -71,7 +71,7 @@ class Pry
   #  Returns a value store for an instance of Pry running on the current thread.
   #
   def self.current
-    Thread.current[:__pry__] ||= Pry::Config.from_hash({}, nil)
+    Thread.current[:__pry__] ||= Pry::Config.from_hash({})
   end
 
   # Load the given file in the context of `Pry.toplevel_binding`


### PR DESCRIPTION
…ment.

The default for the optional second argument is already 'nil', so we don't
have to explicitly pass nil as a second argument.