### PR TITLE
Fix various rubocop offences

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,14 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: symmetrical, new_line, same_line
-Layout/MultilineHashBraceLayout:
-  Exclude:
-    - 'lib/pry/pry_instance.rb'
-
 # Offense count: 9
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,17 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 9
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: symmetrical, new_line, same_line
-Layout/MultilineMethodCallBraceLayout:
-  Exclude:
-    - 'lib/pry/cli.rb'
-    - 'lib/pry/helpers/options_helpers.rb'
-    - 'spec/commands/ls_spec.rb'
-    - 'spec/commands/reload_code_spec.rb'
-
 # Offense count: 10
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,14 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Layout/LeadingCommentSpace:
-  Exclude:
-    - 'lib/pry/commands/ls/instance_vars.rb'
-    - 'lib/pry/input_completer.rb'
-    - 'spec/fixtures/show_source_doc_examples.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,22 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 13
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: aligned, indented
-Layout/MultilineOperationIndentation:
-  Exclude:
-    - 'lib/pry/commands/edit.rb'
-    - 'lib/pry/commands/ls.rb'
-    - 'lib/pry/commands/ls/constants.rb'
-    - 'lib/pry/commands/whereami.rb'
-    - 'lib/pry/helpers/table.rb'
-    - 'lib/pry/method/weird_method_locator.rb'
-    - 'lib/pry/pry_instance.rb'
-    - 'lib/pry/slop/option.rb'
-    - 'lib/pry/wrapped_module.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Layout/RescueEnsureAlignment:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,17 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 10
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: aligned, indented, indented_relative_to_receiver
-Layout/MultilineMethodCallIndentation:
-  Exclude:
-    - 'lib/pry/commands/cat/input_expression_formatter.rb'
-    - 'lib/pry/wrapped_module.rb'
-    - 'spec/command_set_spec.rb'
-    - 'spec/pry_defaults_spec.rb'
-
 # Offense count: 13
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,15 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: symmetrical, new_line, same_line
-Layout/MultilineArrayBraceLayout:
-  Exclude:
-    - 'lib/pry/exceptions.rb'
-    - 'lib/pry/input_completer.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,15 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 9
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: normal, rails
-Layout/IndentationConsistency:
-  Exclude:
-    - 'spec/commands/show_source_spec.rb'
-    - 'spec/indent_spec.rb'
-
 # Offense count: 12
 # Cop supports --auto-correct.
 # Configuration parameters: Width, IgnoredPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,19 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 12
-# Cop supports --auto-correct.
-# Configuration parameters: Width, IgnoredPatterns.
-Layout/IndentationWidth:
-  Exclude:
-    - 'lib/pry/commands/edit.rb'
-    - 'lib/pry/commands/help.rb'
-    - 'lib/pry/method.rb'
-    - 'spec/command_set_spec.rb'
-    - 'spec/command_spec.rb'
-    - 'spec/commands/show_source_spec.rb'
-    - 'spec/helper.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 Layout/LeadingCommentSpace:

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -217,8 +217,8 @@ Pry::CLI.add_options do
     exit
   end
 
-  on(:c, :context=,
-     "Start the session in the specified context. Equivalent to `context.pry` in a session.",
+  on :c, :context=,
+     "Start the session in the specified context. Equivalent to " \
+     "`context.pry` in a session.",
      default: "Pry.toplevel_binding"
-  )
 end

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -73,7 +73,10 @@ class Pry
     end
 
     def runtime_patch?
-       !file_based_exception? && (opts.present?(:patch) || previously_patched?(code_object) || pry_method?(code_object))
+      !file_based_exception? &&
+        (opts.present?(:patch) ||
+         previously_patched?(code_object) ||
+         pry_method?(code_object))
     end
 
     def apply_runtime_patch

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -135,7 +135,8 @@ class Pry
     end
 
     def code_object
-      @code_object ||= !probably_a_file?(filename_argument) &&
+      @code_object ||=
+        !probably_a_file?(filename_argument) &&
         Pry::CodeObject.lookup(filename_argument, _pry_)
     end
 

--- a/lib/pry/commands/help.rb
+++ b/lib/pry/commands/help.rb
@@ -45,7 +45,7 @@ class Pry
         commands = sorted_commands(groups[group_name])
 
         if commands.any?
-           help_text << help_text_for_commands(group_name, commands)
+          help_text << help_text_for_commands(group_name, commands)
         end
       end
 

