### PR TITLE
Config#forget recursively removes a key from self and its default

### DIFF
--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -181,7 +181,7 @@ class Pry
       def forget(key)
         key = key.to_s
         __remove(key)
-        default.forget(key) if !default.nil? && default != last_default
+        default.forget(key) if default && default != last_default
       end
 
       #

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -181,6 +181,7 @@ class Pry
       def forget(key)
         key = key.to_s
         __remove(key)
+        default.forget(key) if !default.nil? && default != last_default
       end
 
       #

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -143,7 +143,7 @@ describe Pry::Config do
   end
 
   describe '#forget' do
-    it 'allows a key to return its default value' do
+    it 'restores a key to its default value' do
       last_default = described_class.from_hash(a: 'c')
       middle_default = described_class.from_hash({a: 'b'}, last_default)
       c = described_class.from_hash({a: 'a'}, middle_default)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -142,13 +142,13 @@ describe Pry::Config do
     end
   end
 
-  describe "#forget" do
-    it "forgets a local key" do
-      local = described_class.new described_class.from_hash(foo: 1)
-      local.foo = 2
-      expect(local.foo).to eq 2
-      local.forget(:foo)
-      expect(local.foo).to eq(1)
+  describe '#forget' do
+    it 'allows a key to return its default value' do
+      last_default = described_class.from_hash(a: 'c')
+      middle_default = described_class.from_hash({a: 'b'}, last_default)
+      c = described_class.from_hash({a: 'a'}, middle_default)
+      c.forget(:a)
+      expect(c.a).to eq('c')
     end
   end
 


### PR DESCRIPTION
```
 # .pryrc
 Pry.config.input = RbReadline

 # pry session
 pry(main)> _pry_.config.forget(:input)
 # This will unexpectedly return RbReadline instead of Pry's default, 'Readline'
 pry(main)> _pry_.config.input
```

I ran into this issue while working on a custom input, my pry plugin set
`Pry.config.input = Custom.new(..)` and then i expected to be able to restore
Prys default (Readline) by calling `_pry_.config.forget(:input)`.

But that wasn't the case, and instead I had to do this:

```
pry(main)> Pry.config.forget(:input)
pry(main)> _pry_.config.forget(:input)
```

which isn't the expected behavior.