### PR TITLE
Various rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,14 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-Layout/SpaceBeforeComma:
-  Exclude:
-    - 'lib/pry/commands/hist.rb'
-    - 'lib/pry/helpers/text.rb'
-    - 'spec/sticky_locals_spec.rb'
-
 # Offense count: 5
 # Cop supports --auto-correct.
 Layout/SpaceBeforeSemicolon:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,14 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-Layout/SpaceAfterSemicolon:
-  Exclude:
-    - 'spec/commands/show_doc_spec.rb'
-    - 'spec/commands/show_source_spec.rb'
-    - 'spec/commands/whereami_spec.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 Layout/SpaceBeforeComma:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,13 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Layout/RescueEnsureAlignment:
-  Exclude:
-    - 'lib/pry/command_set.rb'
-    - 'lib/pry/pager.rb'
-
 # Offense count: 30
 # Cop supports --auto-correct.
 Layout/SpaceAfterComma:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,16 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBrackets.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBrackets: space, no_space
-Layout/SpaceInsideArrayLiteralBrackets:
-  Exclude:
-    - 'lib/pry/input_completer.rb'
-    - 'spec/history_spec.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Layout/SpaceInsideArrayPercentLiteral:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,21 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 42
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideHashLiteralBraces:
-  Exclude:
-    - 'lib/pry/commands/gem_stats.rb'
-    - 'lib/pry/commands/help.rb'
-    - 'spec/command_set_spec.rb'
-    - 'spec/commands/gist_spec.rb'
-    - 'spec/config_spec.rb'
-    - 'spec/method_spec.rb'
-    - 'spec/sticky_locals_spec.rb'
-
 # Offense count: 4
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,15 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceInsideParens:
-  Exclude:
-    - 'spec/pry_defaults_spec.rb'
-    - 'spec/sticky_locals_spec.rb'
-
 # Offense count: 25
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,13 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-Layout/SpaceBeforeSemicolon:
-  Exclude:
-    - 'spec/commands/show_doc_spec.rb'
-    - 'spec/method_spec.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBrackets.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,12 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Layout/SpaceInsideArrayPercentLiteral:
-  Exclude:
-    - 'spec/helpers/table_spec.rb'
-
 # Offense count: 42
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,21 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 30
-# Cop supports --auto-correct.
-Layout/SpaceAfterComma:
-  Exclude:
-    - 'lib/pry/code_object.rb'
-    - 'lib/pry/commands/find_method.rb'
-    - 'lib/pry/commands/gem_list.rb'
-    - 'lib/pry/config/behavior.rb'
-    - 'lib/pry/helpers/table.rb'
-    - 'spec/commands/play_spec.rb'
-    - 'spec/commands/raise_up_spec.rb'
-    - 'spec/hooks_spec.rb'
-    - 'spec/pry_defaults_spec.rb'
-    - 'spec/syntax_checking_spec.rb'
-
 # Offense count: 5
 # Cop supports --auto-correct.
 Layout/SpaceAfterSemicolon:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,25 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 25
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceInsideStringInterpolation:
-  Exclude:
-    - 'lib/pry/code/code_file.rb'
-    - 'lib/pry/code/loc.rb'
-    - 'lib/pry/commands/gem_install.rb'
-    - 'lib/pry/commands/hist.rb'
-    - 'lib/pry/commands/install_command.rb'
-    - 'lib/pry/commands/ls/methods.rb'
-    - 'lib/pry/commands/ls/self_methods.rb'
-    - 'lib/pry/commands/show_doc.rb'
-    - 'lib/pry/commands/show_source.rb'
-    - 'lib/pry/commands/stat.rb'
-    - 'spec/commands/edit_spec.rb'
-    - 'spec/history_spec.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: AllowInHeredoc.

--- a/lib/pry/code/code_file.rb
+++ b/lib/pry/code/code_file.rb
@@ -60,7 +60,7 @@ class Pry
     def abs_path
       code_path.detect { |path| readable?(path) } ||
         raise(MethodSource::SourceNotFoundError,
-              "Cannot open #{ @filename.inspect } for reading.")
+              "Cannot open #{@filename.inspect} for reading.")
     end
 
     # @param [String] path