--- a/lib/pry/commands/ls.rb
+++ b/lib/pry/commands/ls.rb
@@ -55,8 +55,8 @@ class Pry
       opt.on :v, :verbose,   "Show methods and constants on all super-classes (ignores Pry.config.ls.ceiling)"
       opt.on :g, :globals,   "Show global variables, including those builtin to Ruby (in cyan)"
       opt.on :l, :locals,    "Show hash of local vars, sorted by descending size"
-      opt.on :c, :constants, "Show constants, highlighting classes (in blue), and exceptions (in purple).\n" <<
-      " " * 32 <<            "Constants that are pending autoload? are also shown (in yellow)"
+      opt.on :c, :constants, "Show constants, highlighting classes (in blue), and exceptions (in purple).\n" \
+                             "#{' ' * 32}Constants that are pending autoload? are also shown (in yellow)"
       opt.on :i, :ivars,     "Show instance variables (in blue) and class variables (in bright blue)"
       opt.on :G, :grep,      "Filter output by regular expression", argument: true
       if Object.respond_to?(:deprecate_constant)

--- a/lib/pry/commands/ls/constants.rb
+++ b/lib/pry/commands/ls/constants.rb
@@ -35,8 +35,8 @@ class Pry
       def format(mod, constants)
         constants.sort_by(&:downcase).map do |name|
           if Object.respond_to?(:deprecate_constant) &&
-            DEPRECATED_CONSTANTS.include?(name)      &&
-            !show_deprecated_constants?
+             DEPRECATED_CONSTANTS.include?(name) &&
+             !show_deprecated_constants?
             next
           end
 

--- a/lib/pry/commands/ls/instance_vars.rb
+++ b/lib/pry/commands/ls/instance_vars.rb
@@ -20,7 +20,7 @@ class Pry
         ivars = if Object === @interrogatee
                   Pry::Method.safe_send(@interrogatee, :instance_variables)
                 else
-                  [] #TODO: BasicObject support
+                  [] # TODO: BasicObject support
                 end
         kvars = Pry::Method.safe_send(interrogatee_mod, :class_variables)
         ivars_out = output_section('instance variables', format(:instance_var, ivars))

--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -98,10 +98,12 @@ class Pry
 
       set_file_and_dir_locals(@file)
 
-      out = "\n#{bold('From:')} #{location}:\n\n" <<
-        code.with_line_numbers(use_line_numbers?).with_marker(marker).highlighted << "\n"
-
-      _pry_.pager.page out
+      pretty_code = code.with_line_numbers(use_line_numbers?)
+        .with_marker(marker)
+        .highlighted
+      _pry_.pager.page(
+        "\n#{bold('From:')} #{location}:\n\n" << pretty_code << "\n"
+      )
     end
 
     private

--- a/lib/pry/exceptions.rb
+++ b/lib/pry/exceptions.rb
@@ -49,9 +49,10 @@ class Pry
   # the exception is just a vanilla RuntimeError.
   module FrozenObjectException
     def self.===(exception)
