### PR TITLE
Fix the 'clear-screen' command

### DIFF
--- a/lib/pry/commands/clear_screen.rb
+++ b/lib/pry/commands/clear_screen.rb
@@ -4,7 +4,7 @@ class Pry::Command::ClearScreen < Pry::ClassCommand
   description 'Clear the contents of the screen/window Pry is running in.'
 
   def process
-    if Helpers::Platform.windows?
+    if Pry::Helpers::Platform.windows?
       _pry_.config.system.call(_pry_.output, 'cls', _pry_)
     else
       _pry_.config.system.call(_pry_.output, 'clear', _pry_)

--- a/spec/commands/clear_screen_spec.rb
+++ b/spec/commands/clear_screen_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe "clear-screen" do
+  before do
+    @t = pry_tester
+  end
+
+  it 'calls the "clear" command on non-Windows platforms' do
+    expect(Pry.config.system).to receive(:call).with(an_instance_of(Pry::Output), 'clear', an_instance_of(Pry))
+    @t.process_command 'clear-screen'
+  end
+
+  it 'calls the "cls" command on Windows' do
+    expect(Pry::Helpers::Platform).to receive(:windows?).at_least(:once).and_return(true)
+    expect(Pry.config.system).to receive(:call).with(an_instance_of(Pry::Output), 'cls', an_instance_of(Pry))
+    @t.process_command 'clear-screen'
+  end
+end


### PR DESCRIPTION
    [1] pry(main)> clear-screen
    NameError: uninitialized constant Pry::Command::ClearScreen::Helpers
    Did you mean?  Pry::Helpers

    [1] pry(main)> pry-version
    Pry version: 0.12.2 on Ruby 2.5.1.