### PR TITLE
Update Pry::Config::Behavior#eager_load!

### DIFF
--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -277,7 +277,7 @@ class Pry
       #   An array of keys inserted into self, or nil if {#last_default} is nil.
       #
       def eager_load!
-        return if !last_default
+        return unless last_default
 
         last_default.keys.each { |key| self[key] = public_send(key) }
       end

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -262,30 +262,33 @@ class Pry
       end
 
       #
-      # Normally keys are read from a default on first access, this method can
-      # be used to eagerly load all keys from {#last_default} at once instead.
+      # Eagerly loads keys into self directly from #{last_default}.
       #
       # @example
-      #   _pry_.config.eager_load!
-      #   _pry_.config.keys # => [..., ..., ...]
       #
-      # @return [void]
+      #   [1] pry(main)> _pry_.config.keys.size
+      #   => 13
+      #  [2] pry(main)> _pry_.config.eager_load!;
+      #  [warning] Pry.config.exception_whitelist is deprecated, please use Pry.config.unrescued_exceptions instead.
+      #  [3] pry(main)> _pry_.config.keys.size
+      #  => 40
+      #
+      # @return [Array<String>, nil]
+      #   An array of keys inserted into self, or nil if {#last_default} is nil.
       #
       def eager_load!
-        default = @default
-        while default && default.respond_to?(:memoized_methods)
-          default.memoized_methods.each { self[key] = default.public_send(key) }
-          default = @default.default
-        end
+        return if !last_default
+
+        last_default.keys.each { |key| self[key] = public_send(key) }
       end
 
       #
       # @example
       #   # _pry_.config -> Pry.config -> Pry::Config.defaults
-      #   _pry_.config.last_default
+      #   [1] pry(main)> _pry_.config.last_default
       #
       # @return [Pry::Config::Behaviour]
-      #   The last default, or nil.
+      #   The last linked default, or nil if there is none.
       #
       def last_default
         last = @default

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -262,7 +262,7 @@ class Pry
       end
 
       #
-      # Eagerly loads keys into self directly from #{last_default}.
+      # Eagerly loads keys into self directly from {#last_default}.
       #
       # @example
       #

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -268,4 +268,14 @@ RSpec.describe Pry::Config do
       end
     end
   end
+
+  describe "#eager_load!" do
+    it "eagerly loads keys from the last default into self" do
+      last_default = described_class.from_hash(foo: 1, bar: 2, baz: 3)
+      c = described_class.from_hash({}, last_default)
+      expect(c.keys.size).to eq(0)
+      c.eager_load!
+      expect(c.keys.size).to eq(3)
+    end
+  end
 end


### PR DESCRIPTION
I don't think `#eager_load!` was working properly on Pry master or
even any of the released Prys from a quick test I did.

The `memoized_methods` method `eager_load!` is relying on has
since been removed from master too, so an update is needed.

The new implementation is simpler, and it includes a test case to
check that its behaving as expected because my manual tests suggest
it was not (I observed some keys being loaded but not all of them).