-      ["can't modify frozen class/module",
-       "can't modify frozen Class",
-       "can't modify frozen object",
+      [
+        "can't modify frozen class/module",
+        "can't modify frozen Class",
+        "can't modify frozen object"
       ].include?(exception.message)
     end
   end

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -23,8 +23,9 @@ class Pry
 
     def self.tablify(things, line_length, config = Pry.config)
       table = Table.new(things, { column_count: things.size }, config)
-      table.column_count -= 1 until (1 == table.column_count) ||
-        table.fits_on_line?(line_length)
+      until (1 == table.column_count) || table.fits_on_line?(line_length)
+        table.column_count -= 1
+      end
       table
     end
 

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -213,7 +213,7 @@ class Pry::InputCompleter
         path.call(receiver + "." << e)
       when /^[0-9]/
       when *Operators
-        #receiver + " " << e
+        # receiver + " " << e
       end
     end.compact
   end

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -330,15 +330,16 @@ class Pry
     # @return [Symbol] The visibility of the method. May be `:public`,
     #   `:protected`, or `:private`.
     def visibility
-     @visibility ||= if owner.public_instance_methods.any? { |m| m.to_s == name }
-                       :public
-                     elsif owner.protected_instance_methods.any? { |m| m.to_s == name }
-                       :protected
-                     elsif owner.private_instance_methods.any? { |m| m.to_s == name }
-                       :private
-                     else
-                       :none
-                     end
+      @visibility ||=
+        if owner.public_instance_methods.any? { |m| m.to_s == name }
+          :public
+        elsif owner.protected_instance_methods.any? { |m| m.to_s == name }
+          :protected
+        elsif owner.private_instance_methods.any? { |m| m.to_s == name }
+          :private
+        else
+          :none
+        end
     end
 
     # @return [String] A representation of the method's signature, including its

--- a/lib/pry/method/weird_method_locator.rb
+++ b/lib/pry/method/weird_method_locator.rb
@@ -31,7 +31,7 @@ class Pry
               binding_file, binding_line = b.eval('__FILE__'), b.eval('__LINE__')
             end
             (File.expand_path(method.source_file) == File.expand_path(binding_file)) &&
-            method.source_range.include?(binding_line)
+              method.source_range.include?(binding_line)
           end
         rescue
           false
@@ -186,8 +186,8 @@ class Pry
           Pry::Method.method_definition?(method.name, v)
         end
 
-        @original_method_source_location = source_index &&
-          [target_file, index_to_line_number(source_index)]
+        @original_method_source_location =
+          source_index && [target_file, index_to_line_number(source_index)]
       end
 
       def index_to_line_number(index)

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -396,8 +396,8 @@ class Pry
   # Force `eval_string` into the encoding of `val`. [Issue #284]
   def ensure_correct_encoding!(val)
     if @eval_string.empty? &&
-        val.respond_to?(:encoding) &&
-        val.encoding != @eval_string.encoding
+       val.respond_to?(:encoding) &&
+       val.encoding != @eval_string.encoding
       @eval_string.force_encoding(val.encoding)
     end
   end

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -203,7 +203,8 @@ class Pry
   end
 
   def sticky_locals
-    { _in_: input_ring,
+    {
+      _in_: input_ring,
       _out_: output_ring,
       _pry_: self,
       _ex_: last_exception && last_exception.wrapped_exception,

--- a/lib/pry/slop/option.rb
+++ b/lib/pry/slop/option.rb
@@ -142,8 +142,8 @@ class Pry::Slop
 
     # Returns the String inspection text.
     def inspect
-      "#<Slop::Option [-#{short} | --#{long}" +
-      "#{'=' if expects_argument?}#{'=?' if accepts_optional_argument?}]" +
+      "#<Slop::Option [-#{short} | --#{long}" \
+      "#{'=' if expects_argument?}#{'=?' if accepts_optional_argument?}]" \
       " (#{description}) #{config.inspect}"
     end
 

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -287,9 +287,7 @@ class Pry
     #   candidate of rank 0 will be returned, or a CommandError raised if
     #   there are no candidates at all.
     def primary_candidate
-      @primary_candidate ||= candidates.find { |c| c.file } ||
-        # This will raise an exception if there is no candidate at all.
-        candidate(0)
+      @primary_candidate ||= candidates.find { |c| c.file } || candidate(0)
     end
 
     # @return [Array<Array<Pry::Method>>] The array of `Pry::Method` objects,

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -578,10 +578,10 @@ describe Pry::CommandSet do
 
   describe '.process_line' do
     it 'should return Result.new(false) if there is no matching command' do
-     result = @set.process_line('1 + 42')
-     expect(result.command?).to eq false
-     expect(result.void_command?).to eq false
-     expect(result.retval).to eq nil
+      result = @set.process_line('1 + 42')
+      expect(result.command?).to eq false
+      expect(result.void_command?).to eq false
+      expect(result.retval).to eq nil
     end
 
     it 'should return Result.new(true, VOID) if the command is not keep_retval' do

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -282,9 +282,9 @@ describe Pry::CommandSet do
     @set.helpers { def my_helper; end }
 
     @set.run_command(@ctx, 'foo')
-    expect(Pry::Command.subclass('foo', '', {}, Module.new)
-                .new({target: binding}))
-                .not_to(respond_to :my_helper)
+    expect(
+      Pry::Command.subclass('foo', '', {}, Module.new).new(target: binding)
+    ).not_to(respond_to :my_helper)
   end
 
   it 'should not recreate a new helper module when helpers is called' do

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -164,7 +164,8 @@ describe "ls" do
 
     it "should include instance methods by default" do
       output = pry_eval(
-        "ls Module.new{ def shinanagarns; 4; end; public :shinanagarns }")
+        "ls Module.new{ def shinanagarns; 4; end; public :shinanagarns }"
+      )
       expect(output).to match(/shinanagarns/)
     end
 

--- a/spec/commands/reload_code_spec.rb
+++ b/spec/commands/reload_code_spec.rb
@@ -12,7 +12,8 @@ describe "reload_code" do
       expect do
         pry_eval(
           "cd Class.new(Class.new{ def goo; end; public :goo })",
-          "reload-code")
+          "reload-code"
+        )
       end.to raise_error(Pry::CommandError)
     end
 
@@ -23,7 +24,8 @@ describe "reload_code" do
     it 'raises an error when pry command not found' do
       expect do
         pry_eval(
-          "reload-code not-a-real-command")
+          "reload-code not-a-real-command"
+        )
       end.to raise_error(Pry::CommandError, /Cannot locate not-a-real-command!/)
     end
   end

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -642,7 +642,7 @@ describe "show-source" do
           class Array
             15.times do |i|
               define_method(:"doge#{i}") do