--- a/lib/pry/code/loc.rb
+++ b/lib/pry/code/loc.rb
@@ -63,7 +63,7 @@ class Pry
         padded = lineno.to_s.rjust(max_width)
         colorized_lineno = color ? Pry::Helpers::BaseHelpers.colorize_code(padded) : padded
         properly_padded_line = handle_multiline_entries_from_edit_command(line, max_width)
-        tuple[0] = "#{ colorized_lineno }: #{ properly_padded_line }"
+        tuple[0] = "#{colorized_lineno}: #{properly_padded_line}"
       end
 
       # Prepends a marker "=>" or an empty marker to the +line+.
@@ -74,9 +74,9 @@ class Pry
       def add_marker(marker_lineno)
         tuple[0] =
           if lineno == marker_lineno
-            " => #{ line }"
+            " => #{line}"
           else
-            "    #{ line }"
+            "    #{line}"
           end
       end
 
@@ -85,7 +85,7 @@ class Pry
       # @param [Integer] distance
       # @return [void]
       def indent(distance)
-        tuple[0] = "#{ ' ' * distance }#{ line }"
+        tuple[0] = "#{' ' * distance}#{line}"
       end
 
       def handle_multiline_entries_from_edit_command(line, max_width)

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -133,9 +133,9 @@ class Pry
     def method_or_class_lookup
       obj = case str
             when /\S+\(\)\z/
-              Pry::Method.from_str(str.sub(/\(\)\z/, ''),target) || Pry::WrappedModule.from_str(str, target)
+              Pry::Method.from_str(str.sub(/\(\)\z/, ''), target) || Pry::WrappedModule.from_str(str, target)
             else
-              Pry::WrappedModule.from_str(str,target) || Pry::Method.from_str(str, target)
+              Pry::WrappedModule.from_str(str, target) || Pry::Method.from_str(str, target)
             end
 
       lookup_super(obj, super_level)

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -341,11 +341,12 @@ class Pry
     # @param [String] search The user's search.
     # @return [Pry::Command?]
     def find_command_for_help(search)
-      find_command(search) || (begin
-        find_command_by_match_or_listing(search)
-      rescue ArgumentError
-        nil
-      end)
+      find_command(search) ||
+        (begin
+           find_command_by_match_or_listing(search)
+         rescue ArgumentError
+           nil
+         end)
     end
 
     # Is the given line a command invocation?

--- a/lib/pry/commands/find_method.rb
+++ b/lib/pry/commands/find_method.rb
@@ -142,7 +142,7 @@ class Pry
     # @return [Array<Method>]
     #
     def search_all_methods(namespace)
-      done = Hash.new { |h,k| h[k] = {} }
+      done = Hash.new { |h, k| h[k] = {} }
       matches = []
 
       recurse_namespace(namespace) do |klass|

--- a/lib/pry/commands/gem_install.rb
+++ b/lib/pry/commands/gem_install.rb
@@ -20,7 +20,7 @@ class Pry
 
     def process(gem)
       Rubygem.install(gem)
-      output.puts "Gem `#{ green(gem) }` installed."
+      output.puts "Gem `#{green(gem)}` installed."
       require gem
     rescue LoadError
       require_path = gem.split('-').join('/')

--- a/lib/pry/commands/gem_list.rb
+++ b/lib/pry/commands/gem_list.rb
@@ -16,7 +16,7 @@ class Pry
       gems    = Rubygem.list(pattern).group_by(&:name)
 
       gems.each do |gem, specs|
-        specs.sort! do |a,b|
+        specs.sort! do |a, b|
           Gem::Version.new(b.version) <=> Gem::Version.new(a.version)
         end
 

--- a/lib/pry/commands/gem_stats.rb
+++ b/lib/pry/commands/gem_stats.rb
@@ -63,12 +63,14 @@ VVVVVVVVVVVVVVVVVVVVV
     #{red('Dependencies')} (development)
     %{ddependencies}
     FORMAT
-    format_str % {name: green(h.name),
-                  version: bold("v#{h.version}"),
-                  downloads: h.downloads,
-                  version_downloads: h.version_downloads,
-                  rdependencies: format_dependencies(h.dependencies.runtime),
-                  ddependencies: format_dependencies(h.dependencies.development)}
+    format_str % {
+      name: green(h.name),
+      version: bold("v#{h.version}"),
+      downloads: h.downloads,
+      version_downloads: h.version_downloads,
+      rdependencies: format_dependencies(h.dependencies.runtime),
+      ddependencies: format_dependencies(h.dependencies.development)
+    }
   end
 
   def format_dependencies(rdeps)

