### PR TITLE
prevent LoadError being raised when using auto completions + Bundler.

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -96,6 +96,7 @@ require 'tempfile'
 require 'pathname'
 
 require 'pry/version'
+require 'pry/input_completer'
 require 'pry/repl'
 require 'pry/code'
 require 'pry/ring'

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -115,7 +115,6 @@ class Pry
           Pry::Config.from_hash(Pry::Command::Ls::DEFAULT_OPTIONS)
         },
         completer: proc {
-          require_relative "../input_completer"
           Pry::InputCompleter
         },
         gist: proc {

--- a/lib/pry/config/default.rb
+++ b/lib/pry/config/default.rb
@@ -115,7 +115,7 @@ class Pry
           Pry::Config.from_hash(Pry::Command::Ls::DEFAULT_OPTIONS)
         },
         completer: proc {
-          require "pry/input_completer"
+          require_relative "../input_completer"
           Pry::InputCompleter
         },
         gist: proc {

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 Bundler.require :default, :test
 require 'pry/testable'
+require 'English'
 require_relative 'spec_helpers/mock_pry'
 require_relative 'spec_helpers/repl_tester'
 

--- a/spec/integration/bundler_spec.rb
+++ b/spec/integration/bundler_spec.rb
@@ -1,19 +1,19 @@
 RSpec.describe 'Bundler' do
-  before :all do
-    @ruby = RbConfig.ruby.shellescape
-    @pry_dir = File.expand_path(File.join(__FILE__, '../../../lib')).shellescape
-  end
+  let(:ruby) { RbConfig.ruby.shellescape }
+  let(:pry_dir) { File.expand_path(File.join(__FILE__, '../../../lib')).shellescape }
 
-  specify 'a LoadError is not raised after bundler has been activated' do
-    code = <<-RUBY
-    require "pry"
-    require "bundler/inline"
-    gemfile(true) do
-      source "https://rubygems.org"
+  context "when Pry requires Gemfile, which doesn't specify Pry as a dependency" do 
+    it "loads auto-completion correctly" do
+      code = <<-RUBY
+      require "pry"
+      require "bundler/inline"
+      gemfile(true) do
+        source "https://rubygems.org"
+      end
+      exit 42 if Pry.config.completer
+      RUBY
+      `#{ruby} -I#{pry_dir} -e'#{code}'`
+      expect($CHILD_STATUS.exitstatus).to eq(42)
     end
-    exit 42 if Pry.config.completer
-    RUBY
-    `#{@ruby} -I#{@pry_dir} -e'#{code}'`
-    expect($CHILD_STATUS.exitstatus).to eq(42)
   end
 end

--- a/spec/integration/bundler_spec.rb
+++ b/spec/integration/bundler_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe 'Bundler' do
+  before :all do
+    @ruby = RbConfig.ruby.shellescape
+    @pry_dir = File.expand_path(File.join(__FILE__, '../../../lib')).shellescape
+  end
+
+  specify 'a LoadError is not raised after bundler has been activated' do
+    code = <<-RUBY
+    require "pry"
+    require "bundler/inline"
+    gemfile(true) do
+      source "https://rubygems.org"
+    end
+    exit 42 if Pry.config.completer
+    RUBY
+    o = `#@ruby -I#@pry_dir -e'#{code}'`
+    expect($?.exitstatus).to eq(42)
+  end
+end

--- a/spec/integration/bundler_spec.rb
+++ b/spec/integration/bundler_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'Bundler' do
   let(:ruby) { RbConfig.ruby.shellescape }
   let(:pry_dir) { File.expand_path(File.join(__FILE__, '../../../lib')).shellescape }
 
-  context "when Pry requires Gemfile, which doesn't specify Pry as a dependency" do 
+  context "when Pry requires Gemfile, which doesn't specify Pry as a dependency" do
     it "loads auto-completion correctly" do
       code = <<-RUBY
       require "pry"

--- a/spec/integration/bundler_spec.rb
+++ b/spec/integration/bundler_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Bundler' do
     end
     exit 42 if Pry.config.completer
     RUBY
-    o = `#@ruby -I#@pry_dir -e'#{code}'`
-    expect($?.exitstatus).to eq(42)
+    `#{@ruby} -I#{@pry_dir} -e'#{code}'`
+    expect($CHILD_STATUS.exitstatus).to eq(42)
   end
 end


### PR DESCRIPTION
…ions.

The scenario:

- $ mkdir foogem
- $ cd foogem
- $ echo "source 'https://rubygems.org'" > Gemfile
- $ bundle install
- $ pry -rbundler/setup
- type `"foo".<tab>` into Pry # LoadError raised

Notice that a LoadError is raised when trying to require
"pry/input_completer". This happens because Pry is not in the
Gemfile, so once the sandbox is initialized by Bundler any require
for a Pry file is doomed to fail.

Couple that with the fact that `_pry_.config.completer` is not
read from until a user uses tab completion, and we end up in 
the situation described above.

The fix is easy and i also added a test case to confirm it works, as well as testing manually. 
I have seen this issue come up before in other issues, it can happen for example when 
loading Rails without pry being in the Rails app Gemfile.

I don't expect to be merged as-is, the test description in particular is pretty bad.