-                                           :"doge#{i}"
+                :"doge#{i}"
               end
             end
           end

--- a/spec/fixtures/show_source_doc_examples.rb
+++ b/spec/fixtures/show_source_doc_examples.rb
@@ -1,6 +1,6 @@
 # used by show_source_spec.rb and show_doc_spec.rb
 class TestClassForShowSource
-  #doc
+  # doc
   def alpha
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -23,7 +23,7 @@ end.new(nil)
 if ENV["SET_TRACE_FUNC"]
   set_trace_func(
     proc { |event, file, line, id, _binding, classname|
-     STDERR.printf "%8s %s:%-2d %10s %8s\n", event, file, line, id, classname
+      STDERR.printf("%8s %s:%-2d %10s %8s\n", event, file, line, id, classname)
     }
   )
 end

--- a/spec/indent_spec.rb
+++ b/spec/indent_spec.rb
@@ -169,7 +169,7 @@ else
 end
 TXT
 
- output = <<TXT.strip
+    output = <<TXT.strip
 case foo
 when 1
   2

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -384,10 +384,10 @@ describe "test Pry defaults" do
     Pry.config.input.rewind
 
     @str_output = StringIO.new
-    Object.new.pry output: @str_output,
-                   hooks: Pry::Hooks.new
-                   .add_hook( :before_session, :my_name) { |out,_,_| out.puts "MORNING" }
-                   .add_hook(:after_session, :my_name) { |out,_,_| out.puts "EVENING" }
+    hooks = Pry::Hooks.new
+      .add_hook( :before_session, :my_name) { |out,_,_| out.puts "MORNING" }
+      .add_hook(:after_session, :my_name) { |out,_,_| out.puts "EVENING" }
+    Object.new.pry(output: @str_output, hooks: hooks)
 
     expect(@str_output.string).to match(/MORNING/)
     expect(@str_output.string).to match(/EVENING/)
@@ -395,17 +395,17 @@ describe "test Pry defaults" do
     # try below with just defining one hook
     Pry.config.input.rewind
     @str_output = StringIO.new
-    Object.new.pry output: @str_output,
-                   hooks: Pry::Hooks.new
-                   .add_hook(:before_session, :my_name) { |out,_,_| out.puts "OPEN" }
+    hooks = Pry::Hooks.new
+      .add_hook(:before_session, :my_name) { |out,_,_| out.puts "OPEN" }
+    Object.new.pry(output: @str_output, hooks: hooks)
 
     expect(@str_output.string).to match(/OPEN/)
 
     Pry.config.input.rewind
     @str_output = StringIO.new
-    Object.new.pry output: @str_output,
-                   hooks: Pry::Hooks.new
-                   .add_hook(:after_session, :my_name) { |out,_,_| out.puts "CLOSE" }
+    hooks = Pry::Hooks.new
+      .add_hook(:after_session, :my_name) { |out,_,_| out.puts "CLOSE" }
+    Object.new.pry(output: @str_output, hooks: hooks)
 
     expect(@str_output.string).to match(/CLOSE/)
 


### PR DESCRIPTION
Fixes:

* Layout/IndentationConsistency:
* Layout/IndentationWidth:
* Layout/LeadingCommentSpace:
* Layout/MultilineArrayBraceLayout:
* Layout/MultilineHashBraceLayout:
* Layout/MultilineMethodCallBraceLayout:
* Layout/MultilineMethodCallIndentation:
* Layout/MultilineOperationIndentation:
