### PR TITLE
Fix Ruby 2.6 warning for Binding#source_location

### DIFF
--- a/lib/pry/commands/edit/file_and_line_locator.rb
+++ b/lib/pry/commands/edit/file_and_line_locator.rb
@@ -3,7 +3,11 @@ class Pry
     module FileAndLineLocator
       class << self
         def from_binding(target)
-          [target.eval("__FILE__"), target.eval("__LINE__")]
+          if target.respond_to?(:source_location)
+            target.source_location
+          else
+            [target.eval("__FILE__"), target.eval("__LINE__")]
+          end
         end
 
         def from_code_object(code_object, filename_argument)

--- a/lib/pry/commands/play.rb
+++ b/lib/pry/commands/play.rb
@@ -86,7 +86,13 @@ class Pry
     # The file to play from when no code object is specified.
     # e.g `play --lines 4..10`
     def default_file
-      target.eval("__FILE__") && File.expand_path(target.eval("__FILE__"))
+      file =
+        if target.respond_to?(:source_location)
+          target.source_location.first
+        else
+          target.eval("__FILE__")
+        end
+      file && File.expand_path(file)
     end
 
     def file_content

--- a/lib/pry/commands/reload_code.rb
+++ b/lib/pry/commands/reload_code.rb
@@ -27,7 +27,13 @@ class Pry
     private
 
     def current_file
-      File.expand_path target.eval("__FILE__")
+      file =
+        if target.respond_to?(:source_location)
+          target.source_location.first
+        else
+          target.eval("__FILE__")
+        end
+      File.expand_path file
     end
 
     def reload_current_file

--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -37,8 +37,13 @@ class Pry
     BANNER
 
     def setup
-      @file = expand_path(target.eval('__FILE__'))
-      @line = target.eval('__LINE__')
+      if target.respond_to?(:source_location)
+        file, @line = target.source_location
+        @file = expand_path(file)
+      else
+        @file = expand_path(target.eval('__FILE__'))
+        @line = target.eval('__LINE__')
+      end
       @method = Pry::Method.from_binding(target)
     end
 


### PR DESCRIPTION
`eval('[__FILE__, __LINE__]')` will not work in future Ruby.
Let's stop using it when Binding#source_location is available because it
prints noisy warnings.

Since Binding#source_location is added in Ruby 2.6
https://github.com/ruby/ruby/commit/571e48b7442, this commit is leaving
old code with branching by binding.respond_to?(:source_location).

Fixes #1871