### PR TITLE
Various rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -169,15 +169,6 @@ Naming/MemoizedInstanceVariableName:
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 
-# Offense count: 6
-# Cop supports --auto-correct.
-Performance/RedundantBlockCall:
-  Exclude:
-    - 'lib/pry/commands/code_collector.rb'
-    - 'lib/pry/input_lock.rb'
-    - 'lib/pry/slop.rb'
-    - 'spec/command_spec.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Performance/RedundantMatch:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -171,12 +171,6 @@ Naming/UncommunicativeMethodParamName:
 
 # Offense count: 4
 # Cop supports --auto-correct.
-Performance/Size:
-  Exclude:
-    - 'spec/history_spec.rb'
-
-# Offense count: 4
-# Cop supports --auto-correct.
 Performance/StringReplacement:
   Exclude:
     - 'lib/pry/command.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -169,15 +169,6 @@ Naming/MemoizedInstanceVariableName:
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Performance/StringReplacement:
-  Exclude:
-    - 'lib/pry/command.rb'
-    - 'lib/pry/commands/help.rb'
-    - 'lib/pry/plugins.rb'
-    - 'lib/pry/slop.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Performance/UnneededSort:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -169,12 +169,6 @@ Naming/MemoizedInstanceVariableName:
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/RedundantMatch:
-  Exclude:
-    - 'lib/pry/command.rb'
-
 # Offense count: 4
 # Cop supports --auto-correct.
 # Configuration parameters: MaxKeyValuePairs.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -179,13 +179,6 @@ Security/Eval:
     - 'spec/indent_spec.rb'
     - 'spec/wrapped_module_spec.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AutoCorrect.
-Security/JSONLoad:
-  Exclude:
-    - 'lib/pry/commands/gem_search.rb'
-
 # Offense count: 11
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: inline, group

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -169,12 +169,6 @@ Naming/MemoizedInstanceVariableName:
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Performance/Casecmp:
-  Exclude:
-    - 'lib/pry/slop/option.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Performance/InefficientHashSearch:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -169,13 +169,6 @@ Naming/MemoizedInstanceVariableName:
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Performance/UnneededSort:
-  Exclude:
-    - 'lib/pry/command_set.rb'
-    - 'lib/pry/rubygem.rb'
-
 # Offense count: 10
 Security/Eval:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -169,13 +169,6 @@ Naming/MemoizedInstanceVariableName:
 Naming/UncommunicativeMethodParamName:
   Enabled: false
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Performance/InefficientHashSearch:
-  Exclude:
-    - 'lib/pry/commands/ls/local_vars.rb'
-    - 'lib/pry/indent.rb'
-
 # Offense count: 6
 # Cop supports --auto-correct.
 Performance/RedundantBlockCall:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -171,14 +171,6 @@ Naming/UncommunicativeMethodParamName:
 
 # Offense count: 4
 # Cop supports --auto-correct.
-# Configuration parameters: MaxKeyValuePairs.
-Performance/RedundantMerge:
-  Exclude:
-    - 'lib/pry/slop/commands.rb'
-    - 'spec/config_spec.rb'
-
-# Offense count: 4
-# Cop supports --auto-correct.
 Performance/Size:
   Exclude:
     - 'spec/history_spec.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,14 +33,6 @@ Lint/HandleExceptions:
     - 'lib/pry/pager.rb'
     - 'lib/pry/terminal.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: runtime_error, standard_error
-Lint/InheritException:
-  Exclude:
-    - 'lib/pry/input_lock.rb'
-
 # Offense count: 16
 Lint/InterpolationCheck:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,14 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: AllowInHeredoc.
-Layout/TrailingWhitespace:
-  Exclude:
-    - 'lib/pry/color_printer.rb'
-    - 'lib/pry/testable/variables.rb'
-
 # Offense count: 3
 Lint/Debugger:
   Exclude:

--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -43,7 +43,7 @@ class Pry
 
       begin
         str = obj.inspect
-      rescue Exception 
+      rescue Exception
         # Read the class name off of the singleton class to provide a default
         # inspect.
         singleton = class << obj; self; end

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -305,7 +305,7 @@ class Pry
     # the current scope.
     def check_for_command_collision(command_match, arg_string)
       collision_type = target.eval("defined?(#{command_match})")
