### PR TITLE
Various rubocop fixes (2)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,17 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 9
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: consistent, consistent_relative_to_receiver, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
-Layout/FirstParameterIndentation:
-  Exclude:
-    - 'lib/pry/input_completer.rb'
-    - 'spec/command_spec.rb'
-    - 'spec/commands/ls_spec.rb'
-    - 'spec/method_spec.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,13 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Layout/EmptyLinesAroundMethodBody:
-  Exclude:
-    - 'lib/pry/code_object.rb'
-    - 'lib/pry/indent.rb'
-
 # Offense count: 16
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,19 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 10
-# Cop supports --auto-correct.
-Layout/EmptyLinesAroundAccessModifier:
-  Exclude:
-    - 'lib/pry/commands/cat/abstract_formatter.rb'
-    - 'lib/pry/commands/change_inspector.rb'
-    - 'lib/pry/commands/gem_search.rb'
-    - 'lib/pry/commands/gem_stats.rb'
-    - 'lib/pry/commands/list_inspectors.rb'
-    - 'lib/pry/helpers/table.rb'
-    - 'lib/pry/plugins.rb'
-    - 'spec/method_spec.rb'
-
 # Offense count: 6
 # Cop supports --auto-correct.
 Layout/EmptyLinesAroundExceptionHandlingKeywords:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,13 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: IndentationWidth.
-Layout/IndentAssignment:
-  Exclude:
-    - 'lib/pry/helpers/text.rb'
-
 # Offense count: 4
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,14 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: special_inside_parentheses, consistent, align_brackets
-Layout/IndentArray:
-  Exclude:
-    - 'lib/pry/input_completer.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: IndentationWidth.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,15 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 6
-# Cop supports --auto-correct.
-Layout/EmptyLinesAroundExceptionHandlingKeywords:
-  Exclude:
-    - 'lib/pry/code_object.rb'
-    - 'lib/pry/input_lock.rb'
-    - 'lib/pry/method.rb'
-    - 'lib/pry/method/patcher.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Layout/EmptyLinesAroundMethodBody:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,13 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Layout/EmptyLineAfterMagicComment:
-  Exclude:
-    - 'lib/pry/pry_instance.rb'
-    - 'lib/pry/terminal.rb'
-
 # Offense count: 10
 # Cop supports --auto-correct.
 Layout/EmptyLinesAroundAccessModifier:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,15 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: special_inside_parentheses, consistent, align_braces
-Layout/IndentHash:
-  Exclude:
-    - 'lib/pry/commands/ls.rb'
-    - 'lib/pry/pry_instance.rb'
-
 # Offense count: 9
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,22 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 16
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
-Layout/EmptyLinesAroundModuleBody:
-  Exclude:
-    - 'lib/pry/commands/ls/interrogatable.rb'
-    - 'lib/pry/commands/ls/jruby_hacks.rb'
-    - 'lib/pry/commands/ls/methods_helper.rb'
-    - 'lib/pry/helpers/command_helpers.rb'
-    - 'lib/pry/helpers/documentation_helpers.rb'
-    - 'lib/pry/helpers/table.rb'
-    - 'lib/pry/rubygem.rb'
-    - 'spec/commands/show_doc_spec.rb'
-    - 'spec/commands/show_source_spec.rb'
-
 # Offense count: 9
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,13 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: AllowBorderComment, AllowMarginComment.
-Layout/EmptyComment:
-  Exclude:
-    - 'spec/command_spec.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Layout/EmptyLineAfterMagicComment:

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -127,7 +127,6 @@ class Pry
           nil
         end
       end
-
     rescue Pry::RescuableException
       nil
     end

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -112,7 +112,6 @@ class Pry
 
     # lookup variables and constants and `self` that are not modules
     def default_lookup
-
       # we skip instance methods as we want those to fall through to method_or_class_lookup()
       if safe_to_evaluate?(str) && !looks_like_an_instance_method?(str)
         obj = target.eval(str)

--- a/lib/pry/commands/gem_stats.rb
+++ b/lib/pry/commands/gem_stats.rb
@@ -47,6 +47,7 @@ VVVVVVVVVVVVVVVVVVVVV
   end
 
   private