--- a/lib/pry/commands/help.rb
+++ b/lib/pry/commands/help.rb
@@ -113,7 +113,7 @@ class Pry
       if filtered.size == 1
         display_command(filtered.values.first)
       else
-        display_index({"'#{search}' commands" => filtered.values})
+        display_index({ "'#{search}' commands" => filtered.values })
       end
     end
 
@@ -138,7 +138,7 @@ class Pry
       hash.each_pair do |key, value|
         next unless key.is_a?(String)
         if normalize(key) == normalize(search)
-          return {key => value}
+          return { key => value }
         elsif normalize(key).start_with?(normalize(search))
           matching[key] = value
         end

--- a/lib/pry/commands/hist.rb
+++ b/lib/pry/commands/hist.rb
@@ -25,7 +25,7 @@ class Pry
       opt.on :T, :tail,   "Display the last N items", optional_argument: true, as: Integer
       opt.on :s, :show,   "Show the given range of lines", optional_argument: true, as: Range
       opt.on :G, :grep,   "Show lines matching the given pattern", argument: true, as: String
-      opt.on :c, :clear , "Clear the current session's history"
+      opt.on :c, :clear,  "Clear the current session's history"
       opt.on :r, :replay, "Replay a line or range of lines", argument: true, as: Range
       opt.on     :save,   "Save history to a file", argument: true, as: Range
       opt.on :e, :'exclude-pry', "Exclude Pry commands from the history"

--- a/lib/pry/commands/hist.rb
+++ b/lib/pry/commands/hist.rb
@@ -153,7 +153,7 @@ class Pry
           index = opts[:r]
           index = index.min if index.min == index.max || index.max.nil?
 
-          raise CommandError, "Replay index #{ index } points out to another replay call: `#{ replay_sequence }`"
+          raise CommandError, "Replay index #{index} points out to another replay call: `#{replay_sequence}`"
         end
       else
         false

--- a/lib/pry/commands/install_command.rb
+++ b/lib/pry/commands/install_command.rb
@@ -16,22 +16,22 @@ class Pry
       command = find_command(name)
 
       unless command
-        output.puts "Command #{ green(name) } is not found"
+        output.puts "Command #{green(name)} is not found"
         return
       end
 
       if command_dependencies_met?(command.options)
-        output.puts "Dependencies for #{ green(name) } are met. Nothing to do"
+        output.puts "Dependencies for #{green(name)} are met. Nothing to do"
         return
       end
 
-      output.puts "Attempting to install #{ green(name) } command..."
+      output.puts "Attempting to install #{green(name)} command..."
       gems_to_install = Array(command.options[:requires_gem])
 
       gems_to_install.each do |g|
         next if Rubygem.installed?(g)
 
-        output.puts "Installing #{ green(g) } gem..."
+        output.puts "Installing #{green(g)} gem..."
         Rubygem.install(g)
       end
 
@@ -39,14 +39,14 @@ class Pry
         begin
           require g
         rescue LoadError
-          fail_msg = "Required gem #{ green(g) } installed but not found."
+          fail_msg = "Required gem #{green(g)} installed but not found."
           fail_msg += " Aborting command installation\n"
           fail_msg += 'Tips: 1. Check your PATH; 2. Run `bundle update`'
           raise CommandError, fail_msg
         end
       end
 
-      output.puts "Installation of #{ green(name) } successful! Type `help #{name}` for information"
+      output.puts "Installation of #{green(name)} successful! Type `help #{name}` for information"
     end
   end
 

--- a/lib/pry/commands/ls/methods.rb
+++ b/lib/pry/commands/ls/methods.rb
@@ -25,7 +25,7 @@ class Pry
         # appears right by the prompt.
         resolution_order.take_while(&below_ceiling).reverse.map do |klass|
           methods_here = (methods[klass] || []).select { |m| grep.regexp[m.name] }
-          heading = "#{ Pry::WrappedModule.new(klass).method_prefix }methods"
+          heading = "#{Pry::WrappedModule.new(klass).method_prefix}methods"
           output_section(heading, format(methods_here))
         end.join('')
       end

