### PR TITLE
Refactor Pry::History to be Readline-agnostic

### DIFF
--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -11,23 +11,13 @@ class Pry
       @history = []
       @original_lines = 0
       @file_path = options[:file_path]
-      restore_default_behavior
-    end
-
-    # Assign the default methods for loading, saving, pushing, and clearing.
-    def restore_default_behavior
-      Pry.config.input # force Readline to load if applicable
 
       @loader = method(:read_from_file)
-      @saver  = method(:save_to_file)
+      @saver = method(:save_to_file)
 
-      if defined?(Readline)
-        @pusher  = method(:push_to_readline)
-        @clearer = method(:clear_readline)
-      else
-        @pusher  = proc {}
-        @clearer = proc {}
-      end
+      Pry.config.input # force Readline to load if applicable
+      @pusher = defined?(Readline) ? method(:push_to_readline) : proc {}
+      @clearer = defined?(Readline) ? method(:clear_readline) : proc {}
     end
 
     # Load the input history using `History.loader`.

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -2,22 +2,17 @@ class Pry
   # The History class is responsible for maintaining the user's input history,
   # both internally and within Readline.
   class History
-    attr_accessor :loader, :saver, :pusher, :clearer
+    attr_accessor :loader, :saver
 
     # @return [Fixnum] Number of lines in history when Pry first loaded.
     attr_reader :original_lines
 
     def initialize(options = {})
-      @history = []
-      @original_lines = 0
+      @history = options[:history] || []
       @file_path = options[:file_path]
-
+      @original_lines = 0
       @loader = method(:read_from_file)
       @saver = method(:save_to_file)
-
-      Pry.config.input # force Readline to load if applicable
-      @pusher = defined?(Readline) ? method(:push_to_readline) : proc {}
-      @clearer = defined?(Readline) ? method(:clear_readline) : proc {}
     end
 
     # Load the input history using `History.loader`.
@@ -26,7 +21,6 @@ class Pry
       @loader.call do |line|
         next if invalid_readline_line?(line)
 
-        @pusher.call(line.chomp)
         @history << line.chomp
         @original_lines += 1
       end
@@ -36,15 +30,21 @@ class Pry
     # @param [String] line
     # @return [String] The same line that was passed in
     def push(line)
-      empty_or_invalid_line = line.empty? || invalid_readline_line?(line)
+      return line if line.empty? || invalid_readline_line?(line)
 
-      unless empty_or_invalid_line || (@history.last && line == @history.last)
-        @pusher.call(line)
-        @history << line
-        if !should_ignore?(line) && Pry.config.history.should_save
-          @saver.call(line)
-        end
+      begin
+        last_line = @history[-1]
+      rescue IndexError
+        last_line = nil
       end
+
+      return line if line == last_line
+
+      @history << line
+      if !should_ignore?(line) && Pry.config.history.should_save
+        @saver.call(line)
+      end
+
       line
     end
     alias << push
@@ -52,9 +52,8 @@ class Pry
     # Clear this session's history. This won't affect the contents of the
     # history file.
     def clear
-      @clearer.call
+      @history.clear
       @original_lines = 0
-      @history = []
     end
 
     # @return [Fixnum] The number of lines in history.
@@ -71,7 +70,7 @@ class Pry
     # @return [Array<String>] An Array containing all lines of history loaded
     #   or entered by the user in the current session.
     def to_a
-      @history.dup
+      @history.to_a
     end
 
     # Filter the history with the histignore options
@@ -103,17 +102,6 @@ class Pry
       end
     rescue SystemCallError => error
       warn "Unable to read history file: #{error.message}"
-    end
-
-    # The default pusher. Appends the given line to Readline::HISTORY.
-    # @param [String] line
-    def push_to_readline(line)
-      Readline::HISTORY << line
-    end
-
-    # The default clearer. Clears Readline::HISTORY.
-    def clear_readline
-      Readline::HISTORY.shift until Readline::HISTORY.empty?
     end
 
     # The default saver. Appends the given line to `Pry.history.config.file`.

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -39,7 +39,14 @@ class Pry
     end
 
     def history
-      @history ||= History.new
+      return @history if @history
+
+      @history =
+        if defined?(Pry.config.input::HISTORY)
+          History.new(history: Pry.config.input::HISTORY)
+        else
+          History.new
+        end
     end
 
     #

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -104,7 +104,6 @@ describe Pry do
       @histfile = Tempfile.new(["pryhistory", "txt"])
       @history = Pry::History.new(file_path: @histfile.path)
       Pry.config.history.should_save = true
-      @history.pusher = proc {}
     end
 
     after do

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -15,7 +15,6 @@ describe Pry do
 
   after do
     Pry.history.clear
-    Pry.history.restore_default_behavior
     Pry.history.instance_variable_set(:@original_lines, 0)
   end
 
@@ -46,7 +45,6 @@ describe Pry do
       @hist_file_path = File.expand_path('spec/fixtures/pry_history')
       Pry.config.history.file = @hist_file_path
       Pry.history.clear
-      Pry.history.restore_default_behavior
       Pry.load_history
     end
 
@@ -84,36 +82,6 @@ describe Pry do
       Pry.load_history
 
       expect(Pry.history.history_line_count).to eq 5
-    end
-  end
-
-  describe "#restore_default_behavior" do
-    it "restores loader" do
-      Pry.history.loader = proc {}
-      Pry.history.restore_default_behavior
-      expect(Pry.history.loader.class).to eq Method
-      expect(Pry.history.loader.name.to_sym).to eq :read_from_file
-    end
-
-    it "restores saver" do
-      Pry.history.saver = proc {}
-      Pry.history.restore_default_behavior
-      expect(Pry.history.saver.class).to eq Method
-      expect(Pry.history.saver.name.to_sym).to eq :save_to_file
-    end
-
-    it "restores pusher" do
-      Pry.history.pusher = proc {}
-      Pry.history.restore_default_behavior
-      expect(Pry.history.pusher.class).to eq Method
-      expect(Pry.history.pusher.name.to_sym).to eq :push_to_readline
-    end
-
-    it "restores clearer" do
-      Pry.history.clearer = proc {}
-      Pry.history.restore_default_behavior
-      expect(Pry.history.clearer.class).to eq Method
-      expect(Pry.history.clearer.name.to_sym).to eq :clear_readline
     end
   end
 


### PR DESCRIPTION
1. The `options` parameter may contain the `:history` key, which contains a
   history array (typically `Readline::HISTORY`)

2. The `history` key is expected to have a history object as a value. Usually,
   it's `Readline::HISTORY`. This object *must* be Enumerable and implement
   `#clear` & `#to_a`. If nothing is provided, it defaults to an empty
   array. As result, no hard dependency on `Readline` anymore.

3. Removed duplicated history objects. It looks like the original code assumed
   that pushing to `Readline::HISTORY` also pushes to the file but it's not the
   case. There doesn't seem to be a real need to keep two arrays of history