+
   def format_gem(h)
     h = Pry::Config.from_hash(h)
     format_str = unindent <<-FORMAT

--- a/lib/pry/commands/ls.rb
+++ b/lib/pry/commands/ls.rb
@@ -77,13 +77,13 @@ class Pry
     def process
       @interrogatee = args.empty? ? target_self : target.eval(args.join(' '))
       raise_errors_if_arguments_are_weird
-      ls_entity = LsEntity.new({
+      ls_entity = LsEntity.new(
         interrogatee: @interrogatee,
         no_user_opts: no_user_opts?,
         opts: opts,
         args: args,
         _pry_: _pry_
-      })
+      )
 
       _pry_.pager.page ls_entity.entities_table
     end

--- a/lib/pry/commands/ls/interrogatable.rb
+++ b/lib/pry/commands/ls/interrogatable.rb
@@ -1,5 +1,4 @@
 module Pry::Command::Ls::Interrogatable
-
   private
 
   def interrogating_a_module?
@@ -14,5 +13,4 @@ module Pry::Command::Ls::Interrogatable
       singleton.ancestors.grep(::Class).reject { |c| c == singleton }.first
     end
   end
-
 end

--- a/lib/pry/commands/ls/jruby_hacks.rb
+++ b/lib/pry/commands/ls/jruby_hacks.rb
@@ -1,5 +1,4 @@
 module Pry::Command::Ls::JRubyHacks
-
   private
 
   # JRuby creates lots of aliases for methods imported from java in an attempt
@@ -45,5 +44,4 @@ module Pry::Command::Ls::JRubyHacks
       end
     end.inject(&:+) + (name.size / 100.0)
   end
-
 end

--- a/lib/pry/commands/ls/methods_helper.rb
+++ b/lib/pry/commands/ls/methods_helper.rb
@@ -1,7 +1,6 @@
 require 'pry/commands/ls/jruby_hacks'
 
 module Pry::Command::Ls::MethodsHelper
-
   include Pry::Command::Ls::JRubyHacks
 
   private
@@ -42,5 +41,4 @@ module Pry::Command::Ls::MethodsHelper
       end
     end
   end
-
 end

--- a/lib/pry/helpers/command_helpers.rb
+++ b/lib/pry/helpers/command_helpers.rb
@@ -1,6 +1,5 @@
 class Pry
   module Helpers
-
     module CommandHelpers
       include OptionsHelpers
 
@@ -152,6 +151,5 @@ class Pry
         _pry_.inject_local("_dir_", _pry_.last_dir, target)
       end
     end
-
   end
 end

--- a/lib/pry/helpers/documentation_helpers.rb
+++ b/lib/pry/helpers/documentation_helpers.rb
@@ -1,6 +1,5 @@
 class Pry
   module Helpers
-
     # This class contains methods useful for extracting
     # documentation from methods and classes.
     module DocumentationHelpers

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -110,6 +110,5 @@ class Pry
         @colorless_cache[thing]
       end
     end
-
   end
 end

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -80,6 +80,7 @@ class Pry
       def to_a; items.to_a end
 
       private
+
       def _max_width(things)
         things.compact.map(&:size).max || 0
       end

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -3,8 +3,7 @@ class Pry
     # The methods defined on {Text} are available to custom commands via {Pry::Command#text}.
     module Text
       extend self