--- a/lib/pry/commands/ls/self_methods.rb
+++ b/lib/pry/commands/ls/self_methods.rb
@@ -19,7 +19,7 @@ class Pry
         methods = all_methods(true).select do |m|
           m.owner == @interrogatee && grep.regexp[m.name]
         end
-        heading = "#{ Pry::WrappedModule.new(@interrogatee).method_prefix }methods"
+        heading = "#{Pry::WrappedModule.new(@interrogatee).method_prefix}methods"
         output_section(heading, format(methods))
       end
 

--- a/lib/pry/commands/show_doc.rb
+++ b/lib/pry/commands/show_doc.rb
@@ -48,10 +48,9 @@ class Pry
         docs
       else
         if docs.empty?
-          raise CommandError, "No docs found for: #{
-            obj_name ? obj_name : 'current context'
-          }"
+          raise CommandError, "No docs found for: #{obj_name ? obj_name : 'current context'}"
         end
+
         process_comment_markup(docs)
       end
     end

--- a/lib/pry/commands/show_source.rb
+++ b/lib/pry/commands/show_source.rb
@@ -69,10 +69,9 @@ class Pry
         docs
       else
         if docs.empty?
-          raise CommandError, "No docs found for: #{
-            obj_name ? obj_name : 'current context'
-          }"
+          raise CommandError, "No docs found for: #{obj_name ? obj_name : 'current context'}"
         end
+
         process_comment_markup(docs)
       end
     end

--- a/lib/pry/commands/stat.rb
+++ b/lib/pry/commands/stat.rb
@@ -25,7 +25,7 @@ class Pry
         Method Information:
         --
         Name: #{meth.name}
-        Alias#{ "es" if aliases.length > 1 }: #{ aliases.any? ? aliases.join(", ") : "None." }
+        Alias#{"es" if aliases.length > 1}: #{aliases.any? ? aliases.join(", ") : "None."}
         Owner: #{meth.owner ? meth.owner : "Unknown"}
         Visibility: #{meth.visibility}
         Type: #{meth.is_a?(::Method) ? "Bound" : "Unbound"}

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -97,7 +97,7 @@ class Pry
         #
         def from_hash(attributes, default = nil)
           new(default).tap do |config|
-            attributes.each do |key,value|
+            attributes.each do |key, value|
               config[key] = if Hash === value
                               from_hash(value)
                             elsif Array === value
@@ -168,7 +168,7 @@ class Pry
           raise ReservedKeyError, "It is not possible to use '#{key}' as a key name, please choose a different key name."
         end
 
-        __push(key,value)
+        __push(key, value)
       end
 
       #
@@ -360,7 +360,7 @@ class Pry
         end
       end
 
-      def __push(key,value)
+      def __push(key, value)
         unless singleton_class.method_defined? key
           define_singleton_method(key) { self[key] }
           define_singleton_method("#{key}=") { |val| @lookup[key] = val }

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -45,7 +45,7 @@ class Pry
         widths = columns.map { |e| _max_width(e) }
         @rows_without_colors.map do |r|
           padded = []
-          r.each_with_index do |e,i|
+          r.each_with_index do |e, i|
             next unless e
 
             item = e.ljust(widths[i])

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -40,7 +40,7 @@ class Pry
       # @param  [String, #to_s] text
       # @return [String] _text_ stripped of any color codes.
       def strip_color(text)
