### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,6 @@ FROM ruby:2.6-stretch
 RUN apt-get update -y
 RUN apt-get install -y wget make git emacs-nox
 
-RUN wget -O ruby-install-0.4.3.tar.gz https://github.com/postmodern/ruby-install/archive/v0.4.3.tar.gz
-RUN tar -xzvf ruby-install-0.4.3.tar.gz
-RUN cd ruby-install-0.4.3 && make install
-RUN ruby-install ruby 1.9.3
-
 ENV EDITOR emacs
 
 ADD . /pry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
-FROM ubuntu:latest
+# Usage:
+# $ docker build -t pry .
+# $ docker run -t pry
+FROM ruby:2.6-stretch
 
 RUN apt-get update -y
-RUN apt-get install -y wget make git
+RUN apt-get install -y wget make git emacs-nox
 
-RUN wget --no-check-certificate -O ruby-install-0.4.3.tar.gz https://github.com/postmodern/ruby-install/archive/v0.4.3.tar.gz
+RUN wget -O ruby-install-0.4.3.tar.gz https://github.com/postmodern/ruby-install/archive/v0.4.3.tar.gz
 RUN tar -xzvf ruby-install-0.4.3.tar.gz
 RUN cd ruby-install-0.4.3 && make install
-
 RUN ruby-install ruby 1.9.3
-RUN ruby-install ruby 2.1.1
-RUN ruby-install ruby 2.1.2
+
+ENV EDITOR emacs
 
 ADD . /pry
 WORKDIR /pry
+RUN bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Usage:
 # $ docker build -t pry .
-# $ docker run -t pry
+# $ docker run -i -t pry
 FROM ruby:2.6-stretch
 
 RUN apt-get update -y
@@ -11,3 +11,5 @@ ENV EDITOR emacs
 ADD . /pry
 WORKDIR /pry
 RUN bundle install
+
+ENTRYPOINT /bin/bash


### PR DESCRIPTION
* Switch to an image maintained by the Ruby team, running on Debian
Stretch, and targeting Ruby 2.6

* Remove insecure bypass of certificate validation when downloading
  ruby-install

* Run 'bundle install' while provisioning a container.

* Ruby 2.6 available

* Configure $EDITOR to use emacs (at least three Pry devs know emacs)