-      collision_type ||= 'local-variable' if arg_string.match(%r{\A\s*[-+*/%&|^]*=})
+      collision_type ||= 'local-variable' if arg_string =~ %r{\A\s*[-+*/%&|^]*=}
 
       if collision_type
         output.puts(

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -200,7 +200,7 @@ class Pry
                    else
                      case Pry::Method(block).source_file
                      when %r{/pry/.*_commands/(.*).rb}
-                       Regexp.last_match(1).capitalize.gsub(/_/, " ")
+                       Regexp.last_match(1).capitalize.tr('_', " ")
                      when %r{(pry-\w+)-([\d\.]+([\w\.]+)?)}
                        name = Regexp.last_match(1)
                        version = Regexp.last_match(2)

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -288,9 +288,9 @@ class Pry
     def [](pattern)
       @commands.values.select do |command|
         command.matches?(pattern)
-      end.sort_by do |command|
+      end.max_by do |command|
         command.match_score(pattern)
-      end.last
+      end
     end
     alias_method :find_command, :[]
 

--- a/lib/pry/commands/code_collector.rb
+++ b/lib/pry/commands/code_collector.rb
@@ -122,13 +122,13 @@ class Pry
        !args.empty?].count(true) > 1
     end
 
-    def pry_array_content_as_string(array, ranges, &block)
+    def pry_array_content_as_string(array, ranges)
       all = ''
       ranges.each do |range|
         raise CommandError, "Minimum value for range is 1, not 0." if convert_to_range(range).first == 0
 
         ranged_array = Array(array[range]) || []
-        ranged_array.compact.each { |v| all << block.call(v) }
+        ranged_array.compact.each { |v| all << yield(v) }
       end
 
       all

--- a/lib/pry/commands/gem_search.rb
+++ b/lib/pry/commands/gem_search.rb
@@ -25,7 +25,7 @@ class Pry::Command::GemSearch < Pry::ClassCommand
   def process(str)
     uri = URI.parse(API_ENDPOINT)
     uri.query = URI.encode_www_form(query: str)
-    gems = JSON.load Net::HTTP.get(uri)
+    gems = JSON.parse(Net::HTTP.get(uri))
     _pry_.pager.page list_as_string(gems, opts[:limit])
   end
 

--- a/lib/pry/commands/help.rb
+++ b/lib/pry/commands/help.rb
@@ -156,7 +156,7 @@ class Pry
     end
 
     def group_sort_key(group_name)
-      [%w(Help Context Editing Introspection Input_and_output Navigating_pry Gems Basic Commands).index(group_name.gsub(' ', '_')) || 99, group_name]
+      [%w(Help Context Editing Introspection Input_and_output Navigating_pry Gems Basic Commands).index(group_name.tr(' ', '_')) || 99, group_name]
     end
   end
 

--- a/lib/pry/commands/ls/local_vars.rb
+++ b/lib/pry/commands/ls/local_vars.rb
@@ -9,7 +9,7 @@ class Pry
 
       def output_self
         name_value_pairs = @target.eval('local_variables').reject do |e|
-          @sticky_locals.keys.include?(e.to_sym)
+          @sticky_locals.key?(e.to_sym)
         end.map do |name|
           [name, (@target.eval(name.to_s))]
         end

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -227,7 +227,7 @@ class Pry
 
         if kind == :delimiter
           track_delimiter(token)
-        elsif OPEN_TOKENS.keys.include?(token) && !is_optional_do && !is_singleline_if
+        elsif OPEN_TOKENS.key?(token) && !is_optional_do && !is_singleline_if
           @stack << token
           add_after += 1
         elsif token == OPEN_TOKENS[@stack.last]

--- a/lib/pry/input_lock.rb
+++ b/lib/pry/input_lock.rb
@@ -4,7 +4,7 @@ class Pry
   # that threads to not conflict with each other. The latest thread to request
   # ownership of the input wins.
   class InputLock
-    class Interrupt < Exception; end
+    class Interrupt < Exception; end # rubocop:disable Lint/InheritException
 
     class << self
       attr_accessor :input_locks

--- a/lib/pry/plugins.rb
+++ b/lib/pry/plugins.rb
@@ -47,7 +47,7 @@ class Pry
       # Does not reload plugin if it's already active.
       def activate!
         # Create the configuration object for the plugin.
-        Pry.config.send("#{gem_name.gsub('-', '_')}=", Pry::Config.from_hash({}))
+        Pry.config.send("#{gem_name.tr('-', '_')}=", Pry::Config.from_hash({}))
 
         begin
           require gem_name if !active?

--- a/lib/pry/rubygem.rb
+++ b/lib/pry/rubygem.rb
@@ -22,7 +22,7 @@ class Pry
                   Gem.source_index.find_name(name)
                 end
 
-        first_spec = specs.sort_by { |spec| Gem::Version.new(spec.version) }.last
+        first_spec = specs.max_by { |spec| Gem::Version.new(spec.version) }
 
         first_spec || raise(CommandError, "Gem `#{name}` not found")
       end

--- a/lib/pry/slop.rb
+++ b/lib/pry/slop.rb
@@ -496,7 +496,7 @@ class Pry::Slop
       end
     else
       @unknown_options << item if strict? && item =~ /\A--?/
-      block.call(item) if block && !@trash.include?(index)
+      yield(item) if block && !@trash.include?(index)
     end
   end
 

--- a/lib/pry/slop.rb
+++ b/lib/pry/slop.rb
@@ -447,7 +447,7 @@ class Pry::Slop
     meth = method.to_s
     if meth.end_with?('?')
       meth.chop!
-      present?(meth) || present?(meth.gsub('_', '-'))
+      present?(meth) || present?(meth.tr('_', '-'))
     else
       super
     end

--- a/lib/pry/slop/commands.rb
+++ b/lib/pry/slop/commands.rb
@@ -162,10 +162,10 @@ class Pry::Slop
       globals = commands.delete('global')
       helps = commands.reject { |_, v| v.options.none? }
       if globals && globals.options.any?
-        helps.merge!('Global options' => globals.to_s)
+        helps['Global options'] = globals.to_s
       end
       if defaults && defaults.options.any?
-        helps.merge!('Other options' => defaults.to_s)
+        helps['Other options'] = defaults.to_s
       end
       banner = @banner ? "#{@banner}\n" : ""
       banner + helps.map { |key, opts| "  #{key}\n#{opts}" }.join("\n\n")

--- a/lib/pry/slop/option.rb
+++ b/lib/pry/slop/option.rb
@@ -88,7 +88,7 @@ class Pry::Slop
     # when an array type is specified and used more than once, values from
     # both options will be grouped together and flattened into a single array.
     def value=(new_value)
-      if config[:as].to_s.downcase == 'array'
+      if config[:as].to_s.casecmp('array') == 0
         @value ||= []
 
         if new_value.respond_to?(:split)

--- a/lib/pry/testable/variables.rb
+++ b/lib/pry/testable/variables.rb
@@ -41,6 +41,6 @@ module Pry::Testable::Variables
     Pry.current[:pry_local] = value
     b.eval("#{name} = ::Pry.current[:pry_local]")
   ensure
-    Pry.current[:pry_local] = nil   
+    Pry.current[:pry_local] = nil
   end
 end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -605,7 +605,7 @@ describe "Pry::Command" do
         it "should NOT expose &block in create_command's process method" do
           @set.create_command "walking-spanish", "down the hall", takes_block: true do
             def process(&block)
-              block.call
+              block.call # rubocop:disable Performance/RedundantBlockCall
             end
           end
           @out = StringIO.new

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe Pry::Config do
 
     it "returns a duplicate of the lookup table" do
       local = described_class.new(nil)
-      local.to_hash.merge!("foo" => 42)
+      local.to_hash["foo"] = 42
       expect(local.foo).not_to eq(42)
     end
   end
@@ -197,7 +197,7 @@ RSpec.describe Pry::Config do
     end
 
     it "merges a Hash" do
-      @config.merge!(epoch: 420)
+      @config[:epoch] = 420
       expect(@config.epoch).to eq(420)
     end
 

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -27,15 +27,15 @@ describe Pry do
     end
 
     it "does not record lines that contain a NULL byte" do
-      c = Pry.history.to_a.count
+      c = Pry.history.to_a.size
       Pry.history << "a\0b"
-      expect(Pry.history.to_a.count).to eq c
+      expect(Pry.history.to_a.size).to eq c
     end
 
     it "does not record empty lines" do
-      c = Pry.history.to_a.count
+      c = Pry.history.to_a.size
       Pry.history << ''
-      expect(Pry.history.to_a.count).to eq c
+      expect(Pry.history.to_a.size).to eq c
     end
   end
 


### PR DESCRIPTION
Fixes offences of the cops:

* Layout/TrailingWhitespace
* Lint/InheritException
* Performance/Casecmp
* Performance/InefficientHashSearch
* Performance/RedundantBlockCall
* Performance/RedundantMatch
* Performance/RedundantMerge
* Performance/Size
* Performance/StringReplacement
* Performance/UnneededSort
* Security/JSONLoad