-        text.to_s.gsub(/(\001)?\e\[.*?(\d)+m(\002)?/ , '')
+        text.to_s.gsub(/(\001)?\e\[.*?(\d)+m(\002)?/, '')
       end
 
       # Returns _text_ as bold text for use on a terminal.

--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -142,17 +142,18 @@ class Pry
 
       def self.available?
         if @system_pager.nil?
-          @system_pager = begin
-            pager_executable = default_pager.split(' ').first
-            if Helpers::Platform.windows? || Helpers::Platform.windows_ansi?
-              `where /Q #{pager_executable}`
-            else
-              `which #{pager_executable}`
+          @system_pager =
+            begin
+              pager_executable = default_pager.split(' ').first
+              if Helpers::Platform.windows? || Helpers::Platform.windows_ansi?
+                `where /Q #{pager_executable}`
+              else
+                `which #{pager_executable}`
+              end
+              $?.success?
+            rescue
+              false
             end
-            $?.success?
-          rescue
-            false
-          end
         else
           @system_pager
         end

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -66,7 +66,7 @@ describe "edit" do
     it "works with files that contain blanks in their names" do
       tf_path = File.join(File.dirname(@tf_path), 'swoop and doop.rb')
       FileUtils.touch(tf_path)
-      pry_eval "edit #{ tf_path }"
+      pry_eval "edit #{tf_path}"
       expect(@file).to eq tf_path
       FileUtils.rm(tf_path)
     end

--- a/spec/commands/gist_spec.rb
+++ b/spec/commands/gist_spec.rb
@@ -17,7 +17,7 @@ describe 'gist' do
 
       def gist(*args)
         Pad.gist_calls[:gist_args] = args
-        {'html_url' => 'http://gist.blahblah'}
+        { 'html_url' => 'http://gist.blahblah' }
       end
 
       def copy(content); Pad.gist_calls[:copy_args] = content end

--- a/spec/commands/play_spec.rb
+++ b/spec/commands/play_spec.rb
@@ -173,16 +173,16 @@ describe "play" do
 
         def @o.test_method
           @s = [
-            1,2,3,
-            4,5,6
+            1, 2, 3,
+            4, 5, 6
           ]
         end
 
         @t.process_command 'play test_method -e 2'
         expect(@t.eval_string).to eq unindent(<<-STR, 0)
           @s = [
-            1,2,3,
-            4,5,6
+            1, 2, 3,
+            4, 5, 6
           ]
         STR
       end

--- a/spec/commands/raise_up_spec.rb
+++ b/spec/commands/raise_up_spec.rb
@@ -16,7 +16,7 @@ describe "raise-up" do
   end
 
   it "should raise an unamed exception with raise-up" do
-    redirect_pry_io(InputTester.new("raise 'stop'","raise-up 'noreally'")) do
+    redirect_pry_io(InputTester.new("raise 'stop'", "raise-up 'noreally'")) do
       expect { Object.new.pry }.to raise_error(RuntimeError, "noreally")
     end
   end
@@ -32,12 +32,12 @@ describe "raise-up" do
   end
 
   it "should raise the most recently raised exception" do
-    expect { mock_pry("raise NameError, 'homographery'","raise-up") }.to raise_error(NameError, 'homographery')
+    expect { mock_pry("raise NameError, 'homographery'", "raise-up") }.to raise_error(NameError, 'homographery')
   end
 
   it "should allow you to cd up and (eventually) out" do
     redirect_pry_io(InputTester.new("cd :inner", "raise NoMethodError", @inner,
-                                    "deep = :deep", "cd deep","Pad.deep = self",
+                                    "deep = :deep", "cd deep", "Pad.deep = self",
                                     "raise-up NoMethodError", "raise-up", @outer,
                                     "raise-up", "exit-all")) do
       expect { Pry.start(:outer) }.to raise_error NoMethodError

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -24,7 +24,9 @@ describe "show-doc" do
   end
 
   it 'should work even if #call is defined on Symbol' do
-    class Symbol ; def call ; 5 ; end ; end
+    class Symbol
+      def call; 5; end
+    end
     expect(pry_eval(binding, "show-doc @o.sample_method")).to match(/sample doc/)
   end
 

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -9,7 +9,7 @@ describe "show-doc" do
       :sample
     end
 
-    def @o.no_docs;end
+    def @o.no_docs; end
   end
 
   after do
@@ -343,7 +343,7 @@ describe "show-doc" do
         it 'shouldnt say anything about monkeypatches when only one candidate exists for selected class' do
           # Do not remove me.
           class Aarrrrrghh
-            def o;end
+            def o; end
           end
 
           result = pry_eval('show-doc Aarrrrrghh')

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -542,7 +542,7 @@ describe "show-source" do
 
         it 'shouldnt say anything about monkeypatches when only one candidate exists for selected class' do
           class Aarrrrrghh
-            def o;end
+            def o; end
           end
 
           result = pry_eval('show-source Aarrrrrghh')

--- a/spec/commands/whereami_spec.rb
+++ b/spec/commands/whereami_spec.rb
@@ -182,7 +182,7 @@ describe "whereami" do
       end
 
       class Horse < Cor
-        def pig;end
+        def pig; end
       end
 
       out = Horse.new.blimey!
@@ -195,7 +195,7 @@ describe "whereami" do
 
     it 'should show class when -c option used, and binding is outside a method' do
       class Cor
-        def blimey;end
+        def blimey; end
 
         out = pry_eval(binding, 'whereami -c')
         out.should =~ /class Cor/

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Pry::Config do
     end
 
     it "recursively walks a Hash" do
-      h = {'foo1' => {'foo2' => {'foo3' => 'foobar'}}}
+      h = { 'foo1' => { 'foo2' => { 'foo3' => 'foobar' } } }
       default = described_class.from_hash(h)
       expect(default.foo1).to be_instance_of(described_class)
       expect(default.foo1.foo2).to be_instance_of(described_class)
     end
 
     it "recursively walks an Array" do
-      c = described_class.from_hash(ary: [{number: 2}, Object, BasicObject.new])
+      c = described_class.from_hash(ary: [{ number: 2 }, Object, BasicObject.new])
       expect(c.ary[0].number).to eq(2)
       expect(c.ary[1]).to eq(Object)
       expect(BasicObject === c.ary[2]).to be(true)
@@ -64,7 +64,7 @@ RSpec.describe Pry::Config do
     end
 
     it "traverses through a chain of parents" do
-      root = described_class.from_hash({foo: 21})
+      root = described_class.from_hash({ foo: 21 })
       local1 = described_class.new(root)
       local2 = described_class.new(local1)
       local3 = described_class.new(local2)
@@ -128,8 +128,8 @@ RSpec.describe Pry::Config do
 
   describe "#keys" do
     it "returns an array of local keys" do
-      root = described_class.from_hash({zoo: "boo"}, nil)
-      local = described_class.from_hash({foo: "bar"}, root)
+      root = described_class.from_hash({ zoo: "boo" }, nil)
+      local = described_class.from_hash({ foo: "bar" }, root)
       expect(local.keys).to eq(["foo"])
     end
   end
@@ -158,8 +158,8 @@ RSpec.describe Pry::Config do
   describe '#forget' do
     it 'restores a key to its default value' do
       last_default = described_class.from_hash(a: 'c')
-      middle_default = described_class.from_hash({a: 'b'}, last_default)
-      c = described_class.from_hash({a: 'a'}, middle_default)
+      middle_default = described_class.from_hash({ a: 'b' }, last_default)
+      c = described_class.from_hash({ a: 'a' }, middle_default)
       c.forget(:a)
       expect(c.a).to eq('c')
     end
@@ -185,13 +185,13 @@ RSpec.describe Pry::Config do
     end
 
     it "merges an object who returns a Hash through #to_hash" do
-      obj = Class.new { def to_hash() {epoch: 1} end }.new
+      obj = Class.new { def to_hash() { epoch: 1 } end }.new
       @config.merge!(obj)
       expect(@config.epoch).to eq(1)
     end
 
     it "merges an object who returns a Hash through #to_h" do
-      obj = Class.new { def to_h() {epoch: 2} end }.new
+      obj = Class.new { def to_h() { epoch: 2 } end }.new
       @config.merge!(obj)
       expect(@config.epoch).to eq(2)
     end
@@ -232,13 +232,13 @@ RSpec.describe Pry::Config do
 
   describe "#[]" do
     it "traverses back to a default" do
-      default = described_class.from_hash({k: 1})
+      default = described_class.from_hash({ k: 1 })
       local = described_class.new(default)
       expect(local['k']).to eq(1)
     end
 
     it "traverses back to a default (2 deep)" do
-      default1 = described_class.from_hash({k: 1})
+      default1 = described_class.from_hash({ k: 1 })
       default2 = described_class.from_hash({}, default1)
       local = described_class.new(default2)
       expect(local['k']).to eq(1)

--- a/spec/helpers/table_spec.rb
+++ b/spec/helpers/table_spec.rb
@@ -10,10 +10,7 @@ describe 'Formatting Table' do
     t.column_count = 2
     expect(t.fits_on_line?(4)).to eq false
 
-    t.items = %w(
-      a   ccc
-      bb  dddd
-    ).sort
+    t.items = %w[a ccc bb dddd].sort
     expect(t.fits_on_line?(8)).to eq true
     expect(t.fits_on_line?(7)).to eq false
   end

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -159,13 +159,13 @@ describe Pry do
     let(:file_path) { Tempfile.new("pry_history_spec").path }
 
     [Errno::EACCES, Errno::ENOENT].each do |error_class|
-      it "handles #{ error_class } failure to read from history" do
+      it "handles #{error_class} failure to read from history" do
         expect(File).to receive(:foreach).and_raise(error_class)
         expect(history).to receive(:warn).with(/Unable to read history file:/)
         expect { history.load }.to_not raise_error
       end
 
-      it "handles #{ error_class } failure to write history" do
+      it "handles #{error_class} failure to write history" do
         Pry.config.history.should_save = true
         expect(File).to receive(:open).with(file_path, "a", 0600).and_raise(error_class)
         expect(history).to receive(:warn).with(/Unable to write history file:/)

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -125,7 +125,7 @@ describe Pry do
     end
 
     it "should not write histignore words to the history file" do
-      Pry.config.history.histignore = [ "ls", /hist*/, 'exit' ]
+      Pry.config.history.histignore = ["ls", /hist*/, 'exit']
       @history.push "ls"
       @history.push "hist"
       @history.push "kakaroto"

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -350,7 +350,7 @@ describe Pry::Hooks do
 
         Pry.config.hooks.add_hook(:when_started, :test_hook) { |_target, _opt, _pry_| _pry_.binding_stack = [Pry.binding_for(o)] }
 
-        redirect_pry_io(InputTester.new("@value = true","exit-all")) do
+        redirect_pry_io(InputTester.new("@value = true", "exit-all")) do
           Pry.start binding, hello: :baby
         end
 

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -35,7 +35,7 @@ describe Pry::Method do
 
         def self.hello; end
       end
-      meth = Pry::Method.from_str(:hello, Pry.binding_for(klass), {"instance-methods" => true})
+      meth = Pry::Method.from_str(:hello, Pry.binding_for(klass), { "instance-methods" => true })
       expect(meth).to eq klass.instance_method(:hello)
     end
 
@@ -45,7 +45,7 @@ describe Pry::Method do
 
         def self.hello; end
       end
-      meth = Pry::Method.from_str(:hello, Pry.binding_for(klass), {methods: true})
+      meth = Pry::Method.from_str(:hello, Pry.binding_for(klass), { methods: true })
       expect(meth).to eq klass.method(:hello)
     end
 
@@ -541,7 +541,7 @@ describe Pry::Method do
       class Object
         private
 
-        def my_top_level_method ; end
+        def my_top_level_method; end
         alias my_other_top_level_method my_top_level_method
       end
 

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -374,8 +374,8 @@ describe "test Pry defaults" do
   it 'should set the hooks default, and the default should be overridable' do
     Pry.config.input = InputTester.new("exit-all")
     Pry.config.hooks = Pry::Hooks.new
-      .add_hook(:before_session, :my_name) { |out,_,_| out.puts "HELLO" }
-      .add_hook(:after_session, :my_name) { |out,_,_| out.puts "BYE" }
+      .add_hook(:before_session, :my_name) { |out, _, _| out.puts "HELLO" }
+      .add_hook(:after_session, :my_name) { |out, _, _| out.puts "BYE" }
 
     Object.new.pry output: @str_output
     expect(@str_output.string).to match(/HELLO/)
@@ -385,8 +385,8 @@ describe "test Pry defaults" do
 
     @str_output = StringIO.new
     hooks = Pry::Hooks.new
-      .add_hook( :before_session, :my_name) { |out,_,_| out.puts "MORNING" }
-      .add_hook(:after_session, :my_name) { |out,_,_| out.puts "EVENING" }
+      .add_hook( :before_session, :my_name) { |out, _, _| out.puts "MORNING" }
+      .add_hook(:after_session, :my_name) { |out, _, _| out.puts "EVENING" }
     Object.new.pry(output: @str_output, hooks: hooks)
 
     expect(@str_output.string).to match(/MORNING/)
@@ -396,7 +396,7 @@ describe "test Pry defaults" do
     Pry.config.input.rewind
     @str_output = StringIO.new
     hooks = Pry::Hooks.new
-      .add_hook(:before_session, :my_name) { |out,_,_| out.puts "OPEN" }
+      .add_hook(:before_session, :my_name) { |out, _, _| out.puts "OPEN" }
     Object.new.pry(output: @str_output, hooks: hooks)
 
     expect(@str_output.string).to match(/OPEN/)
@@ -404,7 +404,7 @@ describe "test Pry defaults" do
     Pry.config.input.rewind
     @str_output = StringIO.new
     hooks = Pry::Hooks.new
-      .add_hook(:after_session, :my_name) { |out,_,_| out.puts "CLOSE" }
+      .add_hook(:after_session, :my_name) { |out, _, _| out.puts "CLOSE" }
     Object.new.pry(output: @str_output, hooks: hooks)
 
     expect(@str_output.string).to match(/CLOSE/)

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -385,7 +385,7 @@ describe "test Pry defaults" do
 
     @str_output = StringIO.new
     hooks = Pry::Hooks.new
-      .add_hook( :before_session, :my_name) { |out, _, _| out.puts "MORNING" }
+      .add_hook(:before_session, :my_name) { |out, _, _| out.puts "MORNING" }
       .add_hook(:after_session, :my_name) { |out, _, _| out.puts "EVENING" }
     Object.new.pry(output: @str_output, hooks: hooks)
 

--- a/spec/sticky_locals_spec.rb
+++ b/spec/sticky_locals_spec.rb
@@ -133,7 +133,7 @@ describe "Sticky locals (_file_ and friends)" do
         o = Object.new
         redirect_pry_io(InputTester.new("@value = test_local",
                                         "exit-all")) do
-          Pry.start(o, extra_sticky_locals: { test_local: proc { :john }} )
+          Pry.start(o, extra_sticky_locals: { test_local: proc { :john } } )
         end
 
         expect(o.instance_variable_get(:@value)).to eq :john

--- a/spec/sticky_locals_spec.rb
+++ b/spec/sticky_locals_spec.rb
@@ -101,7 +101,7 @@ describe "Sticky locals (_file_ and friends)" do
         o = Object.new
         redirect_pry_io(InputTester.new("@value = test_local",
                                         "exit-all")) do
-          Pry.start(o, extra_sticky_locals: { test_local: :john } )
+          Pry.start(o, extra_sticky_locals: { test_local: :john })
         end
 
         expect(o.instance_variable_get(:@value)).to eq :john
@@ -133,7 +133,7 @@ describe "Sticky locals (_file_ and friends)" do
         o = Object.new
         redirect_pry_io(InputTester.new("@value = test_local",
                                         "exit-all")) do
-          Pry.start(o, extra_sticky_locals: { test_local: proc { :john } } )
+          Pry.start(o, extra_sticky_locals: { test_local: proc { :john } })
         end
 
         expect(o.instance_variable_get(:@value)).to eq :john

--- a/spec/sticky_locals_spec.rb
+++ b/spec/sticky_locals_spec.rb
@@ -119,7 +119,7 @@ describe "Sticky locals (_file_ and friends)" do
           Pry.start(
             o,
             extra_sticky_locals: {
-              test_local1: :john ,
+              test_local1: :john,
               test_local2: :carl
             }
           )

--- a/spec/syntax_checking_spec.rb
+++ b/spec/syntax_checking_spec.rb
@@ -28,7 +28,7 @@ describe Pry do
     ["puts :"]
   ] + [
     ["def", "method(1"], # in this case the syntax error is "expecting ')'".
-    ["o = Object.new.tap{ def o.render;","'MEH'", "}"] # in this case the syntax error is "expecting keyword_end".
+    ["o = Object.new.tap{ def o.render;", "'MEH'", "}"] # in this case the syntax error is "expecting keyword_end".
   ]).compact.each do |foo|
     it "should raise an error on invalid syntax like #{foo.inspect}" do
       redirect_pry_io(InputTester.new(*foo), @str_output) do
@@ -68,7 +68,7 @@ describe Pry do
   end
 
   it "should allow newline delimeted strings" do
-    expect(mock_pry('"%s" % %','foo')).to match(/"foo"/)
+    expect(mock_pry('"%s" % %', 'foo')).to match(/"foo"/)
   end
 
   it "should allow whitespace delimeted strings ending on the first char of a line" do


### PR DESCRIPTION
Fixes offences of:

* Layout/RescueEnsureAlignment
* Layout/SpaceAfterComma
* Layout/SpaceAfterSemicolon
* Layout/SpaceBeforeComma
* Layout/SpaceBeforeSemicolon
* Layout/SpaceInsideArrayLiteralBrackets
* Layout/SpaceInsideArrayPercentLiteral
* Layout/SpaceInsideHashLiteralBraces
* Layout/SpaceInsideParens
* Layout/SpaceInsideStringInterpolation