### PR TITLE
cli: fix undefined `load_path` error

### DIFF
--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -191,7 +191,7 @@ Pry::CLI.add_options do
     Pry.config.requires << file
   end
 
-  on(:I=, "Add a path to the $LOAD_PATH", as: Array, delimiter: ":") do
+  on(:I=, "Add a path to the $LOAD_PATH", as: Array, delimiter: ":") do |load_path|
     load_path.map! do |path|
       /\A\.\// =~ path ? path : File.expand_path(path)
     end


### PR DESCRIPTION
This was mistakenly removed in 22d4ff7b22e2d2b7f49c0d883fcaefd329d2d947.