-      COLORS =
-      {
+      COLORS = {
         "black" => 0,
         "red" => 1,
         "green" => 2,

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -193,7 +193,6 @@ class Pry
     # @return [Array[Integer]]
     #
     def indentation_delta(tokens)
-
       # We need to keep track of whether we've seen a "for" on this line because
       # if the line ends with "do" then that "do" should be discounted (i.e. we're
       # only opening one level not two) To do this robustly we want to keep track

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -14,30 +14,31 @@ class Pry::InputCompleter
   GLOBALVARIABLE_REGEXP     = /^(\$[^.]*)$/
   VARIABLE_REGEXP           = /^([^."].*)\.([^.]*)$/
 
-  ReservedWords = [
-                   "BEGIN", "END",
-                   "alias", "and",
-                   "begin", "break",
-                   "case", "class",
-                   "def", "defined", "do",
-                   "else", "elsif", "end", "ensure",
-                   "false", "for",
-                   "if", "in",
-                   "module",
-                   "next", "nil", "not",
-                   "or",
-                   "redo", "rescue", "retry", "return",
-                   "self", "super",
-                   "then", "true",
-                   "undef", "unless", "until",
-                   "when", "while",
-                   "yield" ]
+  ReservedWords = %w[
+    BEGIN END
+    alias and
+    begin break
+    case class
+    def defined do
+    else elsif end ensure
+    false for
+    if in
+    module
+    next nil not
+    or
+    redo rescue retry return
+    self super
+    then true
+    undef unless until
+    when while
+    yield
+  ].freeze
 
-  Operators = [
-               "%", "&", "*", "**", "+", "-", "/",
-               "<", "<<", "<=", "<=>", "==", "===", "=~", ">", ">=", ">>",
-               "[]", "[]=", "^", "!", "!=", "!~"
-              ]
+  Operators = %w[
+    % & * ** + - /
+    < << <= <=> == === =~ > >= >>
+    [] []= ^ ! != !~
+  ].freeze
 
   WORD_ESCAPE_STR = " \t\n\"\\'`><=;|&{("
 

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -188,10 +188,10 @@ class Pry::InputCompleter
         select_message(path, receiver, message, candidates)
       else
         candidates = eval(
-                          "methods | private_methods | local_variables | " \
-                          "self.class.constants | instance_variables",
-                          bind
-                        ).collect(&:to_s)
+          "methods | private_methods | local_variables | " \
+          "self.class.constants | instance_variables",
+          bind
+        ).collect(&:to_s)
 
         if eval("respond_to?(:class_variables)", bind)
           candidates += eval("class_variables", bind).collect(&:to_s)

--- a/lib/pry/input_lock.rb
+++ b/lib/pry/input_lock.rb
@@ -57,7 +57,6 @@ class Pry
       end
 
       block.call
-
     ensure
       @mutex.synchronize do
         # We are releasing any desire to have the input ownership by removing
@@ -111,7 +110,6 @@ class Pry
       # the readline call succeeded, but we'll never know, and we will retry the
       # call, discarding that piece of input.
       block.call
-
     rescue Interrupt
       # We were asked to back off. The one requesting the interrupt will be
       # waiting on the conditional for the interruptible flag to change to false.
@@ -122,7 +120,6 @@ class Pry
       leave_interruptible_region
       sleep 0.01
       retry
-
     ensure
       leave_interruptible_region
     end

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -59,7 +59,6 @@ class Pry
           from_str(name, target, instance: true) ||
             from_str(name, target, methods: true)
         end
-
       rescue Pry::RescuableException
         nil
       end

--- a/lib/pry/method/patcher.rb
+++ b/lib/pry/method/patcher.rb
@@ -51,7 +51,6 @@ class Pry
           alias_method method.name, method.original_name
           alias_method method.original_name, temp_name
         end
-
       ensure
         method.send(:remove_method, temp_name) rescue nil
       end

--- a/lib/pry/plugins.rb
+++ b/lib/pry/plugins.rb
@@ -110,6 +110,7 @@ class Pry
     end
 
     private
+
     def plugin_located?(plugin)
       @plugins.any? { |existing| existing.gem_name == plugin.gem_name }
     end

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 ##
 # Pry is a powerful alternative to the standard IRB shell for Ruby. It
 # features syntax highlighting, a flexible plugin architecture, runtime

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -540,19 +540,19 @@ class Pry
     object = current_binding.eval('self')
     open_token = @indent.open_delimiters.last || @indent.stack.last
 
-    c = Pry::Config.assign({
-        object: object,
-        nesting_level: binding_stack.size - 1,
-        open_token: open_token,
-        session_line: Pry.history.session_line_count + 1,
-        history_line: Pry.history.history_line_count + 1,
-        expr_number: input_ring.count,
-        _pry_: self,
-        binding_stack: binding_stack,
-        input_ring: input_ring,
-        eval_string: @eval_string,
-        cont: !@eval_string.empty?
-      })
+    c = Pry::Config.assign(
+      object: object,
+      nesting_level: binding_stack.size - 1,
+      open_token: open_token,
+      session_line: Pry.history.session_line_count + 1,
+      history_line: Pry.history.history_line_count + 1,
+      expr_number: input_ring.count,
+      _pry_: self,
+      binding_stack: binding_stack,
+      input_ring: input_ring,
+      eval_string: @eval_string,
+      cont: !@eval_string.empty?
+    )
 
     Pry.critical_section do
       # If input buffer is empty, then use normal prompt. Otherwise use the wait

--- a/lib/pry/rubygem.rb
+++ b/lib/pry/rubygem.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 
 class Pry
   module Rubygem
-
     class << self
       def installed?(name)
         if Gem::Specification.respond_to?(:find_all_by_name)
@@ -79,6 +78,5 @@ class Pry
         Gem.refresh
       end
     end
-
   end
 end

--- a/lib/pry/terminal.rb
+++ b/lib/pry/terminal.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 class Pry::Terminal
   class << self
     # Return a pair of [rows, columns] which gives the size of the window.

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -7,7 +7,6 @@ describe "Pry::Command" do
   describe 'call_safely' do
     it 'should display a message if gems are missing' do
       cmd = @set.create_command "ford-prefect", "From a planet near Beetlegeuse", requires_gem: %w(ghijkl) do
-        #
       end
 
       expect(mock_command(cmd, %w(hello world)).output).to match(/install-command ford-prefect/)
@@ -15,7 +14,6 @@ describe "Pry::Command" do
 
     it 'should abort early if arguments are required' do
       cmd = @set.create_command 'arthur-dent', "Doesn't understand Thursdays", argument_required: true do
-        #
       end
 
       expect { mock_command(cmd, %w()) }.to raise_error Pry::CommandError
@@ -79,7 +77,6 @@ describe "Pry::Command" do
   describe 'help' do
     it 'should default to the description for blocky commands' do
       @set.command 'oolon-colluphid', "Raving Atheist" do
-        #
       end
 
       expect(mock_command(@set['help'], %w(oolon-colluphid), command_set: @set).output).to match(/Raving Atheist/)
@@ -196,9 +193,7 @@ describe "Pry::Command" do
 
     it 'should raise a command error if process is not overridden' do
       cmd = @set.create_command 'jeltz', "Commander of a Vogon constructor fleet" do
-        def proccces
-          #
-        end
+        def proccces; end
       end
 
       expect { mock_command(cmd) }.to raise_error Pry::CommandError

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -784,10 +784,10 @@ describe "Pry::Command" do
   describe 'group' do
     before do
       @set.import(
-                  Pry::CommandSet.new do
-                    create_command("magic") { group("Not for a public use") }
-                  end
-                )
+        Pry::CommandSet.new do
+          create_command("magic") { group("Not for a public use") }
+        end
+      )
     end
 
     it 'should be correct for default commands' do

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -20,13 +20,19 @@ describe "ls" do
     end
 
     it "should include super-classes by default" do
-      expect(pry_eval(
-        "cd Class.new(Class.new{ def goo; end; public :goo }).new",
-        "ls")).to match(/goo/)
+      expect(
+        pry_eval(
+          "cd Class.new(Class.new{ def goo; end; public :goo }).new",
+          "ls"
+        )
+      ).to match(/goo/)
 
-      expect(pry_eval(
-        "cd Class.new(Class.new{ def goo; end; public :goo })",
-        "ls -M")).to match(/goo/)
+      expect(
+        pry_eval(
+          "cd Class.new(Class.new{ def goo; end; public :goo })",
+          "ls -M"
+        )
+      ).to match(/goo/)
     end
 
     it "should not include super-classes when -q is given" do
@@ -47,10 +53,12 @@ describe "ls" do
     end
 
     it "should work on subclasses of BasicObject" do
-      expect(pry_eval(
-        "class LessBasic < BasicObject; def jaroussky; 5; end; end",
-        "ls LessBasic.new"
-      )).to match(/LessBasic#methods:.*jaroussky/m)
+      expect(
+        pry_eval(
+          "class LessBasic < BasicObject; def jaroussky; 5; end; end",
+          "ls LessBasic.new"
+        )
+      ).to match(/LessBasic#methods:.*jaroussky/m)
     end
   end
 
@@ -127,6 +135,7 @@ describe "ls" do
       expect(result).not_to match(/0x\d{5}/)
       expect(result).to match(/asdf.*xyz/m)
     end
+
     it 'should not list pry noise' do
       expect(pry_eval('ls -l')).not_to match(/_(?:dir|file|ex|pry|out|in)_/)
     end
@@ -134,17 +143,23 @@ describe "ls" do
 
   describe "when inside Modules" do
     it "should still work" do
-      expect(pry_eval(
-        "cd Module.new{ def foobie; end; public :foobie }",
-        "ls -M")).to match(/foobie/)
+      expect(
+        pry_eval(
+          "cd Module.new{ def foobie; end; public :foobie }",
+          "ls -M"
+        )
+      ).to match(/foobie/)
     end
 
     it "should work for ivars" do
-      expect(pry_eval(
-        "module StigmaT1sm; def foobie; @@gharble = 456; end; end",
-        "Object.new.tap{ |o| o.extend(StigmaT1sm) }.foobie",
-        "cd StigmaT1sm",
-        "ls -i")).to match(/@@gharble/)
+      expect(
+        pry_eval(
+          "module StigmaT1sm; def foobie; @@gharble = 456; end; end",
+          "Object.new.tap{ |o| o.extend(StigmaT1sm) }.foobie",
+          "cd StigmaT1sm",
+          "ls -i"
+        )
+      ).to match(/@@gharble/)
     end
 
     it "should include instance methods by default" do
@@ -184,11 +199,13 @@ describe "ls" do
     end
 
     it "should show constants for an object's class regardless of mixins" do
-      expect(pry_eval(
-        "cd Pry.new",
-        "extend Module.new",
-        "ls -c"
-      )).to match(/Method/)
+      expect(
+        pry_eval(
+          "cd Pry.new",
+          "extend Module.new",
+          "ls -c"
+        )
+      ).to match(/Method/)
     end
   end
 

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -356,7 +356,6 @@ describe "show-doc" do
     describe "when no class/module arg is given" do
       before do
         module TestHost
-
           # hello there froggy
           module M
             def d; end
@@ -530,7 +529,6 @@ describe "show-doc" do
     describe "for modules" do
       before do
         module Jesus
-
           # alpha-doc
           module Alpha
             def alpha; :alpha; end

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -611,7 +611,6 @@ describe "show-source" do
         describe "should skip over broken modules" do
           before do
             module BabyDuck
-
               module Muesli
                 binding.eval("def a; end", "dummy.rb", 1)
                 binding.eval("def b; end", "dummy.rb", 2)

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -486,10 +486,11 @@ describe Pry::Method do
       end
 
       it "should include the Pry::Method.instance_resolution_order of Class after the singleton classes" do
-        expect(Pry::Method.resolution_order(LS::Top)).to eq(
-                                                           [eigen_class(LS::Top), eigen_class(Object), eigen_class(BasicObject),
-                                                            *Pry::Method.instance_resolution_order(Class)]
-                                                         )
+        singleton_classes = [
+          eigen_class(LS::Top), eigen_class(Object), eigen_class(BasicObject),
+          *Pry::Method.instance_resolution_order(Class)
+        ]
+        expect(Pry::Method.resolution_order(LS::Top)).to eq(singleton_classes)
       end
     end
   end

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -262,9 +262,11 @@ describe Pry::Method do
     it 'should be able to find private and protected instance methods defined in a class' do
       @class = Class.new do
         protected
+
         def prot; 1; end
 
         private
+
         def priv; 1; end
       end
       should_find_method('priv')
@@ -537,6 +539,7 @@ describe Pry::Method do
       # top-level methods get added as private instance methods on Object
       class Object
         private
+
         def my_top_level_method ; end
         alias my_other_top_level_method my_top_level_method
       end


### PR DESCRIPTION
Fixes for:

* Layout/EmptyComment:
* Layout/EmptyLineAfterMagicComment:
* Layout/EmptyLinesAroundAccessModifier:
* Layout/EmptyLinesAroundExceptionHandlingKeywords:
* Layout/EmptyLinesAroundMethodBody:
* Layout/EmptyLinesAroundModuleBody:
* Layout/FirstParameterIndentation:
* Layout/IndentArray:
* Layout/IndentAssignment:
* Layout/IndentHash:
