### PR TITLE
ring: fix swap parts of array in to_a and index access

### DIFF
--- a/lib/pry/ring.rb
+++ b/lib/pry/ring.rb
@@ -57,10 +57,7 @@ class Pry
         return @buffer[(count + index) % max_size] if index.is_a?(Integer)
         return @buffer[index] if count <= max_size
 
-        # Swap parts of array when the array turns page and starts overwriting
-        # from the beginning, then apply the range.
-        last_part = @buffer.slice([index.end, max_size - 1].min, count % max_size)
-        (last_part + (@buffer - last_part))[index]
+        transpose_buffer_tail[index]
       end
     end
 
@@ -68,8 +65,7 @@ class Pry
     def to_a
       return @buffer.dup if count <= max_size
 
-      last_part = @buffer.slice(count % max_size, @buffer.size)
-      last_part + (@buffer - last_part)
+      transpose_buffer_tail
     end
 
     # Clear the buffer and reset count.
@@ -79,6 +75,13 @@ class Pry
         @buffer = []
         @count = 0
       end
+    end
+
+    private
+
+    def transpose_buffer_tail
+      tail = @buffer.slice(count % max_size, @buffer.size)
+      tail.concat @buffer.slice(0, count % max_size)
     end
   end
 end

--- a/spec/ring_spec.rb
+++ b/spec/ring_spec.rb
@@ -13,6 +13,11 @@ describe Pry::Ring do
       ring << 1 << 2 << 3 << 4 << 5
       expect(ring.to_a).to eq([3, 4, 5])
     end
+
+    it "keeps duplicate elements" do
+      ring << 1 << 1 << 1 << 1
+      expect(ring.to_a).to eq([1, 1, 1])
+    end
   end
 
   describe "#[]" do
@@ -52,6 +57,10 @@ describe Pry::Ring do
         expect(ring[-1]).to eq(5)
         expect(ring[-2]).to eq(4)
         expect(ring[-3]).to eq(3)
+      end
+
+      it "returns the first element when accessed through 0..0" do
+        expect(ring[0..0]).to eq([3])
       end
 
       it "reads elements via inclusive range" do


### PR DESCRIPTION
I fixed a bug where the same value disappears when swapping parts of the array. 

example

`Pry.config.memory_size = 3`

before

```
[1] pry(main)> 1
=> 1
[2] pry(main)> 1
=> 1
[3] pry(main)> 1
=> 1
[3] pry(main)> 1
=> 1
[4] pry(main)> _pry_.input_ring.to_a
=> ["1\n"]
```

after

```
[1] pry(main)> 1
=> 1
[2] pry(main)> 1
=> 1
[3] pry(main)> 1
=> 1
[4] pry(main)> 1
=> 1
[5] pry(main)> _pry_.input_ring.to_a
=> ["1\n", "1\n", "1\n"]
```

and I fixed a bug that different values will be returned for Integer and Range.

```
[1] pry(main)> 1
=> 1
[2] pry(main)> 2
=> 2
[3] pry(main)> 3
=> 3
[4] pry(main)> 4
=> 4
```

```
[4] pry(main)> _pry_.input_ring[0]
=> "2\n"

[4] pry(main)> _pry_.input_ring[0..0]
=> "3\n"
```