### PR TITLE
CI against Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ references:
 jobs:
   rubocop_lint:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.6
     working_directory: ~/pry
     steps:
       - checkout
@@ -48,7 +48,7 @@ jobs:
           command: bundle exec rubocop --parallel
   yard_lint:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.6
     working_directory: ~/pry
     steps:
       - checkout
@@ -120,6 +120,15 @@ jobs:
       - <<: *bundle_install
       - <<: *install_ubuntu_nano
       - <<: *unit
+  "ruby-2.6":
+    docker:
+      - image: circleci/ruby:2.6
+    working_directory: ~/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *install_ubuntu_nano
+      - <<: *unit
   "jruby-9.1-jdk":
     docker:
       - image: circleci/jruby:9.1-jdk
@@ -170,6 +179,10 @@ workflows:
             - rubocop_lint
             - yard_lint
       - "ruby-2.5":
+          requires:
+            - rubocop_lint
+            - yard_lint
+      - "ruby-2.6":
           requires:
             - rubocop_lint
             - yard_lint


### PR DESCRIPTION
Ruby 2.6 has been released. 

- https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

This patch adds Ruby 2.6 to CI.
