### PR TITLE
rubocop: fix offences of the Metrics/LineLength cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,3 +49,6 @@ Style/StringLiterals:
 # TODO: delete this rule when we drop Ruby 1.9.3 support.
 Style/SymbolArray:
   EnforcedStyle: brackets
+
+Metrics/LineLength:
+  Max: 90

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -86,7 +86,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, ExcludedMethods.
 # ExcludedMethods: refine
 Metrics/BlockLength:
-  Max: 760
+  Max: 794
 
 # Offense count: 1
 # Configuration parameters: CountBlocks.
@@ -313,9 +313,3 @@ Style/PerlBackrefs:
     - 'lib/pry/last_exception.rb'
     - 'lib/pry/method.rb'
     - 'lib/pry/rubygem.rb'
-
-# Offense count: 869
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
-# URISchemes: http, https
-Metrics/LineLength:
-  Max: 205

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,9 @@ group :development do
   gem 'yard'
 
   # Rubocop supports only >=2.2.0
-  gem 'rubocop', '= 0.65.0', require: false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
+    gem 'rubocop', '= 0.65.0', require: false
+  end
 end
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,9 @@ $LOAD_PATH.unshift 'lib'
 require 'pry/version'
 
 CLOBBER.include('**/*~', '**/*#*', '**/*.log')
-CLEAN.include('**/*#*', '**/*#*.*', '**/*_flymake*.*', '**/*_flymake', '**/*.rbc', '**/.#*.*')
+CLEAN.include(
+  '**/*#*', '**/*#*.*', '**/*_flymake*.*', '**/*_flymake', '**/*.rbc', '**/.#*.*'
+)
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
@@ -112,6 +114,8 @@ namespace :docker do
 
   desc "test pry on multiple ruby versions"
   task test: :build do
-    system "docker run -i -t -v /tmp/prytmp:/tmp/prytmp pry/pry ./multi_test_inside_docker.sh"
+    system(
+      "docker run -i -t -v /tmp/prytmp:/tmp/prytmp pry/pry ./multi_test_inside_docker.sh"
+    )
   end
 end

--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -7,7 +7,9 @@ require 'pry/hooks'
 
 class Pry
   # The default hooks - display messages when beginning and ending Pry sessions.
-  DEFAULT_HOOKS = Pry::Hooks.new.add_hook(:before_session, :default) do |_out, _target, _pry_|
+  DEFAULT_HOOKS = Pry::Hooks.new.add_hook(
+    :before_session, :default
+  ) do |_out, _target, _pry_|
     next if _pry_.quiet?
 
     _pry_.run_command("whereami --quiet")
@@ -75,7 +77,9 @@ class Pry
   end
 
   DEFAULT_SYSTEM = proc do |output, cmd, _|
-    output.puts "Error: there was a problem executing system command: #{cmd}" unless system(cmd)
+    unless system(cmd)
+      output.puts "Error: there was a problem executing system command: #{cmd}"
+    end
   end
 
   # This is to keep from breaking under Rails 3.2 for people who are doing that

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -53,7 +53,11 @@ class Pry
       end
 
       def parse_options(args = ARGV)
-        raise NoOptionsError, "No command line options defined! Use Pry::CLI.add_options to add command line options." unless options
+        unless options
+          raise NoOptionsError,
+                "No command line options defined! Use Pry::CLI.add_options to " \
+                "add command line options."
+        end
 
         @pass_argv = args.index { |cli_arg| %w[- --].include?(cli_arg) }
         if @pass_argv
@@ -133,7 +137,9 @@ Pry::CLI.add_options do
     "See http://pryrepl.org/ for more information.\n"
   )
 
-  on :e, :exec=, "A line of code to execute in context before the session starts" do |input|
+  on(
+    :e, :exec=, "A line of code to execute in context before the session starts"
+  ) do |input|
     Pry.config.exec_string += "\n" unless Pry.config.exec_string.empty?
     Pry.config.exec_string += input
   end

--- a/lib/pry/code/loc.rb
+++ b/lib/pry/code/loc.rb
@@ -1,7 +1,7 @@
 class Pry
   class Code
-    # Represents a line of code (which may, in fact, contain multiple lines if the
-    # entirety was eval'd as a single unit following the `edit` command).
+    # Represents a line of code (which may, in fact, contain multiple lines if
+    # the entirety was eval'd as a single unit following the `edit` command).
     #
     # A line of code is a tuple, which consists of a line and a line number. A
     # `LOC` object's state (namely, the line parameter) can be changed via
@@ -61,7 +61,12 @@ class Pry
       # @return [void]
       def add_line_number(max_width = 0, color = false)
         padded = lineno.to_s.rjust(max_width)
-        colorized_lineno = color ? Pry::Helpers::BaseHelpers.colorize_code(padded) : padded
+        colorized_lineno =
+          if color
+            Pry::Helpers::BaseHelpers.colorize_code(padded)
+          else
+            padded
+          end
         properly_padded_line = handle_multiline_entries_from_edit_command(line, max_width)
         tuple[0] = "#{colorized_lineno}: #{properly_padded_line}"
       end

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -113,7 +113,8 @@ class Pry
 
     # lookup variables and constants and `self` that are not modules
     def default_lookup
-      # we skip instance methods as we want those to fall through to method_or_class_lookup()
+      # we skip instance methods as we want those to fall through to
+      # method_or_class_lookup()
       if safe_to_evaluate?(str) && !looks_like_an_instance_method?(str)
         obj = target.eval(str)
 
@@ -130,12 +131,15 @@ class Pry
     end
 
     def method_or_class_lookup
-      obj = case str
-            when /\S+\(\)\z/
-              Pry::Method.from_str(str.sub(/\(\)\z/, ''), target) || Pry::WrappedModule.from_str(str, target)
-            else
-              Pry::WrappedModule.from_str(str, target) || Pry::Method.from_str(str, target)
-            end
+      obj =
+        case str
+        when /\S+\(\)\z/
+          Pry::Method.from_str(str.sub(/\(\)\z/, ''), target) ||
+          Pry::WrappedModule.from_str(str, target)
+        else
+          Pry::WrappedModule.from_str(str, target) ||
+          Pry::Method.from_str(str, target)
+        end
 
       lookup_super(obj, super_level)
     end

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -3,8 +3,9 @@ require 'pry/helpers/documentation_helpers'
 
 class Pry
   # The super-class of all commands, new commands should be created by calling
-  # {Pry::CommandSet#command} which creates a BlockCommand or {Pry::CommandSet#create_command}
-  # which creates a ClassCommand. Please don't use this class directly.
+  # {Pry::CommandSet#command} which creates a BlockCommand or
+  # {Pry::CommandSet#create_command} which creates a ClassCommand. Please don't
+  # use this class directly.
   class Command
     extend Helpers::DocumentationHelpers
     extend CodeObject::Helpers
@@ -177,7 +178,11 @@ class Pry
       # @return [Fixnum]
       def match_score(val)
         if command_regex =~ val
-          Regexp.last_match.size > 1 ? Regexp.last_match.begin(1) : Regexp.last_match.end(0)
+          if Regexp.last_match.size > 1
+            Regexp.last_match.begin(1)
+          else
+            Regexp.last_match.end(0)
+          end
         else
           -1
         end
@@ -352,7 +357,9 @@ class Pry
       self.class.command_regex =~ val
 
       # please call Command.matches? before Command#call_safely
-      raise CommandError, "fatal: called a command which didn't match?!" unless Regexp.last_match
+      unless Regexp.last_match
+        raise CommandError, "fatal: called a command which didn't match?!"
+      end
 
       captures = Regexp.last_match.captures
       pos = Regexp.last_match.end(0)
@@ -367,7 +374,11 @@ class Pry
 
       args =
         if arg_string
-          command_options[:shellwords] ? Shellwords.shellwords(arg_string) : arg_string.split(" ")
+          if command_options[:shellwords]
+            Shellwords.shellwords(arg_string)
+          else
+            arg_string.split(" ")
+          end
         else
           []
         end
@@ -381,7 +392,9 @@ class Pry
     def process_line(line)
       command_match, arg_string, captures, args = tokenize(line)
 
-      check_for_command_collision(command_match, arg_string) if Pry.config.collision_warning
+      if Pry.config.collision_warning
+        check_for_command_collision(command_match, arg_string)
+      end
 
       self.arg_string = arg_string
       self.captures = captures
@@ -445,7 +458,9 @@ WARN
         return void
       end
 
-      raise CommandError, "The command '#{command_name}' requires an argument." if command_options[:argument_required] && args.empty?
+      if command_options[:argument_required] && args.empty?
+        raise CommandError, "The command '#{command_name}' requires an argument."
+      end
 
       ret = use_unpatched_symbol do
         call_with_hooks(*args)

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -64,7 +64,9 @@ class Pry
     #   # Greet somebody
     # @example Regexp command
     #   MyCommands = Pry::CommandSet.new do
-    #     command /number-(\d+)/, "number-N regex command", :listing => "number" do |num, name|
+    #     command(
+    #       /number-(\d+)/, "number-N regex command", :listing => "number"
+    #     ) do |num, name|
     #       puts "hello #{name}, nice number: #{num}"
     #     end
     #   end
@@ -82,7 +84,9 @@ class Pry
       end
       options = Pry::Command.default_options(match).merge!(options)
 
-      @commands[match] = Pry::BlockCommand.subclass(match, description, options, helper_module, &block)
+      @commands[match] = Pry::BlockCommand.subclass(
+        match, description, options, helper_module, &block
+      )
     end
     alias command block_command
 
@@ -102,7 +106,9 @@ class Pry
     #     end
     #
     #     def process
-    #       raise Pry::CommandError, "-u and -d makes no sense" if opts.present?(:u) && opts.present?(:d)
+    #       if opts.present?(:u) && opts.present?(:d)
+    #         raise Pry::CommandError, "-u and -d makes no sense"
+    #       end
     #       result = args.join(" ")
     #       result.downcase! if opts.present?(:downcase)
     #       result.upcase! if opts.present?(:upcase)
@@ -117,7 +123,9 @@ class Pry
       end
       options = Pry::Command.default_options(match).merge!(options)
 
-      @commands[match] = Pry::ClassCommand.subclass(match, description, options, helper_module, &block)
+      @commands[match] = Pry::ClassCommand.subclass(
+        match, description, options, helper_module, &block
+      )
       @commands[match].class_eval(&block)
       @commands[match]
     end
@@ -127,7 +135,8 @@ class Pry
     end
 
     # Removes some commands from the set
-    # @param [Array<String>] searches the matches or listings of the commands to remove
+    # @param [Array<String>] searches the matches or listings of the commands
+    #   to remove
     def delete(*searches)
       searches.each do |search|
         cmd = find_command_by_match_or_listing(search)
@@ -231,8 +240,8 @@ class Pry
       @commands.delete(cmd.match)
     end
 
-    def disabled_command(name_of_disabled_command, message, matcher = name_of_disabled_command)
-      create_command name_of_disabled_command do
+    def disabled_command(disabled_command_name, message, matcher = disabled_command_name)
+      create_command(disabled_command_name) do
         match matcher
         description ""
 
@@ -317,7 +326,9 @@ class Pry
     #
     def []=(pattern, command)
       return @commands.delete(pattern) if command.equal?(nil)
-      raise TypeError, "command is not a subclass of Pry::Command" unless Class === command && command < Pry::Command
+      unless Class === command && command < Pry::Command
+        raise TypeError, "command is not a subclass of Pry::Command"
+      end
 
       bind_command_to_pattern = pattern != command.match
       if bind_command_to_pattern

--- a/lib/pry/commands/amend_line.rb
+++ b/lib/pry/commands/amend_line.rb
@@ -55,7 +55,8 @@ class Pry
         array[range] = arg_string + "\n"
       end
 
-      # @return [Fixnum] The number of lines currently in `eval_string` (the input buffer).
+      # @return [Fixnum] The number of lines currently in `eval_string` (the
+      #   input buffer)
       def line_count
         eval_string.lines.count
       end

--- a/lib/pry/commands/cat.rb
+++ b/lib/pry/commands/cat.rb
@@ -24,12 +24,18 @@ class Pry
       BANNER
 
       def options(opt)
-        opt.on :ex,        "Show the context of the last exception", optional_argument: true, as: Integer
-        opt.on :i, :in,    "Show one or more entries from Pry's expression history", optional_argument: true, as: Range, default: -5..-1
-        opt.on :s, :start, "Starting line (defaults to the first line)", optional_argument: true, as: Integer
-        opt.on :e, :end,   "Ending line (defaults to the last line)", optional_argument: true, as: Integer
+        opt.on :ex, "Show the context of the last exception",
+               optional_argument: true, as: Integer
+        opt.on :i, :in, "Show one or more entries from Pry's expression history",
+               optional_argument: true, as: Range, default: -5..-1
+        opt.on :s, :start, "Starting line (defaults to the first line)",
+               optional_argument: true, as: Integer
+        opt.on :e, :end, "Ending line (defaults to the last line)",
+               optional_argument: true, as: Integer
         opt.on :l, :'line-numbers', "Show line numbers"
-        opt.on :t, :type, "The file type for syntax highlighting (e.g., 'ruby' or 'python')", argument: true, as: Symbol
+        opt.on :t, :type, "The file type for syntax highlighting " \
+                          "(e.g., 'ruby' or 'python')",
+               argument: true, as: Symbol
       end
 
       def process

--- a/lib/pry/commands/cat/exception_formatter.rb
+++ b/lib/pry/commands/cat/exception_formatter.rb
@@ -59,7 +59,10 @@ class Pry
 
         def check_for_errors
           raise CommandError, "No exception found." unless ex
-          raise CommandError, "The given backtrace level is out of bounds." unless backtrace_file
+
+          unless backtrace_file
+            raise CommandError, "The given backtrace level is out of bounds."
+          end
         end
 
         def start_and_end_line_for_code_window
@@ -70,12 +73,13 @@ class Pry
         end
 
         def header
-          unindent %{
-          #{bold 'Exception:'} #{ex.class}: #{ex.message}
-          --
-          #{bold('From:')} #{backtrace_file}:#{backtrace_line} @ #{bold("level: #{backtrace_level}")} of backtrace (of #{ex.backtrace.size - 1}).
-
-        }
+          unindent(
+            "#{bold 'Exception:'} #{ex.class}: #{ex.message}\n" \
+            "--\n" \
+            "#{bold('From:')} #{backtrace_file}:#{backtrace_line} @ " \
+            "#{bold("level: #{backtrace_level}")} of backtrace " \
+            "(of #{ex.backtrace.size - 1}).\n\n"
+          )
         end
       end
     end

--- a/lib/pry/commands/cat/file_formatter.rb
+++ b/lib/pry/commands/cat/file_formatter.rb
@@ -7,7 +7,9 @@ class Pry
         attr_reader :_pry_
 
         def initialize(file_with_embedded_line, _pry_, opts)
-          raise CommandError, "Must provide a filename, --in, or --ex." unless file_with_embedded_line
+          unless file_with_embedded_line
+            raise CommandError, "Must provide a filename, --in, or --ex."
+          end
 
           @file_with_embedded_line = file_with_embedded_line
           @opts = opts

--- a/lib/pry/commands/cat/input_expression_formatter.rb
+++ b/lib/pry/commands/cat/input_expression_formatter.rb
@@ -16,7 +16,8 @@ class Pry
           if numbered_input_items.length > 1
             content = ""
             numbered_input_items.each do |i, s|
-              content << "#{Helpers::Text.bold(i.to_s)}:\n" << decorate(Pry::Code(s).with_indentation(2)).to_s
+              content << "#{Helpers::Text.bold(i.to_s)}:\n"
+              content << decorate(Pry::Code(s).with_indentation(2)).to_s
             end
 
             content

--- a/lib/pry/commands/cd.rb
+++ b/lib/pry/commands/cd.rb
@@ -24,7 +24,9 @@ class Pry
         state.old_stack ||= []
 
         if arg_string.strip == "-"
-          _pry_.binding_stack, state.old_stack = state.old_stack, _pry_.binding_stack unless state.old_stack.empty?
+          unless state.old_stack.empty?
+            _pry_.binding_stack, state.old_stack = state.old_stack, _pry_.binding_stack
+          end
         else
           stack = ObjectPath.new(arg_string, _pry_.binding_stack).resolve
 

--- a/lib/pry/commands/change_prompt.rb
+++ b/lib/pry/commands/change_prompt.rb
@@ -37,8 +37,9 @@ class Pry
         if Pry::Prompt[prompt]
           _pry_.prompt = Pry::Prompt[prompt]
         else
-          raise Pry::CommandError, "'#{prompt}' isn't a known prompt. " \
-                                   "Run `change-prompt --list` to see the list of known prompts."
+          raise Pry::CommandError,
+                "'#{prompt}' isn't a known prompt. Run `change-prompt --list` " \
+                "to see the list of known prompts."
         end
       end
 

--- a/lib/pry/commands/code_collector.rb
+++ b/lib/pry/commands/code_collector.rb
@@ -29,17 +29,21 @@ class Pry
         @input_expression_ranges = []
         @output_result_ranges = []
 
-        opt.on :l, :lines, "Restrict to a subset of lines. Takes a line number or range",
+        opt.on :l, :lines, "Restrict to a subset of lines. Takes a line number " \
+                           "or range",
                optional_argument: true, as: Range, default: 1..-1
-        opt.on :o, :out, "Select lines from Pry's output result history. Takes an index or range",
+        opt.on :o, :out, "Select lines from Pry's output result history. " \
+                         "Takes an index or range",
                optional_argument: true, as: Range, default: -5..-1 do |r|
           output_result_ranges << (r || (-5..-1))
         end
-        opt.on :i, :in, "Select lines from Pry's input expression history. Takes an index or range",
+        opt.on :i, :in, "Select lines from Pry's input expression history. " \
+                        "Takes an index or range",
                optional_argument: true, as: Range, default: -5..-1 do |r|
           input_expression_ranges << (r || (-5..-1))
         end
-        opt.on :s, :super, "Select the 'super' method. Can be repeated to traverse the ancestors",
+        opt.on :s, :super, "Select the 'super' method. Can be repeated to " \
+                           "traverse the ancestors",
                as: :count
         opt.on :d, :doc, "Select lines from the code object's documentation"
       end
@@ -54,7 +58,11 @@ class Pry
       def content
         @content ||=
           begin
-            raise CommandError, "Only one of --out, --in, --doc and CODE_OBJECT may be specified." if bad_option_combination?
+            if bad_option_combination?
+              raise CommandError,
+                    "Only one of --out, --in, --doc and CODE_OBJECT may " \
+                    "be specified."
+            end
 
             content = if opts.present?(:o)
                         pry_output_content
@@ -92,7 +100,9 @@ class Pry
       #
       # @return [String]
       def pry_output_content
-        pry_array_content_as_string(_pry_.output_ring, self.class.output_result_ranges) do |v|
+        pry_array_content_as_string(
+          _pry_.output_ring, self.class.output_result_ranges
+        ) do |v|
           _pry_.config.gist.inspecter.call(v)
         end
       end
@@ -102,7 +112,9 @@ class Pry
       #
       # @return [String]
       def pry_input_content
-        pry_array_content_as_string(_pry_.input_ring, self.class.input_expression_ranges) { |v| v }
+        pry_array_content_as_string(
+          _pry_.input_ring, self.class.input_expression_ranges
+        ) { |v| v }
       end
 
       # The line range passed to `--lines`, converted to a 0-indexed range.
@@ -125,7 +137,9 @@ class Pry
       def pry_array_content_as_string(array, ranges)
         all = ''
         ranges.each do |range|
-          raise CommandError, "Minimum value for range is 1, not 0." if convert_to_range(range).first == 0
+          if convert_to_range(range).first == 0
+            raise CommandError, "Minimum value for range is 1, not 0."
+          end
 
           ranged_array = Array(array[range]) || []
           ranged_array.compact.each { |v| all << yield(v) }

--- a/lib/pry/commands/edit/file_and_line_locator.rb
+++ b/lib/pry/commands/edit/file_and_line_locator.rb
@@ -24,7 +24,10 @@ class Pry
 
             file_name, line = exception.bt_source_location_for(backtrace_level)
             raise CommandError, "Exception has no associated file." if file_name.nil?
-            raise CommandError, "Cannot edit exceptions raised in REPL." if Pry.eval_path == file_name
+
+            if Pry.eval_path == file_name
+              raise CommandError, "Cannot edit exceptions raised in REPL."
+            end
 
             [file_name, line]
           end

--- a/lib/pry/commands/find_method.rb
+++ b/lib/pry/commands/find_method.rb
@@ -5,7 +5,8 @@ class Pry
 
       match 'find-method'
       group 'Context'
-      description 'Recursively search for a method within a Class/Module or the current namespace.'
+      description 'Recursively search for a method within a Class/Module or ' \
+                  'the current namespace.'
       command_options shellwords: false
 
       banner <<-'BANNER'
@@ -103,7 +104,9 @@ class Pry
       end
 
       def matched_method_lines(header, method)
-        method.source.split(/\n/).select { |x| x =~ pattern }.join("\n#{' ' * header.length}")
+        method.source.split(/\n/).select { |x| x =~ pattern }.join(
+          "\n#{' ' * header.length}"
+        )
       end
 
       # Run the given block against every constant in the provided namespace.
@@ -147,7 +150,8 @@ class Pry
         matches = []
 
         recurse_namespace(namespace) do |klass|
-          (Pry::Method.all_from_class(klass) + Pry::Method.all_from_obj(klass)).each do |method|
+          methods = Pry::Method.all_from_class(klass) + Pry::Method.all_from_obj(klass)
+          methods.each do |method|
             next if done[method.owner][method.name]
 
             done[method.owner][method.name] = true

--- a/lib/pry/commands/gem_readme.rb
+++ b/lib/pry/commands/gem_readme.rb
@@ -20,7 +20,8 @@ class Pry
           raise Pry::CommandError, "Gem '#{name}' doesn't appear to have a README"
         end
       rescue Gem::LoadError
-        raise Pry::CommandError, "Gem '#{name}' wasn't found. Are you sure it is installed?"
+        raise Pry::CommandError,
+              "Gem '#{name}' wasn't found. Are you sure it is installed?"
       end
 
       Pry::Commands.add_command(self)

--- a/lib/pry/commands/gist.rb
+++ b/lib/pry/commands/gist.rb
@@ -24,7 +24,8 @@ class Pry
         CodeCollector.inject_options(opt)
         opt.on :login, "Authenticate the gist gem with GitHub"
         opt.on :p, :public, "Create a public gist (default: false)", default: false
-        opt.on :clip, "Copy the selected content to clipboard instead, do NOT gist it", default: false
+        opt.on :clip, "Copy the selected content to clipboard instead, do NOT " \
+                      "gist it", default: false
       end
 
       def process
@@ -55,10 +56,14 @@ class Pry
           input_expressions = _pry_.input_ring[range] || []
           Array(input_expressions).each_with_index do |code, index|
             corrected_index = index + range.first
-            if code && code != ""
-              content << code
-              content << comment_expression_result_for_gist(_pry_.config.gist.inspecter.call(_pry_.output_ring[corrected_index])).to_s if code !~ /;\Z/
-            end
+            next unless code && code != ""
+
+            content << code
+            next unless code !~ /;\Z/
+
+            content << comment_expression_result_for_gist(
+              _pry_.config.gist.inspecter.call(_pry_.output_ring[corrected_index])
+            ).to_s
           end
         end
 
@@ -75,7 +80,9 @@ class Pry
       end
 
       def gist_content(content, filename)
-        response = ::Gist.gist(content, filename: filename || "pry_gist.rb", public: !!opts[:p])
+        response = ::Gist.gist(
+          content, filename: filename || "pry_gist.rb", public: !!opts[:p]
+        )
         if response
           url = response['html_url']
           message = "Gist created at URL #{url}"

--- a/lib/pry/commands/help.rb
+++ b/lib/pry/commands/help.rb
@@ -59,7 +59,8 @@ class Pry
       # @return [String] The generated help string.
       def help_text_for_commands(name, commands)
         "#{bold(name.capitalize)}\n" << commands.map do |command|
-          "  #{command.options[:listing].to_s.ljust(18)} #{command.description.capitalize}"
+          "  #{command.options[:listing].to_s.ljust(18)} " \
+          "#{command.description.capitalize}"
         end.join("\n")
       end
 
@@ -155,7 +156,12 @@ class Pry
       end
 
       def group_sort_key(group_name)
-        [%w[Help Context Editing Introspection Input_and_output Navigating_pry Gems Basic Commands].index(group_name.tr(' ', '_')) || 99, group_name]
+        [
+          %w[
+            Help Context Editing Introspection Input_and_output Navigating_pry
+            Gems Basic Commands
+          ].index(group_name.tr(' ', '_')) || 99, group_name
+        ]
       end
     end
 

--- a/lib/pry/commands/hist.rb
+++ b/lib/pry/commands/hist.rb
@@ -21,14 +21,19 @@ class Pry
       BANNER
 
       def options(opt)
-        opt.on :a, :all,    "Display all history"
-        opt.on :H, :head,   "Display the first N items", optional_argument: true, as: Integer
-        opt.on :T, :tail,   "Display the last N items", optional_argument: true, as: Integer
-        opt.on :s, :show,   "Show the given range of lines", optional_argument: true, as: Range
-        opt.on :G, :grep,   "Show lines matching the given pattern", argument: true, as: String
-        opt.on :c, :clear,  "Clear the current session's history"
-        opt.on :r, :replay, "Replay a line or range of lines", argument: true, as: Range
-        opt.on     :save,   "Save history to a file", argument: true, as: Range
+        opt.on :a, :all, "Display all history"
+        opt.on :H, :head, "Display the first N items",
+               optional_argument: true, as: Integer
+        opt.on :T, :tail, "Display the last N items",
+               optional_argument: true, as: Integer
+        opt.on :s, :show, "Show the given range of lines",
+               optional_argument: true, as: Range
+        opt.on :G, :grep, "Show lines matching the given pattern",
+               argument: true, as: String
+        opt.on :c, :clear, "Clear the current session's history"
+        opt.on :r, :replay, "Replay a line or range of lines",
+               argument: true, as: Range
+        opt.on :save, "Save history to a file", argument: true, as: Range
         opt.on :e, :'exclude-pry', "Exclude Pry commands from the history"
         opt.on :n, :'no-numbers',  "Omit line numbers"
       end
@@ -125,7 +130,8 @@ class Pry
       #   46676: a = 100
       #   46677: hist --tail
       #   [3] pry(main)> hist --replay 46894
-      #   Error: Replay index 46894 points out to another replay call: `hist -r 46675..46677`
+      #   Error: Replay index 46894 points out to another replay call:
+      #   `hist -r 46675..46677`
       #   [4] pry(main)>
       #
       # @raise [Pry::CommandError] If +replay_sequence+ contains another
@@ -145,7 +151,9 @@ class Pry
             index = opts[:r]
             index = index.min if index.min == index.max || index.max.nil?
 
-            raise CommandError, "Replay index #{index} points out to another replay call: `#{replay_sequence}`"
+            raise CommandError,
+                  "Replay index #{index} points out to another replay call: " \
+                  "`#{replay_sequence}`"
           end
         else
           false

--- a/lib/pry/commands/install_command.rb
+++ b/lib/pry/commands/install_command.rb
@@ -13,7 +13,7 @@ class Pry
       BANNER
 
       def process(name)
-        require 'rubygems/dependency_installer' unless defined? Gem::DependencyInstaller
+        require 'rubygems/dependency_installer'
         command = find_command(name)
 
         unless command
@@ -47,7 +47,10 @@ class Pry
           end
         end
 
-        output.puts "Installation of #{green(name)} successful! Type `help #{name}` for information"
+        output.puts(
+          "Installation of #{green(name)} successful! Type `help #{name}` " \
+          "for information"
+        )
       end
     end
 

--- a/lib/pry/commands/ls.rb
+++ b/lib/pry/commands/ls.rb
@@ -50,18 +50,33 @@ class Pry
 
       def options(opt)
         opt.on :m, :methods, "Show public methods defined on the Object"
-        opt.on :M, "instance-methods", "Show public methods defined in a Module or Class"
-        opt.on :p, :ppp,       "Show public, protected (in yellow) and private (in green) methods"
-        opt.on :q, :quiet,     "Show only methods defined on object.singleton_class and object.class"
-        opt.on :v, :verbose,   "Show methods and constants on all super-classes (ignores Pry.config.ls.ceiling)"
-        opt.on :g, :globals,   "Show global variables, including those builtin to Ruby (in cyan)"
-        opt.on :l, :locals,    "Show hash of local vars, sorted by descending size"
-        opt.on :c, :constants, "Show constants, highlighting classes (in blue), and exceptions (in purple).\n" \
-                               "#{' ' * 32}Constants that are pending autoload? are also shown (in yellow)"
-        opt.on :i, :ivars,     "Show instance variables (in blue) and class variables (in bright blue)"
-        opt.on :G, :grep,      "Filter output by regular expression", argument: true
-        opt.on :d, :dconstants, "Show deprecated constants" if Object.respond_to?(:deprecate_constant)
-        opt.on :J, "all-java", "Show all the aliases for methods from java (default is to show only prettiest)" if Helpers::Platform.jruby?
+        opt.on :M, "instance-methods", "Show public methods defined in a " \
+                                       "Module or Class"
+        opt.on :p, :ppp, "Show public, protected (in yellow) and private " \
+                         "(in green) methods"
+        opt.on :q, :quiet, "Show only methods defined on object.singleton_class " \
+                           "and object.class"
+        opt.on :v, :verbose, "Show methods and constants on all super-classes " \
+                             "(ignores Pry.config.ls.ceiling)"
+        opt.on :g, :globals, "Show global variables, including those builtin to " \
+                             "Ruby (in cyan)"
+        opt.on :l, :locals, "Show hash of local vars, sorted by descending size"
+        opt.on :c, :constants, "Show constants, highlighting classes (in blue), " \
+                               "and exceptions (in purple).\n" \
+                               "#{' ' * 32}Constants that are pending autoload? " \
+                               "are also shown (in yellow)"
+        opt.on :i, :ivars, "Show instance variables (in blue) and class " \
+                           "variables (in bright blue)"
+        opt.on :G, :grep, "Filter output by regular expression", argument: true
+
+        if Object.respond_to?(:deprecate_constant)
+          opt.on :d, :dconstants, "Show deprecated constants"
+        end
+
+        if Helpers::Platform.jruby?
+          opt.on :J, "all-java", "Show all the aliases for methods from java " \
+                                 "(default is to show only prettiest)"
+        end
       end
 
       # Exclude -q, -v and --grep because they,
@@ -93,9 +108,15 @@ class Pry
         [
           ['-l does not make sense with a specified Object', :locals, any_args],
           ['-g does not make sense with a specified Object', :globals, any_args],
-          ['-q does not make sense with -v',                 :quiet, opts.present?(:verbose)],
-          ['-M only makes sense with a Module or a Class',   'instance-methods', non_mod_interrogatee],
-          ['-c only makes sense with a Module or a Class',   :constants, any_args && non_mod_interrogatee]
+          ['-q does not make sense with -v', :quiet, opts.present?(:verbose)],
+          [
+            '-M only makes sense with a Module or a Class', 'instance-methods',
+            non_mod_interrogatee
+          ],
+          [
+            '-c only makes sense with a Module or a Class', :constants,
+            any_args && non_mod_interrogatee
+          ]
         ]
       end
 

--- a/lib/pry/commands/ls/methods_helper.rb
+++ b/lib/pry/commands/ls/methods_helper.rb
@@ -16,7 +16,9 @@ class Pry
                       Pry::Method.all_from_obj(@interrogatee)
                     end
 
-          methods = trim_jruby_aliases(methods) if Pry::Helpers::Platform.jruby? && !@jruby_switch
+          if Pry::Helpers::Platform.jruby? && !@jruby_switch
+            methods = trim_jruby_aliases(methods)
+          end
 
           methods.select { |method| @ppp_switch || method.visibility == :public }
         end

--- a/lib/pry/commands/play.rb
+++ b/lib/pry/commands/play.rb
@@ -49,7 +49,9 @@ class Pry
       end
 
       def show_input
-        run "show-input" if opts.present?(:print) || !Pry::Code.complete_expression?(eval_string)
+        if opts.present?(:print) || !Pry::Code.complete_expression?(eval_string)
+          run "show-input"
+        end
       end
 
       def content_after_options

--- a/lib/pry/commands/raise_up.rb
+++ b/lib/pry/commands/raise_up.rb
@@ -25,7 +25,8 @@ class Pry
       def process
         return _pry.pager.page help if captures[0] =~ /(-h|--help)\b/
 
-        # Handle 'raise-up', 'raise-up "foo"', 'raise-up RuntimeError, 'farble' in a rubyesque manner
+        # Handle 'raise-up', 'raise-up "foo"', 'raise-up RuntimeError, 'farble'
+        # in a rubyesque manner
         target.eval("_pry_.raise_up#{captures[0]}")
       end
     end

--- a/lib/pry/commands/reload_code.rb
+++ b/lib/pry/commands/reload_code.rb
@@ -38,7 +38,9 @@ class Pry
       end
 
       def reload_current_file
-        raise CommandError, "Current file: #{current_file} cannot be found on disk!" unless File.exist?(current_file)
+        unless File.exist?(current_file)
+          raise CommandError, "Current file: #{current_file} cannot be found on disk!"
+        end
 
         load current_file
         output.puts "The current file: #{current_file} was reloaded!"

--- a/lib/pry/commands/ri.rb
+++ b/lib/pry/commands/ri.rb
@@ -15,7 +15,11 @@ class Pry
       BANNER
 
       def process(spec)
-        return output.puts "Please provide a class, module, or method name (e.g: ri Array#push)" unless spec
+        unless spec
+          return output.puts(
+            "Please provide a class, module, or method name (e.g: ri Array#push)"
+          )
+        end
 
         # Lazily load RI
         require 'rdoc/ri/driver'
@@ -50,7 +54,9 @@ class Pry
         end
 
         # Spin-up an RI insance.
-        ri = RDoc::RI::PryDriver.new _pry_.pager, use_stdout: true, interactive: false
+        ri = RDoc::RI::PryDriver.new(
+          _pry_.pager, use_stdout: true, interactive: false
+        )
 
         begin
           ri.display_names [spec] # Get the documentation (finally!)

--- a/lib/pry/commands/show_doc.rb
+++ b/lib/pry/commands/show_doc.rb
@@ -48,7 +48,9 @@ class Pry
           # command '--help' shouldn't use markup highlighting
           docs
         else
-          raise CommandError, "No docs found for: #{obj_name || 'current context'}" if docs.empty?
+          if docs.empty?
+            raise CommandError, "No docs found for: #{obj_name || 'current context'}"
+          end
 
           process_comment_markup(docs)
         end

--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -12,10 +12,13 @@ class Pry
       end
 
       def options(opt)
-        opt.on :s, :super, "Select the 'super' method. Can be repeated to traverse the ancestors", as: :count
+        opt.on :s, :super, "Select the 'super' method. Can be repeated to " \
+                           "traverse the ancestors", as: :count
         opt.on :l, "line-numbers", "Show line numbers"
-        opt.on :b, "base-one", "Show line numbers but start numbering at 1 (useful for `amend-line` and `play` commands)"
-        opt.on :a, :all, "Show all definitions and monkeypatches of the module/class"
+        opt.on :b, "base-one", "Show line numbers but start numbering at 1 " \
+                               "(useful for `amend-line` and `play` commands)"
+        opt.on :a, :all, "Show all definitions and monkeypatches of the " \
+                         "module/class"
       end
 
       def process
@@ -25,12 +28,13 @@ class Pry
         @original_code_object = code_object
 
         if !obj_name && code_object.c_module? && !opts[:all]
-          result = "Warning: You're inside an object, whose class is defined by means\n" \
-                   "         of the C Ruby API. Pry cannot display the information for\n" \
-                   "         this class."
+          result = "You're inside an object, whose class is defined by means of " \
+                   "the C Ruby API.\nPry cannot display the information for this " \
+                   "class."
           if code_object.candidates.any?
-            result += "\n         However, you can view monkey-patches applied to this class.\n" \
-                      "         Just execute the same command with the '--all' switch."
+            result += "\nHowever, you can view monkey-patches applied to this " \
+                      "class.\n.Just execute the same command with the '--all' " \
+                      "switch."
           end
         elsif show_all_modules?(code_object)
           # show all monkey patches for a module
@@ -46,11 +50,10 @@ class Pry
         _pry_.pager.page result
       end
 
-      # This method checks whether the `code_object` is a WrappedModule,
-      # if it is, then it returns the first candidate (monkeypatch) with
-      # accessible source (or docs). If `code_object` is not a WrappedModule (i.e a
-      # method or a command) then the `code_object` itself is just
-      # returned.
+      # This method checks whether the `code_object` is a WrappedModule, if it
+      # is, then it returns the first candidate (monkeypatch) with accessible
+      # source (or docs). If `code_object` is not a WrappedModule (i.e a method
+      # or a command) then the `code_object` itself is just returned.
       #
       # @return [Pry::WrappedModule, Pry::Method, Pry::Command]
       def code_object_with_accessible_source(code_object)
@@ -59,7 +62,9 @@ class Pry
           if candidate
             return candidate
           else
-            raise CommandError, no_definition_message unless valid_superclass?(code_object)
+            unless valid_superclass?(code_object)
+              raise CommandError, no_definition_message
+            end
 
             @used_super = true
             code_object_with_accessible_source(code_object.super)
@@ -78,11 +83,13 @@ class Pry
       end
 
       def content_and_headers_for_all_module_candidates(mod)
-        result = "Found #{mod.number_of_candidates} candidates for `#{mod.name}` definition:\n"
+        result = "Found #{mod.number_of_candidates} candidates for " \
+                 "`#{mod.name}` definition:\n"
         mod.number_of_candidates.times do |v|
           candidate = mod.candidate(v)
           begin
-            result << "\nCandidate #{v + 1}/#{mod.number_of_candidates}: #{candidate.source_file}:#{candidate.source_line}\n"
+            result << "\nCandidate #{v + 1}/#{mod.number_of_candidates}: " \
+                      "#{candidate.source_file}:#{candidate.source_line}\n"
             content = content_for(candidate)
 
             result << "Number of lines: #{content.lines.count}\n\n" << content
@@ -107,9 +114,16 @@ class Pry
         h = "\n#{bold('From:')} #{file_name}"
         h << code_object_header(code_object, line_num)
         h << "\n#{bold('Number of lines:')} " << "#{content.lines.count}\n\n"
-        h << bold('** Warning:') << " Cannot find code for #{@original_code_object.nonblank_name}. Showing superclass #{code_object.nonblank_name} instead. **\n\n" if @used_super
+        if @used_super
+          h << bold('** Warning:')
+          h << " Cannot find code for #{@original_code_object.nonblank_name}. " \
+               "Showing superclass #{code_object.nonblank_name} instead. **\n\n"
+        end
 
-        h << bold('** Warning:') << " Cannot find code for '#{code_object.name}' (source_location is nil)" if content.lines.none?
+        if content.lines.none?
+          h << bold('** Warning:')
+          h << " Cannot find code for '#{code_object.name}' (source_location is nil)"
+        end
 
         h
       end
@@ -118,9 +132,11 @@ class Pry
         if code_object.real_method_object?
           method_header(code_object, line_num)
 
-          # It sucks we have to test for both Pry::WrappedModule and WrappedModule::Candidate,
-          # probably indicates a deep refactor needs to happen in those classes.
-        elsif code_object.is_a?(Pry::WrappedModule) || code_object.is_a?(Pry::WrappedModule::Candidate)
+          # It sucks we have to test for both Pry::WrappedModule and
+          # WrappedModule::Candidate, probably indicates a deep refactor needs
+          # to happen in those classes.
+        elsif code_object.is_a?(Pry::WrappedModule) ||
+              code_object.is_a?(Pry::WrappedModule::Candidate)
           module_header(code_object, line_num)
         else
           ""
@@ -143,7 +159,8 @@ class Pry
         h << " #{bold('name:')} #{code_object.nonblank_name}"
 
         if code_object.number_of_candidates > 1
-          h << (bold("\nNumber of monkeypatches: ") << code_object.number_of_candidates.to_s)
+          h << bold("\nNumber of monkeypatches: ")
+          h << code_object.number_of_candidates.to_s
           h << ". Use the `-a` option to display all available monkeypatches"
         end
         h
@@ -186,8 +203,9 @@ class Pry
       end
 
       # takes into account possible yard docs, and returns yard_file / yard_line
-      # Also adjusts for start line of comments (using start_line_for), which it has to infer
-      # by subtracting number of lines of comment from start line of code_object
+      # Also adjusts for start line of comments (using start_line_for), which it
+      # has to infer by subtracting number of lines of comment from start line
+      # of code_object
       def file_and_line_for(code_object)
         if code_object.module_with_yard_docs?
           [code_object.yard_file, code_object.yard_line]

--- a/lib/pry/commands/show_input.rb
+++ b/lib/pry/commands/show_input.rb
@@ -3,7 +3,8 @@ class Pry
     class ShowInput < Pry::ClassCommand
       match 'show-input'
       group 'Editing'
-      description 'Show the contents of the input buffer for the current multi-line expression.'
+      description 'Show the contents of the input buffer for the current ' \
+                  'multi-line expression.'
 
       banner <<-'BANNER'
         Show the contents of the input buffer for the current multi-line expression.

--- a/lib/pry/commands/show_source.rb
+++ b/lib/pry/commands/show_source.rb
@@ -29,7 +29,8 @@ class Pry
       BANNER
 
       def options(opt)
-        opt.on :e, :eval, "evaluate the command's argument as a ruby expression and show the class its return value"
+        opt.on :e, :eval, "evaluate the command's argument as a ruby " \
+                          "expression and show the class its return value"
         opt.on :d, :doc, 'include documentation in the output'
         super(opt)
       end
@@ -69,7 +70,9 @@ class Pry
           # command '--help' shouldn't use markup highlighting
           docs
         else
-          raise CommandError, "No docs found for: #{obj_name || 'current context'}" if docs.empty?
+          if docs.empty?
+            raise CommandError, "No docs found for: #{obj_name || 'current context'}"
+          end
 
           process_comment_markup(docs)
         end

--- a/lib/pry/commands/switch_to.rb
+++ b/lib/pry/commands/switch_to.rb
@@ -13,7 +13,9 @@ class Pry
         selection = selection.to_i
 
         if selection < 0 || selection > _pry_.binding_stack.size - 1
-          raise CommandError, "Invalid binding index #{selection} - use `nesting` command to view valid indices."
+          raise CommandError,
+                "Invalid binding index #{selection} - use `nesting` command " \
+                "to view valid indices."
         else
           Pry.start(_pry_.binding_stack[selection])
         end

--- a/lib/pry/commands/watch_expression.rb
+++ b/lib/pry/commands/watch_expression.rb
@@ -5,7 +5,8 @@ class Pry
 
       match 'watch'
       group 'Context'
-      description 'Watch the value of an expression and print a notification whenever it changes.'
+      description 'Watch the value of an expression and print a notification ' \
+                  'whenever it changes.'
       command_options use_prefix: false
 
       banner <<-'BANNER'
@@ -29,10 +30,13 @@ class Pry
 
       def options(opt)
         opt.on :d, :delete,
-               "Delete the watch expression with the given index. If no index is given; clear all watch expressions.",
+               "Delete the watch expression with the given index. If no index " \
+               "is given; clear all watch expressions.",
                optional_argument: true, as: Integer
         opt.on :l, :list,
-               "Show all current watch expressions and their values.  Calling watch with no expressions or options will also show the watch expressions."
+               "Show all current watch expressions and their values. Calling " \
+               "watch with no expressions or options will also show the watch " \
+               "expressions."
       end
 
       def process

--- a/lib/pry/commands/watch_expression/expression.rb
+++ b/lib/pry/commands/watch_expression/expression.rb
@@ -22,7 +22,8 @@ class Pry
         # Has the value of the expression changed?
         #
         # We use the pretty-printed string represenation to detect differences
-        # as this avoids problems with dup (causes too many differences) and == (causes too few)
+        # as this avoids problems with dup (causes too many differences) and ==
+        # (causes too few)
         def changed?
           (value != previous_value)
         end

--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -49,7 +49,7 @@ class Pry
       end
 
       def options(opt)
-        opt.on :q, :quiet,             "Don't display anything in case of an error"
+        opt.on :q, :quiet, "Don't display anything in case of an error"
         opt.on :n, :"no-line-numbers", "Do not display line numbers"
         opt.on :m, :method, "Show the complete source for the current method."
         opt.on :c, :class, "Show the complete source for the current class or module."
@@ -86,7 +86,9 @@ class Pry
       end
 
       def process
-        raise CommandError, "Only one of -m, -c, -f, and  LINES may be specified." if bad_option_combination?
+        if bad_option_combination?
+          raise CommandError, "Only one of -m, -c, -f, and  LINES may be specified."
+        end
 
         if nothing_to_do?
           return

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -22,10 +22,12 @@ class Pry
         exception_handler: Pry::DEFAULT_EXCEPTION_HANDLER,
         unrescued_exceptions: Pry::DEFAULT_UNRESCUED_EXCEPTIONS,
         exception_whitelist: Pry.lazy do
-                               defaults.output.puts '[warning] Pry.config.exception_whitelist is deprecated, ' \
-                                                    'please use Pry.config.unrescued_exceptions instead.'
-                               Pry::DEFAULT_UNRESCUED_EXCEPTIONS
-                             end,
+          defaults.output.puts(
+            '[warning] Pry.config.exception_whitelist is deprecated, ' \
+            'please use Pry.config.unrescued_exceptions instead.'
+          )
+          Pry::DEFAULT_UNRESCUED_EXCEPTIONS
+        end,
         hooks: Pry::DEFAULT_HOOKS,
         pager: true,
         system: Pry::DEFAULT_SYSTEM,
@@ -53,16 +55,19 @@ class Pry
         ls: Pry::Config.from_hash(Pry::Command::Ls::DEFAULT_OPTIONS),
         completer: Pry::InputCompleter,
         gist: Pry::Config.from_hash(inspecter: proc(&:pretty_inspect)),
-        history: Pry::Config.from_hash(should_save: true, should_load: true).tap do |history|
-          history_file = if File.exist?(File.expand_path('~/.pry_history'))
-                           '~/.pry_history'
-                         elsif ENV.key?('XDG_DATA_HOME') && ENV['XDG_DATA_HOME'] != ''
-                           # See XDG Base Directory Specification at
-                           # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
-                           ENV['XDG_DATA_HOME'] + '/pry/pry_history'
-                         else
-                           '~/.local/share/pry/pry_history'
-                         end
+        history: Pry::Config.from_hash(
+          should_save: true, should_load: true
+        ).tap do |history|
+          history_file =
+            if File.exist?(File.expand_path('~/.pry_history'))
+              '~/.pry_history'
+            elsif ENV.key?('XDG_DATA_HOME') && ENV['XDG_DATA_HOME'] != ''
+              # See XDG Base Directory Specification at
+              # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
+              ENV['XDG_DATA_HOME'] + '/pry/pry_history'
+            else
+              '~/.local/share/pry/pry_history'
+            end
           history.file = File.expand_path(history_file)
         end,
         exec_string: ""
@@ -78,11 +83,13 @@ class Pry
       require 'readline'
       ::Readline
     rescue LoadError
-      defaults.output.puts "Sorry, you can't use Pry without Readline or a compatible library. \n" \
-                           "Possible solutions: \n" \
-                           " * Rebuild Ruby with Readline support using `--with-readline` \n" \
-                           " * Use the rb-readline gem, which is a pure-Ruby port of Readline \n" \
-                           " * Use the pry-coolline gem, a pure-ruby alternative to Readline"
+      defaults.output.puts(
+        "Sorry, you can't use Pry without Readline or a compatible library. \n" \
+        "Possible solutions: \n" \
+        " * Rebuild Ruby with Readline support using `--with-readline` \n" \
+        " * Use the rb-readline gem, which is a pure-Ruby port of Readline \n" \
+        " * Use the pry-coolline gem, a pure-ruby alternative to Readline"
+      )
       raise
     end
     private_class_method :lazy_readline

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -164,7 +164,11 @@ class Pry
       #
       def []=(key, value)
         key = key.to_s
-        raise ReservedKeyError, "It is not possible to use '#{key}' as a key name, please choose a different key name." if @reserved_keys.include?(key)
+        if @reserved_keys.include?(key)
+          raise ReservedKeyError,
+                "It is not possible to use '#{key}' as a key name, please " \
+                "choose a different key name."
+        end
 
         __push(key, value)
       end
@@ -267,7 +271,8 @@ class Pry
       #  [1] pry(main)> _pry_.config.keys.size
       #  => 13
       #  [2] pry(main)> _pry_.config.eager_load!;
-      #  [warning] Pry.config.exception_whitelist is deprecated, please use Pry.config.unrescued_exceptions instead.
+      #  [warning] Pry.config.exception_whitelist is deprecated,
+      #  please use Pry.config.unrescued_exceptions instead.
       #  [3] pry(main)> _pry_.config.keys.size
       #  => 40
       #

--- a/lib/pry/editor.rb
+++ b/lib/pry/editor.rb
@@ -19,7 +19,10 @@ class Pry
     end
 
     def invoke_editor(file, line, blocking = true)
-      raise CommandError, "Please set Pry.config.editor or export $VISUAL or $EDITOR" unless _pry_.config.editor
+      unless _pry_.config.editor
+        raise CommandError,
+              "Please set Pry.config.editor or export $VISUAL or $EDITOR"
+      end
 
       editor_invocation = build_editor_invocation_string(file, line, blocking)
       return nil unless editor_invocation
@@ -42,7 +45,10 @@ class Pry
         _pry_.config.editor.call(*args)
       else
         sanitized_file = Helpers::Platform.windows? ? file : Shellwords.escape(file)
-        "#{_pry_.config.editor} #{blocking_flag_for_editor(blocking)} #{start_line_syntax_for_editor(sanitized_file, line)}"
+        editor = _pry_.config.editor
+        flag = blocking_flag_for_editor(blocking)
+        start_line = start_line_syntax_for_editor(sanitized_file, line)
+        "#{editor} #{flag} #{start_line}"
       end
     end
 
@@ -51,7 +57,11 @@ class Pry
       # Note we dont want to use Pry.config.system here as that
       # may be invoked non-interactively (i.e via Open4), whereas we want to
       # ensure the editor is always interactive
-      system(*Shellwords.split(editor_invocation)) || raise(CommandError, "`#{editor_invocation}` gave exit status: #{$CHILD_STATUS.exitstatus}")
+      system(*Shellwords.split(editor_invocation)) ||
+        raise(
+          CommandError,
+          "`#{editor_invocation}` gave exit status: #{$CHILD_STATUS.exitstatus}"
+        )
     end
 
     # We need JRuby specific code here cos just shelling out using

--- a/lib/pry/exceptions.rb
+++ b/lib/pry/exceptions.rb
@@ -65,7 +65,10 @@ class Pry
   if Object.respond_to?(:deprecate_constant)
     deprecate_constant :DEFAULT_EXCEPTION_WHITELIST
   else
-    warn('DEFAULT_EXCEPTION_WHITELIST is deprecated and will be removed in a future version of Pry. Please use DEFAULT_UNRESCUED_EXCEPTIONS instead.')
+    warn(
+      'DEFAULT_EXCEPTION_WHITELIST is deprecated and will be removed in a ' \
+      'future version of Pry. Please use DEFAULT_UNRESCUED_EXCEPTIONS instead.'
+    )
   end
 
   # CommandErrors are caught by the REPL loop and displayed to the user. They

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -18,7 +18,8 @@ class Pry
       # This is required to introspect methods on objects like Net::HTTP::Get that
       # have overridden the `method` method.
       def safe_send(obj, method, *args, &block)
-        (Module === obj ? Module : Object).instance_method(method).bind(obj).call(*args, &block)
+        (Module === obj ? Module : Object).instance_method(method)
+          .bind(obj).call(*args, &block)
       end
       public :safe_send
 
@@ -50,7 +51,9 @@ class Pry
       end
 
       def highlight(string, regexp, highlight_color = :bright_yellow)
-        string.gsub(regexp) { |match| "<#{highlight_color}>#{match}</#{highlight_color}>" }
+        string.gsub(regexp) do |match|
+          "<#{highlight_color}>#{match}</#{highlight_color}>"
+        end
       end
 
       # formatting

--- a/lib/pry/helpers/command_helpers.rb
+++ b/lib/pry/helpers/command_helpers.rb
@@ -1,5 +1,6 @@
 class Pry
   module Helpers
+    # rubocop:disable Metrics/ModuleLength
     module CommandHelpers
       include OptionsHelpers
 
@@ -23,17 +24,31 @@ class Pry
       def get_method_or_raise(name, target, opts = {}, omit_help = false)
         meth = Pry::Method.from_str(name, target, opts)
 
-        command_error("The method '#{name}' could not be found.", omit_help, MethodNotFound) if name && !meth
+        if name && !meth
+          command_error(
+            "The method '#{name}' could not be found.", omit_help, MethodNotFound
+          )
+        end
 
         (opts[:super] || 0).times do
           if meth.super
             meth = meth.super
           else
-            command_error("'#{meth.name_with_owner}' has no super method.", omit_help, MethodNotFound)
+            command_error(
+              "'#{meth.name_with_owner}' has no super method.",
+              omit_help,
+              MethodNotFound
+            )
           end
         end
 
-        command_error("No method name given, and context is not a method.", omit_help, MethodNotFound) if !meth || (!name && internal_binding?(target))
+        if !meth || (!name && internal_binding?(target))
+          command_error(
+            "No method name given, and context is not a method.",
+            omit_help,
+            MethodNotFound
+          )
+        end
 
         set_file_and_dir_locals(meth.source_file)
         meth
@@ -73,7 +88,8 @@ class Pry
         # Find the longest common whitespace to all indented lines
         # Ignore lines containing just -- or ++ as these seem to be used by
         # comment authors as delimeters.
-        margin = text.scan(/^[ \t]*(?!--\n|\+\+\n)(?=[^ \t\n])/).inject do |current_margin, next_indent|
+        scanned_text = text.scan(/^[ \t]*(?!--\n|\+\+\n)(?=[^ \t\n])/)
+        margin = scanned_text.inject do |current_margin, next_indent|
           if next_indent.start_with?(current_margin)
             current_margin
           elsif current_margin.start_with?(next_indent)
@@ -147,5 +163,6 @@ class Pry
         pry.inject_local("_dir_", pry.last_dir, ctx)
       end
     end
+    # rubocop:enable Metrics/ModuleLength
   end
 end

--- a/lib/pry/helpers/documentation_helpers.rb
+++ b/lib/pry/helpers/documentation_helpers.rb
@@ -12,13 +12,14 @@ class Pry
 
       def process_rdoc(comment)
         comment = comment.dup
-        comment.gsub(%r{<code>(?:\s*\n)?(.*?)\s*</code>}m) { CodeRay.scan(Regexp.last_match(1), :ruby).term }
+        last_match_ruby = proc { CodeRay.scan(Regexp.last_match(1), :ruby).term }
+        comment.gsub(%r{<code>(?:\s*\n)?(.*?)\s*</code>}m, &last_match_ruby)
           .gsub(%r{<em>(?:\s*\n)?(.*?)\s*</em>}m) { "\e[1m#{Regexp.last_match(1)}\e[0m" }
           .gsub(%r{<i>(?:\s*\n)?(.*?)\s*</i>}m) { "\e[1m#{Regexp.last_match(1)}\e[0m" }
-          .gsub(%r{<tt>(?:\s*\n)?(.*?)\s*</tt>}m) { CodeRay.scan(Regexp.last_match(1), :ruby).term }
+          .gsub(%r{<tt>(?:\s*\n)?(.*?)\s*</tt>}m, &last_match_ruby)
           .gsub(/\B\+(\w+?)\+\B/) { "\e[32m#{Regexp.last_match(1)}\e[0m" }
-          .gsub(/((?:^[ \t]+.+(?:\n+|\Z))+)/) { CodeRay.scan(Regexp.last_match(1), :ruby).term }
-          .gsub(/`(?:\s*\n)?([^\e]*?)\s*`/) { "`#{CodeRay.scan(Regexp.last_match(1), :ruby).term}`" }
+          .gsub(/((?:^[ \t]+.+(?:\n+|\Z))+)/, &last_match_ruby)
+          .gsub(/`(?:\s*\n)?([^\e]*?)\s*`/) { "`#{last_match_ruby.call}`" }
       end
 
       def process_yardoc_tag(comment, tag)

--- a/lib/pry/helpers/options_helpers.rb
+++ b/lib/pry/helpers/options_helpers.rb
@@ -8,8 +8,11 @@ class Pry
         @method_target = target
         opt.on :M, "instance-methods", "Operate on instance methods."
         opt.on :m, :methods, "Operate on methods."
-        opt.on :s, :super, "Select the 'super' method. Can be repeated to traverse the ancestors.", as: :count
-        opt.on :c, :context, "Select object context to run under.", argument: true do |context|
+        opt.on :s, :super, "Select the 'super' method. Can be repeated to " \
+                           "traverse the ancestors.", as: :count
+        opt.on(
+          :c, :context, "Select object context to run under.", argument: true
+        ) do |context|
           @method_target = Pry.binding_for(target.eval(context))
         end
       end

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -23,7 +23,9 @@ class Pry
 
     def self.tablify(things, line_length, config = Pry.config)
       table = Table.new(things, { column_count: things.size }, config)
-      table.column_count -= 1 until (table.column_count == 1) || table.fits_on_line?(line_length)
+      until (table.column_count == 1) || table.fits_on_line?(line_length)
+        table.column_count -= 1
+      end
       table
     end
 

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -1,6 +1,7 @@
 class Pry
   module Helpers
-    # The methods defined on {Text} are available to custom commands via {Pry::Command#text}.
+    # The methods defined on {Text} are available to custom commands via
+    # {Pry::Command#text}.
     module Text
       extend self # rubocop:disable Style/ModuleFunction
 

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -110,7 +110,9 @@ class Pry
       if defined?(@history_file)
         @history_file
       else
-        FileUtils.mkdir_p(File.dirname(history_file_path)) unless File.exist?(history_file_path)
+        unless File.exist?(history_file_path)
+          FileUtils.mkdir_p(File.dirname(history_file_path))
+        end
         @history_file = File.open(history_file_path, 'a', 0o600).tap do |file|
           file.sync = true
         end

--- a/lib/pry/hooks.rb
+++ b/lib/pry/hooks.rb
@@ -71,7 +71,9 @@ class Pry
 
       # do not allow duplicates, but allow multiple `nil` hooks
       # (anonymous hooks)
-      raise ArgumentError, "Hook with name '#{hook_name}' already defined!" if hook_exists?(event_name, hook_name) && !hook_name.nil?
+      if hook_exists?(event_name, hook_name) && !hook_name.nil?
+        raise ArgumentError, "Hook with name '#{hook_name}' already defined!"
+      end
 
       raise ArgumentError, "Must provide a block or callable." if !block && !callable
 

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -145,7 +145,9 @@ class Pry
       input.lines.each do |line|
         if in_string?
           tokens = tokenize("#{open_delimiters_line}\n#{line}")
-          tokens = tokens.drop_while { |token, _type| !(String === token && token.include?("\n")) }
+          tokens = tokens.drop_while do |token, _type|
+            !(String === token && token.include?("\n"))
+          end
           previously_in_string = true
         else
           tokens = tokenize(line)
@@ -215,7 +217,8 @@ class Pry
       # If the list of tokens contains a matching closing token the line should
       # not be indented (and thus we should return true).
       tokens.each do |token, kind|
-        is_singleline_if = SINGLELINE_TOKENS.include?(token) && end_of_statement?(last_token, last_kind)
+        is_singleline_if =
+          SINGLELINE_TOKENS.include?(token) && end_of_statement?(last_token, last_kind)
         is_optional_do = (token == "do" && seen_for_at.include?(add_after - 1))
 
         unless kind == :space
@@ -254,17 +257,18 @@ class Pry
       [remove_before, add_after]
     end
 
-    # If the code just before an "if" or "while" token on a line looks like the end of a statement,
-    # then we want to treat that "if" as a singleline, not multiline statement.
+    # If the code just before an "if" or "while" token on a line looks like the
+    # end of a statement, then we want to treat that "if" as a singleline, not
+    # multiline statement.
     def end_of_statement?(last_token, last_kind)
       (last_token =~ %r{^[)\]\}/]$} || STATEMENT_END_TOKENS.include?(last_kind))
     end
 
     # Are we currently in the middle of a string literal.
     #
-    # This is used to determine whether to re-indent a given line, we mustn't re-indent
-    # within string literals because to do so would actually change the value of the
-    # String!
+    # This is used to determine whether to re-indent a given line, we mustn't
+    # re-indent within string literals because to do so would actually change
+    # the value of the String!
     #
     # @return Boolean
     def in_string?
@@ -283,9 +287,10 @@ class Pry
 
     # Update the internal state about what kind of strings are open.
     #
-    # Most of the complication here comes from the fact that HEREDOCs can be nested. For
-    # normal strings (which can't be nested) we assume that CodeRay correctly pairs
-    # open-and-close delimiters so we don't bother checking what they are.
+    # Most of the complication here comes from the fact that HEREDOCs can be
+    # nested. For normal strings (which can't be nested) we assume that CodeRay
+    # correctly pairs open-and-close delimiters so we don't bother checking what
+    # they are.
     #
     # @param [String] token The token (of type :delimiter)
     def track_delimiter(token)

--- a/lib/pry/method/disowned.rb
+++ b/lib/pry/method/disowned.rb
@@ -47,9 +47,12 @@ class Pry
 
       # Raise a more useful error message instead of trying to forward to nil.
       def method_missing(meth_name, *args, &block)
-        raise "Cannot call '#{meth_name}' on an undef'd method." if method(:name).respond_to?(meth_name)
+        if method(:name).respond_to?(meth_name)
+          raise "Cannot call '#{meth_name}' on an undef'd method."
+        end
 
-        Object.instance_method(:method_missing).bind(self).call(meth_name, *args, &block)
+        Object.instance_method(:method_missing).bind(self)
+          .call(meth_name, *args, &block)
       end
     end
   end

--- a/lib/pry/method/patcher.rb
+++ b/lib/pry/method/patcher.rb
@@ -75,7 +75,9 @@ class Pry
         if line =~ /\Adef (?:.*?\.)?#{Regexp.escape(method.original_name)}(?=[\(\s;]|$)/
           "def #{method.original_name}#{$'}"
         else
-          raise CommandError, "Could not find original `def #{method.original_name}` line to patch."
+          raise CommandError,
+                "Could not find original `def #{method.original_name}` line " \
+                "to patch."
         end
       end
 

--- a/lib/pry/method/weird_method_locator.rb
+++ b/lib/pry/method/weird_method_locator.rb
@@ -6,10 +6,11 @@ class Pry
     # Given a `Binding` from inside a method and a 'seed' Pry::Method object,
     # there are primarily two situations where the seed method doesn't match
     # the Binding:
-    # 1. The Pry::Method is from a subclass 2. The Pry::Method represents a method of the same name
-    # while the original was renamed to something else. For 1. we
-    # search vertically up the inheritance chain,
-    # and for 2. we search laterally along the object's method table.
+    # 1. The Pry::Method is from a subclass
+    # 2. The Pry::Method represents a method of the same name while the original
+    # was renamed to something else. For 1. we search vertically up the
+    # inheritance chain, and for 2. we search laterally along the object's
+    # method table.
     #
     # When we locate the method that matches the Binding we wrap it in
     # Pry::Method and return it, or return nil if we fail.
@@ -110,17 +111,18 @@ class Pry
         Pry.eval_path == file
       end
 
-      # it's possible in some cases that the method we find by this approach is a sub-method of
-      # the one we're currently in, consider:
+      # it's possible in some cases that the method we find by this approach is
+      # a sub-method of the one we're currently in, consider:
       #
       # class A; def b; binding.pry; end; end
       # class B < A; def b; super; end; end
       #
-      # Given that we can normally find the source_range of methods, and that we know which
-      # __FILE__ and __LINE__ the binding is at, we can hope to disambiguate these cases.
+      # Given that we can normally find the source_range of methods, and that we
+      # know which __FILE__ and __LINE__ the binding is at, we can hope to
+      # disambiguate these cases.
       #
-      # This obviously won't work if the source is unavaiable for some reason, or if both
-      # methods have the same __FILE__ and __LINE__.
+      # This obviously won't work if the source is unavaiable for some reason,
+      # or if both methods have the same __FILE__ and __LINE__.
       #
       # @return [Pry::Method, nil] The Pry::Method representing the
       #   superclass method.
@@ -156,7 +158,8 @@ class Pry
         return unless valid_file?(target_file)
 
         alias_name = all_methods_for(target_self).find do |v|
-          expanded_source_location(target_self.method(v).source_location) == renamed_method_source_location
+          location = target_self.method(v).source_location
+          expanded_source_location(location) == renamed_method_source_location
         end
 
         alias_name && Pry::Method(target_self.method(alias_name))
@@ -180,7 +183,9 @@ class Pry
       # @return [Array<String, Fixnum>] The `source_location` of the
       #   renamed method
       def renamed_method_source_location
-        return @original_method_source_location if defined?(@original_method_source_location)
+        if defined?(@original_method_source_location)
+          return @original_method_source_location
+        end
 
         source_index = lines_for_file(target_file)[0..(target_line - 1)].rindex do |v|
           Pry::Method.method_definition?(method.name, v)

--- a/lib/pry/plugins.rb
+++ b/lib/pry/plugins.rb
@@ -40,7 +40,9 @@ class Pry
         cli_options_file = File.join(spec.full_gem_path, "lib/#{spec.name}/cli.rb")
         return unless File.exist?(cli_options_file)
 
-        cli_options_file = File.realpath(cli_options_file) if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.4")
+        if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.4.4")
+          cli_options_file = File.realpath(cli_options_file)
+        end
         require cli_options_file
       end
 
@@ -71,7 +73,9 @@ class Pry
       def supported?
         pry_version = Gem::Version.new(VERSION)
         spec.dependencies.each do |dependency|
-          return dependency.requirement.satisfied_by?(pry_version) if dependency.name == "pry"
+          if dependency.name == "pry"
+            return dependency.requirement.satisfied_by?(pry_version)
+          end
         end
         true
       end
@@ -118,7 +122,9 @@ class Pry
 
     def gem_list
       Gem.refresh
-      Gem::Specification.respond_to?(:each) ? Gem::Specification : Gem.source_index.find_name('')
+      return Gem::Specification if Gem::Specification.respond_to?(:each)
+
+      Gem.source_index.find_name('')
     end
   end
 end

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -84,9 +84,13 @@ class Pry
       def add(name, description = '', separators = %w[> *])
         name = name.to_s
 
-        raise ArgumentError, "separators size must be 2, given #{separators.size}" unless separators.size == 2
+        unless separators.size == 2
+          raise ArgumentError, "separators size must be 2, given #{separators.size}"
+        end
 
-        raise ArgumentError, "the '#{name}' prompt was already added" if @prompts.key?(name)
+        if @prompts.key?(name)
+          raise ArgumentError, "the '#{name}' prompt was already added"
+        end
 
         @prompts[name] = new(
           name,

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -138,7 +138,11 @@ class Pry
 
     Pry.critical_section do
       completer = config.completer.new(config.input, self)
-      completer.call str, target: current_binding, custom_completions: custom_completions.call.push(*sticky_locals.keys)
+      completer.call(
+        str,
+        target: current_binding,
+        custom_completions: custom_completions.call.push(*sticky_locals.keys)
+      )
     end
   end
 
@@ -300,7 +304,9 @@ class Pry
     end
 
     if complete_expr
-      @suppress_output = true if @eval_string =~ /;\Z/ || @eval_string.empty? || @eval_string =~ /\A *#.*\n\z/
+      if @eval_string =~ /;\Z/ || @eval_string.empty? || @eval_string =~ /\A *#.*\n\z/
+        @suppress_output = true
+      end
 
       # A bug in jruby makes java.lang.Exception not rescued by
       # `rescue Pry::RescuableException` clause.
@@ -327,7 +333,9 @@ class Pry
         # Eliminate following warning:
         # warning: singleton on non-persistent Java type X
         # (http://wiki.jruby.org/Persistence)
-        e.class.__persistent__ = true if Helpers::Platform.jruby? && e.class.respond_to?('__persistent__')
+        if Helpers::Platform.jruby? && e.class.respond_to?('__persistent__')
+          e.class.__persistent__ = true
+        end
         self.last_exception = e
         result = e
       end
@@ -434,7 +442,9 @@ class Pry
   # @return [Boolean] `true` if `val` is a command, `false` otherwise
   def process_command_safely(val)
     process_command(val)
-  rescue CommandError, Pry::Slop::InvalidOptionError, MethodSource::SourceNotFoundError => e
+  rescue CommandError,
+         Pry::Slop::InvalidOptionError,
+         MethodSource::SourceNotFoundError => e
     Pry.last_internal_error = e
     output.puts "Error: #{e.message}"
     true

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -102,7 +102,9 @@ class Pry
         original_val = "#{indentation}#{val}"
         indented_val = @indent.indent(val)
 
-        if output.tty? && pry.config.correct_indent && Pry::Helpers::BaseHelpers.use_ansi_codes?
+        if output.tty? &&
+           pry.config.correct_indent &&
+           Pry::Helpers::BaseHelpers.use_ansi_codes?
           output.print @indent.correct_indentation(
             current_prompt,
             indented_val,
@@ -240,7 +242,9 @@ class Pry
         begin
           # rb-readline doesn't support this method:
           # https://github.com/ConnorAtherton/rb-readline/issues/152
-          overhang += current_prompt.length - indented_val.length if Readline.vi_editing_mode?
+          if Readline.vi_editing_mode?
+            overhang += current_prompt.length - indented_val.length
+          end
         rescue NotImplementedError
           # VI editing mode is unsupported on JRuby.
           # https://github.com/pry/pry/issues/1840

--- a/lib/pry/repl_file_loader.rb
+++ b/lib/pry/repl_file_loader.rb
@@ -45,7 +45,9 @@ class Pry
       end
 
       unless _pry_.eval_string.empty?
-        _pry_.output.puts "#{_pry_.eval_string}...exception encountered, going interactive!"
+        _pry_.output.puts(
+          "#{_pry_.eval_string}...exception encountered, going interactive!"
+        )
         interactive_mode(_pry_)
       end
     end
@@ -59,7 +61,9 @@ class Pry
         s.interactive_mode(_pry_)
       end
 
-      Pry::Commands.command "load-file", "Load another file through the repl" do |file_name|
+      Pry::Commands.command(
+        "load-file", "Load another file through the repl"
+      ) do |file_name|
         s.non_interactive_mode(_pry_, File.read(File.expand_path(file_name)))
       end
     end

--- a/lib/pry/slop/commands.rb
+++ b/lib/pry/slop/commands.rb
@@ -143,7 +143,9 @@ class Pry
           if (opts = commands['default'])
             opts.parse! items
           else
-            raise InvalidCommandError, "Unknown command `#{items[0]}`" if config[:strict] && items[0]
+            if config[:strict] && items[0]
+              raise InvalidCommandError, "Unknown command `#{items[0]}`"
+            end
           end
           execute_global_opts! items
         end

--- a/lib/pry/slop/option.rb
+++ b/lib/pry/slop/option.rb
@@ -49,11 +49,15 @@ class Pry
           count: proc { @count }
         }
 
-        @slop.config[:longest_flag] = long.size if long && long.size > @slop.config[:longest_flag]
+        if long && long.size > @slop.config[:longest_flag]
+          @slop.config[:longest_flag] = long.size
+        end
 
         @config.each_key do |key|
           predicate = :"#{key}?"
-          self.class.__send__(:define_method, predicate) { !!@config[key] } unless self.class.method_defined? predicate
+          unless self.class.method_defined?(predicate)
+            self.class.__send__(:define_method, predicate) { !!@config[key] }
+          end
         end
       end
 
@@ -88,7 +92,9 @@ class Pry
         if config[:as].to_s.casecmp('array') == 0
           @value ||= []
 
-          @value.concat new_value.split(config[:delimiter], config[:limit]) if new_value.respond_to?(:split)
+          if new_value.respond_to?(:split)
+            @value.concat new_value.split(config[:delimiter], config[:limit])
+          end
         else
           @value = new_value
         end

--- a/lib/pry/terminal.rb
+++ b/lib/pry/terminal.rb
@@ -43,7 +43,9 @@ class Pry
           require 'io/console'
 
           begin
-            $stdout.winsize if $stdout.respond_to?(:tty?) && $stdout.tty? && $stdout.respond_to?(:winsize)
+            if $stdout.respond_to?(:tty?) && $stdout.tty? && $stdout.respond_to?(:winsize)
+              $stdout.winsize
+            end
           rescue Errno::EOPNOTSUPP
             # $stdout is probably a socket, which doesn't support #winsize.
           end

--- a/lib/pry/testable/evalable.rb
+++ b/lib/pry/testable/evalable.rb
@@ -9,7 +9,12 @@ class Pry
       end
 
       def pry_eval(*eval_strs)
-        b = String === eval_strs.first ? Pry.toplevel_binding : Pry.binding_for(eval_strs.shift)
+        b =
+          if String === eval_strs.first
+            Pry.toplevel_binding
+          else
+            Pry.binding_for(eval_strs.shift)
+          end
         pry_tester(b).eval(*eval_strs)
       end
     end

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -54,7 +54,10 @@ class Pry
     # @raise [ArgumentError] if the argument is not a `Module`
     # @param [Module] mod
     def initialize(mod)
-      raise ArgumentError, "Tried to initialize a WrappedModule with a non-module #{mod.inspect}" unless ::Module === mod
+      unless ::Module === mod
+        raise ArgumentError, "Tried to initialize a WrappedModule with a " \
+                             "non-module #{mod.inspect}"
+      end
 
       @wrapped = mod
       @memoized_candidates = []
@@ -130,12 +133,16 @@ class Pry
     #
     # @return [Object]
     def singleton_instance
-      raise ArgumentError, "tried to get instance of non singleton class" unless singleton_class?
+      unless singleton_class?
+        raise ArgumentError, "tried to get instance of non singleton class"
+      end
 
       if Helpers::Platform.jruby?
         wrapped.to_java.attached
       else
-        @singleton_instance ||= ObjectSpace.each_object(wrapped).detect { |x| (class << x; self; end) == wrapped }
+        @singleton_instance ||= ObjectSpace.each_object(wrapped).detect do |x|
+          (class << x; self; end) == wrapped
+        end
       end
     end
 

--- a/lib/pry/wrapped_module/candidate.rb
+++ b/lib/pry/wrapped_module/candidate.rb
@@ -41,7 +41,9 @@ class Pry
         if number_of_candidates <= 0
           raise CommandError, "Cannot find a definition for #{name} module!"
         elsif rank > (number_of_candidates - 1)
-          raise CommandError, "No such module candidate. Allowed candidates range is from 0 to #{number_of_candidates - 1}"
+          raise CommandError,
+                "No such module candidate. Allowed candidates range is " \
+                "from 0 to #{number_of_candidates - 1}"
         end
 
         @source = @source_location = nil
@@ -56,7 +58,9 @@ class Pry
         return nil if file.nil?
         return @source if @source
 
-        @source ||= strip_leading_whitespace(Pry::Code.from_file(file).expression_at(line, number_of_lines_in_first_chunk))
+        @source ||= strip_leading_whitespace(
+          Pry::Code.from_file(file).expression_at(line, number_of_lines_in_first_chunk)
+        )
       end
 
       # @raise [Pry::CommandError] If documentation cannot be found.
@@ -116,11 +120,12 @@ class Pry
         @end_method_source_location ||= method_candidates[@rank].last.source_location
       end
 
-      # Return the number of lines between the start of the class definition
-      # and the start of the last method. We use this value so we can
-      # quickly grab these lines from the file (without having to
-      # check each intervening line for validity, which is expensive) speeding up source extraction.
-      # @return [Fixum] Number of lines.
+      # Return the number of lines between the start of the class definition and
+      # the start of the last method. We use this value so we can quickly grab
+      # these lines from the file (without having to check each intervening line
+      # for validity, which is expensive) speeding up source extraction.
+      #
+      # @return [Integer] number of lines.
       def number_of_lines_in_first_chunk
         end_method_line = last_method_source_location.last
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Pry::CLI do
 
   describe "parsing options" do
     it 'should raise if no options defined' do
-      expect { Pry::CLI.parse_options(["--nothing"]) }.to raise_error Pry::CLI::NoOptionsError
+      expect { Pry::CLI.parse_options(["--nothing"]) }
+        .to raise_error Pry::CLI::NoOptionsError
     end
 
     it "should remove args from ARGV by default" do

--- a/spec/code_object_spec.rb
+++ b/spec/code_object_spec.rb
@@ -79,7 +79,10 @@ describe Pry::CodeObject do
           Pry.config.commands.delete("lobster-lady")
         end
 
-        it 'should return Pry::WrappedModule when looking up command class directly (as a class, not as a command)' do
+        it(
+          'returns Pry::WrappedModule when looking up command class directly ' \
+          '(as a class, not as a command)'
+        ) do
           Pry.config.commands.add_command(LobsterLady)
           m = Pry::CodeObject.lookup("LobsterLady", @p)
           expect(m.is_a?(Pry::WrappedModule)).to eq true
@@ -102,7 +105,7 @@ describe Pry::CodeObject do
       end
     end
 
-    it 'should lookup instance methods defined on classes accessed via local variable' do
+    it 'lookups instance methods defined on classes accessed via local variable' do
       o = Class.new do
         def princess_bubblegum
           "mathematic!"
@@ -268,8 +271,8 @@ describe Pry::CodeObject do
       expect(o.is_a?(Pry::WrappedModule)).to eq true
     end
 
-    # actually locals are never looked up (via co.default_lookup)  when they're classes, it
-    # just falls through to co.method_or_class
+    # actually locals are never looked up (via co.default_lookup) when they're
+    # classes, it just falls through to co.method_or_class
     it 'should look up classes before locals' do
       _c = ClassyWassy
       @p.binding_stack = [binding]

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -29,13 +29,15 @@ describe Pry::Code do
 
     specify 'check for files relative to origin pwd' do
       Dir.chdir('spec') do
-        expect(Pry::Code.from_file('spec/' + File.basename(__FILE__)).code_type).to eq :ruby
+        expect(Pry::Code.from_file('spec/' + File.basename(__FILE__)).code_type)
+          .to eq :ruby
       end
     end
 
     specify 'check for Ruby files relative to origin pwd with `.rb` omitted' do
       Dir.chdir('spec') do
-        expect(Pry::Code.from_file('spec/' + File.basename(__FILE__, '.*')).code_type).to eq :ruby
+        expect(Pry::Code.from_file('spec/' + File.basename(__FILE__, '.*')).code_type)
+          .to eq :ruby
       end
     end
 

--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -240,8 +240,13 @@ describe "commands" do
   end
 
   # bug fix for https://github.com/pry/pry/issues/170
-  it 'should not choke on complex string interpolation when checking if ruby code is a command' do
-    redirect_pry_io(InputTester.new('/#{Regexp.escape(File.expand_path("."))}/'), @str_output) do
+  it(
+    "doesn't choke on complex string interpolation when checking if ruby code " \
+    "is a command"
+  ) do
+    redirect_pry_io(
+      InputTester.new('/#{Regexp.escape(File.expand_path("."))}/'), @str_output
+    ) do
       pry
     end
 
@@ -300,7 +305,10 @@ describe "commands" do
     expect(pry_tester(commands: set).eval('hello1')).to match(/hello1/)
   end
 
-  it 'should create a regex command and pass captures into the args list before regular arguments' do
+  it(
+    'creates a regex command and passes captures into the args list ' \
+    'before regular arguments'
+  ) do
     set = Pry::CommandSet.new do
       command(/hello(.)/, "") do |c1, a1|
         output.puts "hello #{c1} #{a1}"
@@ -348,8 +356,12 @@ describe "commands" do
     expect(pry_tester(commands: set).eval('hello baby')).to match(/hello nil baby/)
   end
 
-  it 'should create a command in a nested context and that command should be accessible from the parent' do
-    expect(pry_tester(Object.new).eval(*<<-RUBY.split("\n"))).to match(/instance variables:\s+@x/m)
+  it(
+    'creates a command in a nested context and that command should ' \
+    'be accessible from the parent'
+  ) do
+    tester = pry_tester(Object.new)
+    expect(tester.eval(*<<-RUBY.split("\n"))).to match(/instance variables:\s+@x/m)
       @x = nil
       cd 7
       _pry_.commands.instance_eval { command('bing') { |arg| run arg } }
@@ -394,7 +406,10 @@ describe "commands" do
     expect(t.last_command_result).to eq nil
   end
 
-  it 'should define a command that keeps its return value but does not return when value is void' do
+  it(
+    'should define a command that keeps its return value but does not ' \
+    'return when value is void'
+  ) do
     klass = Pry::CommandSet.new do
       command "hello", "", keep_retval: true do
         void
@@ -404,7 +419,10 @@ describe "commands" do
     expect(pry_tester(commands: klass).eval("hello\n").empty?).to eq true
   end
 
-  it 'a command (with :keep_retval => false) that replaces eval_string with a valid expression should not have the expression value suppressed' do
+  it(
+    "a command (with :keep_retval => false) that replaces eval_string with a " \
+    "valid expression doesn't have the expression value suppressed"
+  ) do
     klass = Pry::CommandSet.new do
       command "hello", "" do
         eval_string.replace("6")
@@ -418,7 +436,10 @@ describe "commands" do
     expect(@str_output.string).to match(/6/)
   end
 
-  it 'a command (with :keep_retval => true) that replaces eval_string with a valid expression should overwrite the eval_string with the return value' do
+  it(
+    'a command (with :keep_retval => true) that replaces eval_string with ' \
+    'a valid expression overwrites the eval_string with the return value'
+  ) do
     klass = Pry::CommandSet.new do
       command "hello", "", keep_retval: true do
         eval_string.replace("6")
@@ -429,7 +450,10 @@ describe "commands" do
     expect(pry_tester(commands: klass).eval("def yo\nhello\n")).to eq 7
   end
 
-  it 'a command that return a value in a multi-line expression should clear the expression and return the value' do
+  it(
+    'a command that return a value in a multi-line expression clears ' \
+    'the expression and return the value'
+  ) do
     klass = Pry::CommandSet.new do
       command "hello", "", keep_retval: true do
         5
@@ -482,7 +506,10 @@ describe "commands" do
     expect(commands["help"].description).to eq "blah"
   end
 
-  it 'should enable an inherited method to access opts and output and target, due to instance_exec' do
+  it(
+    'enables an inherited method to access opts, output and target, ' \
+    'due to instance_exec'
+  ) do
     klass = Pry::CommandSet.new do
       command "v" do
         output.puts target.eval('self').to_s

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -16,7 +16,8 @@ describe Pry::CommandSet do
       expect(@set["help"]).not_to eq nil
       @set["help"] = nil
       expect(@set["help"]).to eq nil
-      expect { @set.run_command(TOPLEVEL_BINDING, "help") }.to raise_error Pry::NoCommandError
+      expect { @set.run_command(TOPLEVEL_BINDING, "help") }
+        .to raise_error Pry::NoCommandError
     end
 
     it "replaces a command" do
@@ -378,7 +379,9 @@ describe Pry::CommandSet do
       desc    = "hello"
       listing = "bing"
       @set.command('foo') {}
-      @set.rename_command('bar', 'foo', description: desc, listing: listing, keep_retval: true)
+      @set.rename_command(
+        'bar', 'foo', description: desc, listing: listing, keep_retval: true
+      )
       expect(@set['bar'].description).to           eq desc
       expect(@set['bar'].options[:listing]).to     eq listing
       expect(@set['bar'].options[:keep_retval]).to eq true

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -6,21 +6,28 @@ describe "Pry::Command" do
 
   describe 'call_safely' do
     it 'should display a message if gems are missing' do
-      cmd = @set.create_command "ford-prefect", "From a planet near Beetlegeuse", requires_gem: %w[ghijkl] do
+      cmd = @set.create_command(
+        "ford-prefect", "From a planet near Beetlegeuse", requires_gem: %w[ghijkl]
+      ) do
       end
 
-      expect(mock_command(cmd, %w[hello world]).output).to match(/install-command ford-prefect/)
+      expect(mock_command(cmd, %w[hello world]).output)
+        .to match(/install-command ford-prefect/)
     end
 
     it 'should abort early if arguments are required' do
-      cmd = @set.create_command 'arthur-dent', "Doesn't understand Thursdays", argument_required: true do
+      cmd = @set.create_command(
+        'arthur-dent', "Doesn't understand Thursdays", argument_required: true
+      ) do
       end
 
       expect { mock_command(cmd, %w[]) }.to raise_error Pry::CommandError
     end
 
     it 'should return VOID without keep_retval' do
-      cmd = @set.create_command 'zaphod-beeblebrox', "Likes pan-Galactic Gargle Blasters" do
+      cmd = @set.create_command(
+        'zaphod-beeblebrox', "Likes pan-Galactic Gargle Blasters"
+      ) do
         def process
           3
         end
@@ -79,7 +86,8 @@ describe "Pry::Command" do
       @set.command 'oolon-colluphid', "Raving Atheist" do
       end
 
-      expect(mock_command(@set['help'], %w[oolon-colluphid], command_set: @set).output).to match(/Raving Atheist/)
+      expect(mock_command(@set['help'], %w[oolon-colluphid], command_set: @set).output)
+        .to match(/Raving Atheist/)
     end
 
     it 'should use slop to generate the help for classy commands' do
@@ -89,7 +97,8 @@ describe "Pry::Command" do
         end
       end
 
-      expect(mock_command(@set['help'], %w[eddie], command_set: @set).output).to match(/Over-cheerful/)
+      expect(mock_command(@set['help'], %w[eddie], command_set: @set).output)
+        .to match(/Over-cheerful/)
     end
 
     it 'should provide --help for classy commands' do
@@ -103,7 +112,9 @@ describe "Pry::Command" do
     end
 
     it 'should provide a -h for classy commands' do
-      cmd = @set.create_command 'zarniwoop', "On an intergalactic cruise, in his office." do
+      cmd = @set.create_command(
+        'zarniwoop', "On an intergalactic cruise, in his office."
+      ) do
         def options(opt)
           opt.on :e, :escape, "Help zaphod escape the Total Perspective Vortex"
         end
@@ -226,7 +237,9 @@ describe "Pry::Command" do
     end
 
     it 'should allow overriding options after definition' do
-      cmd = @set.create_command(/number-(one|two)/, "Lieutenants of the Golgafrinchan Captain", shellwords: false) do
+      cmd = @set.create_command(
+        /number-(one|two)/, "Lieutenants of the Golgafrinchan Captain", shellwords: false
+      ) do
         command_options listing: 'number-one'
       end
 
@@ -337,7 +350,9 @@ describe "Pry::Command" do
 
     it 'should split on spaces if shellwords is not used' do
       expect do |probe|
-        cmd = @set.command('bugblatter-beast', 'would eat its grandmother', shellwords: false, &probe)
+        cmd = @set.command(
+          'bugblatter-beast', 'would eat its grandmother', shellwords: false, &probe
+        )
 
         cmd.new.process_line %(bugblatter-beast "of traal")
       end.to yield_with_args('"of', 'traal"')
@@ -458,14 +473,17 @@ describe "Pry::Command" do
     describe "block-related content removed from arguments" do
       describe "arg_string" do
         it 'should remove block-related content from arg_string (with one normal arg)' do
-          @set.block_command "walking-spanish", "down the hall", takes_block: true do |x, _y|
+          @set.block_command(
+            "walking-spanish", "down the hall", takes_block: true
+          ) do |x, _y|
             insert_variable(:@arg_string, arg_string, target)
             insert_variable(:@x, x, target)
           end
 
           @t.eval 'walking-spanish john| { :jesus }'
 
-          expect(@context.instance_variable_get(:@arg_string)).to eq @context.instance_variable_get(:@x)
+          expect(@context.instance_variable_get(:@arg_string))
+            .to eq(@context.instance_variable_get(:@x))
         end
 
         it 'should remove block-related content from arg_string (with no normal args)' do
@@ -478,7 +496,10 @@ describe "Pry::Command" do
           expect(@context.instance_variable_get(:@arg_string)).to eq ""
         end
 
-        it 'should NOT remove block-related content from arg_string when :takes_block => false' do
+        it(
+          "doesn't remove block-related content from arg_string " \
+          "when :takes_block => false"
+        ) do
           block_string = "| { :jesus }"
           @set.block_command "walking-spanish", "homemade special", takes_block: false do
             insert_variable(:@arg_string, arg_string, target)
@@ -493,7 +514,9 @@ describe "Pry::Command" do
       describe "args" do
         describe "block_command" do
           it "should remove block-related content from arguments" do
-            @set.block_command "walking-spanish", "glass is full of sand", takes_block: true do |x, y|
+            @set.block_command(
+              "walking-spanish", "glass is full of sand", takes_block: true
+            ) do |x, y|
               insert_variable(:@x, x, target)
               insert_variable(:@y, y, target)
             end
@@ -504,8 +527,12 @@ describe "Pry::Command" do
             expect(@context.instance_variable_get(:@y)).to eq nil
           end
 
-          it "should NOT remove block-related content from arguments if :takes_block => false" do
-            @set.block_command "walking-spanish", "litella screeching for a blind pig", takes_block: false do |x, y|
+          it(
+            "doesn't remove block-related content from arguments if :takes_block => false"
+          ) do
+            @set.block_command(
+              "walking-spanish", "litella screeching for a blind pig", takes_block: false
+            ) do |x, y|
               insert_variable(:@x, x, target)
               insert_variable(:@y, y, target)
             end
@@ -519,7 +546,9 @@ describe "Pry::Command" do
 
         describe "create_command" do
           it "should remove block-related content from arguments" do
-            @set.create_command "walking-spanish", "punk sanders carved one out of wood", takes_block: true do
+            @set.create_command(
+              "walking-spanish", "punk sanders carved one out of wood", takes_block: true
+            ) do
               def process(x, y)
                 insert_variable(:@x, x, target)
                 insert_variable(:@y, y, target)
@@ -532,7 +561,9 @@ describe "Pry::Command" do
             expect(@context.instance_variable_get(:@y)).to eq nil
           end
 
-          it "should NOT remove block-related content from arguments if :takes_block => false" do
+          it(
+            "doesn't remove block-related content from arguments if :takes_block => false"
+          ) do
             @set.create_command "walking-spanish", "down the hall", takes_block: false do
               def process(x, y)
                 insert_variable(:@x, x, target)

--- a/spec/commands/cat_spec.rb
+++ b/spec/commands/cat_spec.rb
@@ -15,13 +15,15 @@ describe "cat" do
 
   describe "when invoked without arguments" do
     it 'should display an error message' do
-      expect { @t.eval 'cat' }.to raise_error(Pry::CommandError, /Must provide a filename/)
+      expect { @t.eval 'cat' }
+        .to raise_error(Pry::CommandError, /Must provide a filename/)
     end
   end
 
   describe "on receiving a file that does not exist" do
     it 'should display an error message' do
-      expect { @t.eval 'cat supercalifragilicious66' }.to raise_error(StandardError, /Cannot open/)
+      expect { @t.eval 'cat supercalifragilicious66' }
+        .to raise_error(StandardError, /Cannot open/)
     end
   end
 
@@ -133,10 +135,14 @@ describe "cat" do
 
     it 'should show error when backtrace level out of bounds' do
       @t.last_exception = mock_exception('x', 'x', 'x')
-      expect { @t.eval('cat --ex 3') }.to raise_error(Pry::CommandError, /out of bounds/)
+      expect { @t.eval('cat --ex 3') }
+        .to raise_error(Pry::CommandError, /out of bounds/)
     end
 
-    it 'each successive cat --ex should show the next level of backtrace, and going past the final level should return to the first' do
+    it(
+      'each successive cat --ex should show the next level of backtrace, ' \
+      'and going past the final level should return to the first'
+    ) do
       temp_files = []
       3.times do |i|
         temp_files << Tempfile.new(['pry', '.rb'])

--- a/spec/commands/cd_spec.rb
+++ b/spec/commands/cd_spec.rb
@@ -190,7 +190,7 @@ describe 'cd' do
     expect(@t.mapped_binding_stack).to eq [@o, @obj, 66]
   end
 
-  it 'should cd into an object and its ivar using cd obj/@ivar/ syntax (note following /)' do
+  it 'cds into an object and its ivar using cd obj/@ivar/ syntax (note following /)' do
     @t.eval 'cd @obj/@x/'
     expect(@t.mapped_binding_stack).to eq [@o, @obj, 66]
   end
@@ -200,12 +200,15 @@ describe 'cd' do
     expect(@t.mapped_binding_stack).to eq [@o, @obj, :local]
   end
 
-  it 'should cd into an object and its ivar and back again using cd obj/@ivar/.. syntax' do
+  it 'cds into an object and its ivar and back again using cd obj/@ivar/.. syntax' do
     @t.eval 'cd @obj/@x/..'
     expect(@t.mapped_binding_stack).to eq [@o, @obj]
   end
 
-  it 'should cd into an object and its ivar and back and then into another ivar using cd obj/@ivar/../@y syntax' do
+  it(
+    'cds into an object and its ivar and back and then into another ivar ' \
+    'using cd obj/@ivar/../@y syntax'
+  ) do
     @t.eval 'cd @obj/@x/../@y'
     expect(@t.mapped_binding_stack).to eq [@o, @obj, 79]
   end

--- a/spec/commands/clear_screen_spec.rb
+++ b/spec/commands/clear_screen_spec.rb
@@ -4,14 +4,18 @@ RSpec.describe "clear-screen" do
   end
 
   it 'calls the "clear" command on non-Windows platforms' do
-    expect(Pry::Helpers::Platform).to receive(:windows?).at_least(:once).and_return(false)
-    expect(Pry.config.system).to receive(:call).with(an_instance_of(Pry::Output), 'clear', an_instance_of(Pry))
+    expect(Pry::Helpers::Platform).to receive(:windows?)
+      .at_least(:once).and_return(false)
+    expect(Pry.config.system).to receive(:call)
+      .with(an_instance_of(Pry::Output), 'clear', an_instance_of(Pry))
     @t.process_command 'clear-screen'
   end
 
   it 'calls the "cls" command on Windows' do
-    expect(Pry::Helpers::Platform).to receive(:windows?).at_least(:once).and_return(true)
-    expect(Pry.config.system).to receive(:call).with(an_instance_of(Pry::Output), 'cls', an_instance_of(Pry))
+    expect(Pry::Helpers::Platform).to receive(:windows?)
+      .at_least(:once).and_return(true)
+    expect(Pry.config.system).to receive(:call)
+      .with(an_instance_of(Pry::Output), 'cls', an_instance_of(Pry))
     @t.process_command 'clear-screen'
   end
 end

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -38,7 +38,8 @@ describe "edit" do
     it "should not allow patching any known kind of file" do
       ["file.rb", "file.c", "file.py", "file.yml", "file.gemspec",
        "/tmp/file", "\\\\Temp\\\\file"].each do |file|
-        expect { pry_eval "edit -p #{file}" }.to raise_error(NotImplementedError, /Cannot yet patch false objects!/)
+        expect { pry_eval "edit -p #{file}" }
+          .to raise_error(NotImplementedError, /Cannot yet patch false objects!/)
       end
     end
 
@@ -77,7 +78,9 @@ describe "edit" do
       it "should work with require relative" do
         Pry.config.editor = lambda { |file, _line|
           File.open(file, 'w') { |f| f << 'require_relative "baz.rb"' }
-          File.open(file.gsub('bar.rb', 'baz.rb'), 'w') { |f| f << "Pad.required = true; FileUtils.rm(__FILE__)" }
+          File.open(file.gsub('bar.rb', 'baz.rb'), 'w') do |f|
+            f << "Pad.required = true; FileUtils.rm(__FILE__)"
+          end
           nil
         }
         pry_eval "edit #{@tf_path}"
@@ -403,11 +406,15 @@ describe "edit" do
     end
 
     it "should not work with a filename" do
-      expect { pry_eval 'edit ruby.rb -i' }.to raise_error(Pry::CommandError, /Only one of --ex, --temp, --in, --method and FILE/)
+      expect { pry_eval 'edit ruby.rb -i' }.to raise_error(
+        Pry::CommandError, /Only one of --ex, --temp, --in, --method and FILE/
+      )
     end
 
     it "should not work with nonsense" do
-      expect { pry_eval 'edit --in three' }.to raise_error(Pry::CommandError, /Not a valid range: three/)
+      expect { pry_eval 'edit --in three' }.to raise_error(
+        Pry::CommandError, /Not a valid range: three/
+      )
     end
   end
 
@@ -677,8 +684,9 @@ describe "edit" do
           end
 
           it "should work for a method on an instance" do
-            def_before, def_after =
-              apply_monkey_patch(X.instance_method(:x), 'instance = X.new', "#{@edit} instance.x")
+            def_before, def_after = apply_monkey_patch(
+              X.instance_method(:x), 'instance = X.new', "#{@edit} instance.x"
+            )
 
             expect(def_before).to   eq ':nope'
             expect(def_after).to    eq ':nope'
@@ -797,11 +805,13 @@ describe "edit" do
       end
 
       t = pry_tester(BinkyWink.new.m1)
-      expect { t.process_command "edit -m -n" }.to raise_error(Pry::CommandError, /Cannot find a file for/)
+      expect { t.process_command "edit -m -n" }
+        .to raise_error(Pry::CommandError, /Cannot find a file for/)
     end
 
     it 'errors when a filename arg is passed with --method' do
-      expect { @t.process_command "edit -m Pry#repl" }.to raise_error(Pry::CommandError, /Only one of/)
+      expect { @t.process_command "edit -m Pry#repl" }
+        .to raise_error(Pry::CommandError, /Only one of/)
     end
   end
 
@@ -821,7 +831,8 @@ describe "edit" do
     end
 
     it 'should display a nice error message when cannot open a file' do
-      expect { @t.process_command "edit TrinkyDink#m" }.to raise_error(Pry::CommandError, /Cannot find a file for/)
+      expect { @t.process_command "edit TrinkyDink#m" }
+        .to raise_error(Pry::CommandError, /Cannot find a file for/)
     end
   end
 end

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -146,11 +146,17 @@ describe "hist" do
     expect(output).to eq "1: :banzai\n2: :geronimo\n3: :huzzah\n4: hist --replay 1..3\n"
   end
 
-  it "should raise CommandError when index of `--replay` points out to another `hist --replay`" do
+  it(
+    "raises CommandError when index of `--replay` points out to another " \
+    "`hist --replay`"
+  ) do
     @t.eval ":banzai"
     @t.eval "hist --replay 1"
 
-    expect { @t.eval "hist --replay 2" }.to raise_error(Pry::CommandError, /Replay index 2 points out to another replay call: `hist --replay 1`/)
+    expect { @t.eval "hist --replay 2" }.to raise_error(
+      Pry::CommandError,
+      /Replay index 2 points out to another replay call: `hist --replay 1`/
+    )
   end
 
   it "should disallow execution of `--replay <i>` when CommandError raised" do

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -36,8 +36,10 @@ describe "ls" do
     end
 
     it "should not include super-classes when -q is given" do
-      expect(pry_eval("cd Class.new(Class.new{ def goo; end }).new", "ls -q")).not_to match(/goo/)
-      expect(pry_eval("cd Class.new(Class.new{ def goo; end })", "ls -M -q")).not_to match(/goo/)
+      expect(pry_eval("cd Class.new(Class.new{ def goo; end }).new", "ls -q"))
+        .not_to match(/goo/)
+      expect(pry_eval("cd Class.new(Class.new{ def goo; end })", "ls -M -q"))
+        .not_to match(/goo/)
     end
   end
 
@@ -82,8 +84,10 @@ describe "ls" do
     end
 
     it "should not show protected/private by default" do
-      expect(pry_eval("ls -M Class.new{ def goo; end; private :goo }")).not_to match(/goo/)
-      expect(pry_eval("ls Class.new{ def goo; end; protected :goo }.new")).not_to match(/goo/)
+      expect(pry_eval("ls -M Class.new{ def goo; end; private :goo }"))
+        .not_to match(/goo/)
+      expect(pry_eval("ls Class.new{ def goo; end; protected :goo }.new"))
+        .not_to match(/goo/)
     end
 
     it "should show public methods with -p" do
@@ -91,23 +95,32 @@ describe "ls" do
     end
 
     it "should show protected/private methods with -p" do
-      expect(pry_eval("ls -pM Class.new{ def goo; end; protected :goo }")).to match(/methods: goo/)
-      expect(pry_eval("ls -p Class.new{ def goo; end; private :goo }.new")).to match(/methods: goo/)
+      expect(pry_eval("ls -pM Class.new{ def goo; end; protected :goo }"))
+        .to match(/methods: goo/)
+      expect(pry_eval("ls -p Class.new{ def goo; end; private :goo }.new"))
+        .to match(/methods: goo/)
     end
 
     it "should work for objects with an overridden method method" do
       require 'net/http'
       # This doesn't actually touch the network, promise!
-      expect(pry_eval("ls Net::HTTP::Get.new('localhost')")).to match(/Net::HTTPGenericRequest#methods/)
+      expect(pry_eval("ls Net::HTTP::Get.new('localhost')"))
+        .to match(/Net::HTTPGenericRequest#methods/)
     end
 
-    it "should work for objects which instance_variables returns array of symbol but there is no Symbol#downcase" do
-      test_case = "class Object; alias :fg :instance_variables; def instance_variables; fg.map(&:to_sym); end end;"
+    it(
+      "should work for objects which instance_variables returns array of " \
+      "symbol but there is no Symbol#downcase"
+    ) do
+      test_case = "class Object; alias :fg :instance_variables; " \
+                  "def instance_variables; fg.map(&:to_sym); end end;"
       normalize = "class Object; def instance_variables; fg; end end;"
 
       test = lambda do
         begin
-          pry_eval(test_case, "class GeFromulate2; @flurb=1.3; end", "cd GeFromulate2", "ls")
+          pry_eval(
+            test_case, "class GeFromulate2; @flurb=1.3; end", "cd GeFromulate2", "ls"
+          )
           pry_eval(normalize)
         rescue StandardError
           pry_eval(normalize)
@@ -119,7 +132,8 @@ describe "ls" do
     end
 
     it "should show error message when instance is given with -M option" do
-      expect { pry_eval("ls -M String.new") }.to raise_error(Pry::CommandError, /-M only makes sense with a Module or a Class/)
+      expect { pry_eval("ls -M String.new") }
+        .to raise_error(Pry::CommandError, /-M only makes sense with a Module or a Class/)
     end
 
     it "should handle classes that (pathologically) define .ancestors" do
@@ -183,15 +197,24 @@ describe "ls" do
     end
 
     it "should show constants defined on the current module" do
-      expect(pry_eval("class TempFoo1; BARGHL = 1; end", "ls TempFoo1")).to match(/BARGHL/)
+      expect(pry_eval("class TempFoo1; BARGHL = 1; end", "ls TempFoo1"))
+        .to match(/BARGHL/)
     end
 
     it "should not show constants defined on parent modules by default" do
-      expect(pry_eval("class TempFoo2; LHGRAB = 1; end; class TempFoo3 < TempFoo2; BARGHL = 1; end", "ls TempFoo3")).not_to match(/LHGRAB/)
+      output = pry_eval(
+        "class TempFoo2; LHGRAB = 1; end; " \
+        "class TempFoo3 < TempFoo2; BARGHL = 1; end", "ls TempFoo3"
+      )
+      expect(output).not_to match(/LHGRAB/)
     end
 
     it "should show constants defined on ancestors with -v" do
-      expect(pry_eval("class TempFoo4; LHGRAB = 1; end; class TempFoo5 < TempFoo4; BARGHL = 1; end", "ls -v TempFoo5")).to match(/LHGRAB/)
+      output = pry_eval(
+        "class TempFoo4; LHGRAB = 1; end; " \
+        "class TempFoo5 < TempFoo4; BARGHL = 1; end", "ls -v TempFoo5"
+      )
+      expect(output).to match(/LHGRAB/)
     end
 
     it "should not autoload constants!" do
@@ -231,21 +254,33 @@ describe "ls" do
 
     describe "when in a class" do
       it "should show constants" do
-        expect(pry_eval("class GeFromulate1; FOOTIFICATE=1.3; end", "cd GeFromulate1", "ls")).to match(/FOOTIFICATE/)
+        output = pry_eval(
+          "class GeFromulate1; FOOTIFICATE=1.3; end", "cd GeFromulate1", "ls"
+        )
+        expect(output).to match(/FOOTIFICATE/)
       end
 
       it "should show class variables" do
-        expect(pry_eval("class GeFromulate2; @@flurb=1.3; end", "cd GeFromulate2", "ls")).to match(/@@flurb/)
+        output = pry_eval(
+          "class GeFromulate2; @@flurb=1.3; end", "cd GeFromulate2", "ls"
+        )
+        expect(output).to match(/@@flurb/)
       end
 
       it "should show methods" do
-        expect(pry_eval("class GeFromulate3; def self.mooflight; end ; end", "cd GeFromulate3", "ls")).to match(/mooflight/)
+        output = pry_eval(
+          "class GeFromulate3; def self.mooflight; end ; end",
+          "cd GeFromulate3",
+          "ls"
+        )
+        expect(output).to match(/mooflight/)
       end
     end
 
     describe "when in an object" do
       it "should show methods" do
-        expect(pry_eval("cd Class.new{ def self.fooerise; end; self }", "ls")).to match(/fooerise/)
+        expect(pry_eval("cd Class.new{ def self.fooerise; end; self }", "ls"))
+          .to match(/fooerise/)
       end
 
       it "should show instance variables" do
@@ -256,13 +291,17 @@ describe "ls" do
 
   describe 'on java objects', skip: !Pry::Helpers::Platform.jruby? do
     it 'should omit java-esque aliases by default' do
-      expect(pry_eval('ls java.lang.Thread.current_thread')).to match(/\bthread_group\b/)
-      expect(pry_eval('ls java.lang.Thread.current_thread')).not_to match(/\bgetThreadGroup\b/)
+      expect(pry_eval('ls java.lang.Thread.current_thread'))
+        .to match(/\bthread_group\b/)
+      expect(pry_eval('ls java.lang.Thread.current_thread'))
+        .not_to match(/\bgetThreadGroup\b/)
     end
 
     it 'should include java-esque aliases if requested' do
-      expect(pry_eval('ls java.lang.Thread.current_thread -J')).to match(/\bthread_group\b/)
-      expect(pry_eval('ls java.lang.Thread.current_thread -J')).to match(/\bgetThreadGroup\b/)
+      expect(pry_eval('ls java.lang.Thread.current_thread -J'))
+        .to match(/\bthread_group\b/)
+      expect(pry_eval('ls java.lang.Thread.current_thread -J'))
+        .to match(/\bgetThreadGroup\b/)
     end
   end
 end

--- a/spec/commands/play_spec.rb
+++ b/spec/commands/play_spec.rb
@@ -103,7 +103,8 @@ describe "play" do
     end
 
     it 'has pretty error messages when -d cant find object' do
-      expect { @t.process_command "play -d sdfsdf" }.to raise_error(Pry::CommandError, /Cannot locate/)
+      expect { @t.process_command "play -d sdfsdf" }
+        .to raise_error(Pry::CommandError, /Cannot locate/)
     end
 
     it 'should play a method (a single line)' do

--- a/spec/commands/raise_up_spec.rb
+++ b/spec/commands/raise_up_spec.rb
@@ -32,7 +32,8 @@ describe "raise-up" do
   end
 
   it "should raise the most recently raised exception" do
-    expect { mock_pry("raise NameError, 'homographery'", "raise-up") }.to raise_error(NameError, 'homographery')
+    expect { mock_pry("raise NameError, 'homographery'", "raise-up") }
+      .to raise_error(NameError, 'homographery')
   end
 
   it "should allow you to cd up and (eventually) out" do
@@ -49,6 +50,7 @@ describe "raise-up" do
   end
 
   it "should jump immediately out of nested contexts with !" do
-    expect { mock_pry("cd 1", "cd 2", "cd 3", "raise-up! 'fancy that...'") }.to raise_error(RuntimeError, 'fancy that...')
+    expect { mock_pry("cd 1", "cd 2", "cd 3", "raise-up! 'fancy that...'") }
+      .to raise_error(RuntimeError, 'fancy that...')
   end
 end

--- a/spec/commands/ri_command_spec.rb
+++ b/spec/commands/ri_command_spec.rb
@@ -1,5 +1,7 @@
 describe "ri" do
   it "prints an error message without an argument" do
-    expect(pry_eval("ri")).to include("Please provide a class, module, or method name (e.g: ri Array#push)")
+    expect(pry_eval("ri")).to include(
+      "Please provide a class, module, or method name (e.g: ri Array#push)"
+    )
   end
 end

--- a/spec/commands/save_file_spec.rb
+++ b/spec/commands/save_file_spec.rb
@@ -45,7 +45,9 @@ describe "save-file" do
       @t.eval ':or_nostrils', ':sucking_up_all_the_oxygen', ':or_whatever',
               ':baby_ducks', ':cannot_escape'
       @t.eval "save-file -i 1..2 -i 4..5 --to '#{@path}'"
-      expect(File.read(@path)).to eq(":or_nostrils\n:sucking_up_all_the_oxygen\n:baby_ducks\n:cannot_escape\n")
+      expect(File.read(@path)).to eq(
+        ":or_nostrils\n:sucking_up_all_the_oxygen\n:baby_ducks\n:cannot_escape\n"
+      )
     end
   end
 
@@ -70,7 +72,8 @@ describe "save-file" do
       end
 
       it "should display a success message on save" do
-        expect(@t.eval("save-file --to '#{@path}' baby")).to match(/successfully saved/)
+        expect(@t.eval("save-file --to '#{@path}' baby"))
+          .to match(/successfully saved/)
       end
 
       it 'should save a method to a file truncated by --lines' do

--- a/spec/commands/shell_command_spec.rb
+++ b/spec/commands/shell_command_spec.rb
@@ -39,7 +39,8 @@ describe Pry::Command::ShellCommand do
       describe "given a dash" do
         describe "given no prior directory" do
           it "raises the correct error" do
-            expect { @t.eval ".cd -" }.to raise_error(StandardError, "No prior directory available")
+            expect { @t.eval ".cd -" }
+              .to raise_error(StandardError, "No prior directory available")
           end
         end
 

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -46,7 +46,10 @@ describe "show-doc" do
     expect(pry_eval(binding, "show-doc @o.sample_method -b")).to match(/1: sample doc/)
   end
 
-  it 'should output a method\'s documentation if inside method without needing to use method name' do
+  it(
+    "outputs a method's documentation if inside method without needing to use " \
+    "method name"
+  ) do
     # sample comment
     def @o.sample
       pry_eval(binding, 'show-doc').should =~ /sample comment/
@@ -332,7 +335,10 @@ describe "show-doc" do
           expect(result).to match(/available monkeypatches/)
         end
 
-        it 'shouldnt say anything about monkeypatches when only one candidate exists for selected class' do
+        it(
+          'shouldnt say anything about monkeypatches when only one ' \
+          'candidate exists for selected class'
+        ) do
           # Do not remove me.
           class Aarrrrrghh
             def o; end
@@ -426,7 +432,9 @@ describe "show-doc" do
         'command with spaces',
         'description of a command with spaces'
       ) {}
-      expect(pry_eval('show-doc command with spaces')).to match(/description of a command with spaces/)
+      expect(pry_eval('show-doc command with spaces')).to match(
+        /description of a command with spaces/
+      )
     end
 
     describe "class commands" do
@@ -452,7 +460,10 @@ describe "show-doc" do
         Pry.config.commands.delete("lobster-lady")
       end
 
-      it 'should display actual preceding comment for a class command, when class is used (rather than command name) when looking up' do
+      it(
+        'displays actual preceding comment for a class command, when class ' \
+        'is used (rather than command name) when looking up'
+      ) do
         expect(pry_eval('show-doc LobsterLady')).to match(/pretty pink pincers/)
         Pry.config.commands.delete("lobster-lady")
       end
@@ -498,16 +509,22 @@ describe "show-doc" do
 
       it 'errors when class has no superclass to show' do
         t = pry_tester
-        expect { t.process_command "show-doc Jesus::Brian" }.to raise_error(Pry::CommandError, /Couldn't locate/)
+        expect { t.process_command "show-doc Jesus::Brian" }
+          .to raise_error(Pry::CommandError, /Couldn't locate/)
       end
 
       it 'shows warning when reverting to superclass docs' do
         t = pry_tester
         t.process_command "show-doc Jesus::Jangle"
-        expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Jangle.*Showing.*Jesus::Jingle instead/)
+        expect(t.last_output).to match(
+          /Warning.*?Cannot find.*?Jesus::Jangle.*Showing.*Jesus::Jingle instead/
+        )
       end
 
-      it 'shows nth level superclass docs (when no intermediary superclasses have code either)' do
+      it(
+        'shows nth level superclass docs (when no intermediary superclasses ' \
+        'have code either)'
+      ) do
         t = pry_tester
         t.process_command "show-doc Jesus::Bangle"
         expect(t.last_output).to match(/doink-doc/)
@@ -516,7 +533,9 @@ describe "show-doc" do
       it 'shows correct warning when reverting to nth level superclass' do
         t = pry_tester
         t.process_command "show-doc Jesus::Bangle"
-        expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Bangle.*Showing.*Jesus::Jingle instead/)
+        expect(t.last_output).to match(
+          /Warning.*?Cannot find.*?Jesus::Bangle.*Showing.*Jesus::Jingle instead/
+        )
       end
     end
 
@@ -555,15 +574,21 @@ describe "show-doc" do
       it 'shows warning when reverting to included module doc' do
         t = pry_tester
         t.process_command "show-doc Jesus::Beta"
-        expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Beta.*Showing.*Jesus::Alpha instead/)
+        expect(t.last_output).to match(
+          /Warning.*?Cannot find.*?Jesus::Beta.*Showing.*Jesus::Alpha instead/
+        )
       end
 
       it 'errors when module has no included module to show' do
         t = pry_tester
-        expect { t.process_command "show-source Jesus::Zeta" }.to raise_error(Pry::CommandError, /Couldn't locate/)
+        expect { t.process_command "show-source Jesus::Zeta" }
+          .to raise_error(Pry::CommandError, /Couldn't locate/)
       end
 
-      it 'shows nth level included module doc (when no intermediary modules have code either)' do
+      it(
+        'shows nth level included module doc (when no intermediary modules ' \
+        'have code either)'
+      ) do
         t = pry_tester
         t.process_command "show-doc Jesus::Gamma"
         expect(t.last_output).to match(/alpha-doc/)
@@ -572,7 +597,9 @@ describe "show-doc" do
       it 'shows correct warning when reverting to nth level included module' do
         t = pry_tester
         t.process_command "show-source Jesus::Gamma"
-        expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Gamma.*Showing.*Jesus::Alpha instead/)
+        expect(t.last_output).to match(
+          /Warning.*?Cannot find.*?Jesus::Gamma.*Showing.*Jesus::Alpha instead/
+        )
       end
     end
   end

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -24,11 +24,13 @@ describe "show-source" do
   end
 
   it "should output a method's source with line numbers" do
-    expect(pry_eval(binding, 'show-source -l @o.sample_method')).to match(/\d+: def @o.sample/)
+    expect(pry_eval(binding, 'show-source -l @o.sample_method'))
+      .to match(/\d+: def @o.sample/)
   end
 
   it "should output a method's source with line numbers starting at 1" do
-    expect(pry_eval(binding, 'show-source -b @o.sample_method')).to match(/1: def @o.sample/)
+    expect(pry_eval(binding, 'show-source -b @o.sample_method'))
+      .to match(/1: def @o.sample/)
   end
 
   it "should output a method's source if inside method and no name given" do
@@ -71,10 +73,11 @@ describe "show-source" do
         98
       end
     end
-    expect(mock_pry(binding, "show-source _c#wrongmethod")).to match(/Couldn't locate/)
+    expect(mock_pry(binding, "show-source _c#wrongmethod"))
+      .to match(/Couldn't locate/)
   end
 
-  it "should not show the source and deliver an error message without exclamation point" do
+  it "doesn't show the source and deliver an error message without exclamation point" do
     _c = Class.new
     error_message = "Error: Couldn't locate a definition for _c#wrongmethod\n"
     expect(mock_pry(binding, "show-source _c#wrongmethod")).to eq(error_message)
@@ -111,7 +114,8 @@ describe "show-source" do
       end
     end
 
-    expect { pry_eval(binding, 'cd _c', 'show-source self.moo') }.to raise_error(Pry::CommandError, /Couldn't locate/)
+    expect { pry_eval(binding, 'cd _c', 'show-source self.moo') }
+      .to raise_error(Pry::CommandError, /Couldn't locate/)
   end
 
   it "should find normal methods with self.moo" do
@@ -131,7 +135,8 @@ describe "show-source" do
       end
     end
 
-    expect { pry_eval(binding, 'cd _c', 'show-source self#moo') }.to raise_error(Pry::CommandError, /Couldn't locate/)
+    expect { pry_eval(binding, 'cd _c', 'show-source self#moo') }
+      .to raise_error(Pry::CommandError, /Couldn't locate/)
   end
 
   it "should find normal methods (i.e non-instance methods) by default" do
@@ -167,7 +172,7 @@ describe "show-source" do
       Object.remove_const(:FooBar)
     end
 
-    it "evaluates the argument as ruby and shows the source code for the returned value" do
+    it "shows the source code for the returned value as Ruby" do
       ReplTester.start target: binding do
         input 'show-source -e FooBar.new'
         output(/class FooBar/)
@@ -178,7 +183,8 @@ describe "show-source" do
   it "should raise a CommandError when super method doesn't exist" do
     def @o.foo(*bars); end
 
-    expect { pry_eval(binding, "show-source --super @o.foo") }.to raise_error(Pry::CommandError, /No superclass found/)
+    expect { pry_eval(binding, "show-source --super @o.foo") }
+      .to raise_error(Pry::CommandError, /No superclass found/)
   end
 
   it "should output the source of a method defined inside Pry" do
@@ -335,7 +341,7 @@ describe "show-source" do
         Object.remove_const(:TestHost)
       end
 
-      it "source of variable should take precedence over method that is being shadowed" do
+      it "source of variable takes precedence over method that is being shadowed" do
         source = @t.eval('show-source hello')
         expect(source).not_to match(/def hello/)
         expect(source).to match(/proc \{ ' smile ' \}/)
@@ -361,13 +367,13 @@ describe "show-source" do
       Object.remove_const(:TestHost)
     end
 
-    it "should output source of its class if variable doesn't respond to source_location" do
+    it "outputs source of its class if variable doesn't respond to source_location" do
       _test_host = TestHost.new
       expect(pry_eval(binding, 'show-source _test_host'))
         .to match(/class TestHost\n.*def hello/)
     end
 
-    it "should output source of its class if constant doesn't respond to source_location" do
+    it "outputs source of its class if constant doesn't respond to source_location" do
       TEST_HOST = TestHost.new
       expect(pry_eval(binding, 'show-source TEST_HOST'))
         .to match(/class TestHost\n.*def hello/)
@@ -536,7 +542,9 @@ describe "show-source" do
           end
         end
 
-        result = pry_eval('show-source TestClassForShowSourceClassEval#class_eval_method -a')
+        result = pry_eval(
+          'show-source TestClassForShowSourceClassEval#class_eval_method -a'
+        )
         expect(result).to match(/bing/)
       end
 
@@ -550,7 +558,10 @@ describe "show-source" do
       end
 
       describe "messages relating to -a" do
-        it 'indicates all available monkeypatches can be shown with -a when (when -a not used and more than one candidate exists for class)' do
+        it(
+          'indicates all available monkeypatches can be shown with -a when ' \
+          '(when -a not used and more than one candidate exists for class)'
+        ) do
           class TestClassForShowSource
             def gamma; end
           end
@@ -559,7 +570,10 @@ describe "show-source" do
           expect(result).to match(/available monkeypatches/)
         end
 
-        it 'shouldnt say anything about monkeypatches when only one candidate exists for selected class' do
+        it(
+          "doesn't mention monkeypatches when only 1 candidate exists for " \
+          "selected class"
+        ) do
           class Aarrrrrghh
             def o; end
           end
@@ -604,10 +618,14 @@ describe "show-source" do
         end
 
         it 'should be unable to find module source if no methods defined' do
-          expect { pry_eval(TestHost::C, 'show-source') }.to raise_error(Pry::CommandError, /Couldn't locate/)
+          expect { pry_eval(TestHost::C, 'show-source') }
+            .to raise_error(Pry::CommandError, /Couldn't locate/)
         end
 
-        it 'should display method code (rather than class) if Pry started inside method binding' do
+        it(
+          'displays method code (rather than class) if Pry started inside ' \
+          'method binding'
+        ) do
           out = TestHost::D.invoked_in_method
           expect(out).to match(/invoked_in_method/)
           expect(out).not_to match(/module D/)
@@ -670,7 +688,7 @@ describe "show-source" do
             it "should display a warning, and not monkey-patched definition" do
               out = pry_eval([1, 2, 3], 'show-source')
               expect(out).not_to match(/doge/)
-              expect(out).to match(/warning/i)
+              expect(out).to match(/Pry cannot display the information/)
             end
 
             it "recommends to use the --all switch when other candidates are found" do
@@ -834,16 +852,22 @@ describe "show-source" do
 
       it 'errors when class has no superclass to show' do
         t = pry_tester
-        expect { t.process_command "show-source Jesus::Brian" }.to raise_error(Pry::CommandError, /Couldn't locate/)
+        expect { t.process_command "show-source Jesus::Brian" }
+          .to raise_error(Pry::CommandError, /Couldn't locate/)
       end
 
       it 'shows warning when reverting to superclass code' do
         t = pry_tester
         t.process_command "show-source Jesus::Jangle"
-        expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Jangle.*Showing.*Jesus::Jingle instead/)
+        expect(t.last_output).to match(
+          /Warning.*?Cannot find.*?Jesus::Jangle.*Showing.*Jesus::Jingle instead/
+        )
       end
 
-      it 'shows nth level superclass code (when no intermediary superclasses have code either)' do
+      it(
+        'shows nth level superclass code (when no intermediary ' \
+        'superclasses have code either)'
+      ) do
         t = pry_tester
         t.process_command "show-source Jesus::Bangle"
         expect(t.last_output).to match(/doink/)
@@ -852,7 +876,9 @@ describe "show-source" do
       it 'shows correct warning when reverting to nth level superclass' do
         t = pry_tester
         t.process_command "show-source Jesus::Bangle"
-        expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Bangle.*Showing.*Jesus::Jingle instead/)
+        expect(t.last_output).to match(
+          /Warning.*?Cannot find.*?Jesus::Bangle.*Showing.*Jesus::Jingle instead/
+        )
       end
     end
 
@@ -890,15 +916,21 @@ describe "show-source" do
       it 'shows warning when reverting to included module code' do
         t = pry_tester
         t.process_command "show-source Jesus::Beta"
-        expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Beta.*Showing.*Jesus::Alpha instead/)
+        expect(t.last_output).to match(
+          /Warning.*?Cannot find.*?Jesus::Beta.*Showing.*Jesus::Alpha instead/
+        )
       end
 
       it 'errors when module has no included module to show' do
         t = pry_tester
-        expect { t.process_command "show-source Jesus::Zeta" }.to raise_error(Pry::CommandError, /Couldn't locate/)
+        expect { t.process_command "show-source Jesus::Zeta" }
+          .to raise_error(Pry::CommandError, /Couldn't locate/)
       end
 
-      it 'shows nth level included module code (when no intermediary modules have code either)' do
+      it(
+        'shows nth level included module code (when no intermediary modules ' \
+        'have code either)'
+      ) do
         t = pry_tester
         t.process_command "show-source Jesus::Gamma"
         expect(t.last_output).to match(/alpha/)
@@ -907,7 +939,9 @@ describe "show-source" do
       it 'shows correct warning when reverting to nth level included module' do
         t = pry_tester
         t.process_command "show-source Jesus::Gamma"
-        expect(t.last_output).to match(/Warning.*?Cannot find.*?Jesus::Gamma.*Showing.*Jesus::Alpha instead/)
+        expect(t.last_output).to match(
+          /Warning.*?Cannot find.*?Jesus::Gamma.*Showing.*Jesus::Alpha instead/
+        )
       end
     end
   end

--- a/spec/commands/whereami_spec.rb
+++ b/spec/commands/whereami_spec.rb
@@ -72,7 +72,10 @@ describe "whereami" do
     expect(pry_eval(cor, 'whereami')).to match(/::Kernel.binding [#] omnom/)
   end
 
-  it 'should show description and correct code when __LINE__ and __FILE__ are outside @method.source_location' do
+  it(
+    'shows description and corrects code when __LINE__ and __FILE__ are ' \
+    'outside @method.source_location'
+  ) do
     class Cor
       def blimey!
         eval <<-END, binding, "spec/fixtures/example.erb", 1
@@ -86,7 +89,10 @@ describe "whereami" do
     Object.remove_const(:Cor)
   end
 
-  it 'should show description and correct code when @method.source_location would raise an error' do
+  it(
+    'shows description and corrects code when @method.source_location ' \
+    'would raise an error'
+  ) do
     class Cor
       eval <<-END, binding, "spec/fixtures/example.erb", 1
         def blimey!
@@ -95,7 +101,8 @@ describe "whereami" do
       END
     end
 
-    expect { Cor.instance_method(:blimey!).source }.to raise_error MethodSource::SourceNotFoundError
+    expect { Cor.instance_method(:blimey!).source }
+      .to raise_error MethodSource::SourceNotFoundError
 
     expect(Cor.new.blimey!).to match(/Cor#blimey!.*Look at me/m)
     Object.remove_const(:Cor)
@@ -222,7 +229,9 @@ describe "whereami" do
     Object.remove_const(:Cor)
   end
 
-  it 'should use Pry.config.default_window_size for window size when outside a method context' do
+  it(
+    'uses Pry.config.default_window_size for window size when outside a method context'
+  ) do
     old_size = Pry.config.default_window_size
     Pry.config.default_window_size = 1
     _foo = :litella

--- a/spec/commands/wtf_spec.rb
+++ b/spec/commands/wtf_spec.rb
@@ -12,7 +12,9 @@ describe "wtf?!" do
   end
 
   it "unwinds nested exceptions" do
-    skip('Exception#cause is not supported') if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('2.0.0')
+    if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('2.0.0')
+      skip('Exception#cause is not supported')
+    end
 
     begin
       begin

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -33,11 +33,19 @@ describe Pry::InputCompleter do
 
   it "should not crash if there's a Module that has a symbolic name." do
     skip unless Pry::Helpers::Platform.jruby?
-    expect { Pry::InputCompleter.new(Readline).call "a.to_s.", target: Pry.binding_for(Object.new) }.not_to raise_error
+    expect do
+      Pry::InputCompleter.new(Readline).call(
+        "a.to_s.", target: Pry.binding_for(Object.new)
+      )
+    end.not_to raise_error
   end
 
   it 'should take parenthesis and other characters into account for symbols' do
-    expect { Pry::InputCompleter.new(Readline).call ":class)", target: Pry.binding_for(Object.new) }.not_to raise_error
+    expect do
+      Pry::InputCompleter.new(Readline).call(
+        ":class)", target: Pry.binding_for(Object.new)
+      )
+    end.not_to raise_error
   end
 
   it 'should complete instance variables' do
@@ -114,7 +122,8 @@ describe Pry::InputCompleter do
     completer_test(binding).call('o.foo')
 
     # trailing slash
-    expect(Pry::InputCompleter.new(Readline).call('Mod2/', target: Pry.binding_for(Mod)).include?('Mod2/')).to eq(true)
+    expect(Pry::InputCompleter.new(Readline).call('Mod2/', target: Pry.binding_for(Mod))
+      .include?('Mod2/')).to eq(true)
   end
 
   it 'should complete for arbitrary scopes' do
@@ -186,7 +195,8 @@ describe Pry::InputCompleter do
     completer_test(binding).call('o.foo')
 
     # trailing slash
-    expect(Pry::InputCompleter.new(Readline).call('Mod2/', target: Pry.binding_for(Mod)).include?('Mod2/')).to eq(true)
+    expect(Pry::InputCompleter.new(Readline).call('Mod2/', target: Pry.binding_for(Mod))
+      .include?('Mod2/')).to eq(true)
   end
 
   it 'should complete for arbitrary scopes' do
@@ -211,7 +221,8 @@ describe Pry::InputCompleter do
 
   it 'should not return nil in its output' do
     pry = Pry.new
-    expect(Pry::InputCompleter.new(Readline, pry).call("pry.", target: binding)).not_to include nil
+    expect(Pry::InputCompleter.new(Readline, pry).call("pry.", target: binding))
+      .not_to include nil
   end
 
   it 'completes expressions with all available methods' do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe Pry::Config do
   end
 
   describe "bug #1552" do
-    specify "a local key has precendence over its default when the stored value is false" do
+    specify(
+      "a local key has precendence over its default when the stored value is false"
+    ) do
       local = described_class.from_hash({}, described_class.from_hash('color' => true))
       local.color = false
       expect(local.color).to eq(false)

--- a/spec/documentation_helper_spec.rb
+++ b/spec/documentation_helper_spec.rb
@@ -9,15 +9,19 @@ describe Pry::Helpers::DocumentationHelpers do
     end
 
     it "should strip out leading lines of hashes" do
-      expect(@helper.get_comment_content("###############\n#hello\n#world\n")).to eq("hello\nworld\n")
+      expect(@helper.get_comment_content("###############\n#hello\n#world\n"))
+        .to eq("hello\nworld\n")
     end
 
     it "should remove shebangs" do
-      expect(@helper.get_comment_content("#!/usr/bin/env ruby\n# This is a program\n")).to eq("This is a program\n")
+      expect(@helper.get_comment_content("#!/usr/bin/env ruby\n# This is a program\n"))
+        .to eq("This is a program\n")
     end
 
     it "should unindent past separators" do
-      expect(@helper.get_comment_content(" # Copyright Me <me@cirw.in>\n #--\n # So there.\n")).to eq("Copyright Me <me@cirw.in>\n--\nSo there.\n")
+      str = " # Copyright Me <me@cirw.in>\n #--\n # So there.\n"
+      expect(@helper.get_comment_content(str))
+        .to eq("Copyright Me <me@cirw.in>\n--\nSo there.\n")
     end
   end
 
@@ -51,7 +55,8 @@ describe Pry::Helpers::DocumentationHelpers do
     end
 
     it "should syntax highlight code in <code>" do
-      expect(@helper.process_rdoc("for <code>Example</code>")).to match(/for \e.*Example\e.*/)
+      expect(@helper.process_rdoc("for <code>Example</code>"))
+        .to match(/for \e.*Example\e.*/)
     end
 
     it "should syntax highlight code in <tt>" do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -45,5 +45,3 @@ RSpec.configure do |config|
   include Pry::Testable::Evalable
   include Pry::Testable::Variables
 end
-
-puts "Ruby v#{RUBY_VERSION} (#{defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'}), Pry v#{Pry::VERSION}, method_source v#{MethodSource::VERSION}, CodeRay v#{CodeRay::VERSION}, Pry::Slop v#{Pry::Slop::VERSION}"

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -67,7 +67,9 @@ describe Pry::Hooks do
 
         h2.merge!(h1)
         h2.add_hook(:test_hook, :testing2) {}
-        expect(h2.get_hook(:test_hook, :testing2)).not_to eq h1.get_hook(:test_hook, :testing2)
+        expect(h2.get_hook(:test_hook, :testing2)).not_to eq(
+          h1.get_hook(:test_hook, :testing2)
+        )
       end
 
       it 'should NOT overwrite hooks belonging to shared event in receiver' do
@@ -121,8 +123,12 @@ describe Pry::Hooks do
           h2 = Pry::Hooks.new.add_hook(:test_hook2, :testing) {}
 
           h3 = h2.merge(h1)
-          expect(h3.get_hook(:test_hook, :testing)).to eq h1.get_hook(:test_hook, :testing)
-          expect(h3.get_hook(:test_hook2, :testing)).to eq h2.get_hook(:test_hook2, :testing)
+          expect(h3.get_hook(:test_hook, :testing)).to eq(
+            h1.get_hook(:test_hook, :testing)
+          )
+          expect(h3.get_hook(:test_hook2, :testing)).to eq(
+            h2.get_hook(:test_hook2, :testing)
+          )
         end
 
         it 'should not affect original instances when new hooks are added' do
@@ -146,7 +152,9 @@ describe Pry::Hooks do
       end
 
       hooks_dup = @hooks.dup
-      expect(hooks_dup.get_hook(:test_hook, :testing)).to eq @hooks.get_hook(:test_hook, :testing)
+      expect(hooks_dup.get_hook(:test_hook, :testing)).to eq(
+        @hooks.get_hook(:test_hook, :testing)
+      )
     end
 
     it 'adding a new event to dupped instance should not affect original' do
@@ -155,7 +163,8 @@ describe Pry::Hooks do
 
       hooks_dup.add_hook(:other_test_hook, :testing) { :okay_man }
 
-      expect(hooks_dup.get_hook(:other_test_hook, :testing)).not_to eq @hooks.get_hook(:other_test_hook, :testing)
+      expect(hooks_dup.get_hook(:other_test_hook, :testing))
+        .not_to eq @hooks.get_hook(:other_test_hook, :testing)
     end
 
     it 'adding a new hook to dupped instance should not affect original' do
@@ -164,7 +173,8 @@ describe Pry::Hooks do
 
       hooks_dup.add_hook(:test_hook, :testing2) { :okay_man }
 
-      expect(hooks_dup.get_hook(:test_hook, :testing2)).not_to eq @hooks.get_hook(:test_hook, :testing2)
+      expect(hooks_dup.get_hook(:test_hook, :testing2))
+        .not_to eq @hooks.get_hook(:test_hook, :testing2)
     end
   end
 
@@ -309,7 +319,9 @@ describe Pry::Hooks do
     describe "when_started hook" do
       it 'should yield options to the hook' do
         options = nil
-        Pry.config.hooks.add_hook(:when_started, :test_hook) { |_target, opt, _| options = opt }
+        Pry.config.hooks.add_hook(:when_started, :test_hook) do |_target, opt, _|
+          options = opt
+        end
 
         redirect_pry_io(StringIO.new("exit"), StringIO.new) do
           Pry.start binding, hello: :baby
@@ -323,7 +335,9 @@ describe Pry::Hooks do
       describe "target" do
         it 'should yield the target, as a binding ' do
           b = nil
-          Pry.config.hooks.add_hook(:when_started, :test_hook) { |target, _opt, _| b = target }
+          Pry.config.hooks.add_hook(:when_started, :test_hook) do |target, _opt, _|
+            b = target
+          end
 
           redirect_pry_io(StringIO.new("exit"), StringIO.new) do
             Pry.start 5, hello: :baby
@@ -335,7 +349,9 @@ describe Pry::Hooks do
 
         it 'should yield the target to the hook' do
           b = nil
-          Pry.config.hooks.add_hook(:when_started, :test_hook) { |target, _opt, _| b = target }
+          Pry.config.hooks.add_hook(:when_started, :test_hook) do |target, _opt, _|
+            b = target
+          end
 
           redirect_pry_io(StringIO.new("exit"), StringIO.new) do
             Pry.start 5, hello: :baby
@@ -350,7 +366,9 @@ describe Pry::Hooks do
         o = Object.new
         class << o; attr_accessor :value; end
 
-        Pry.config.hooks.add_hook(:when_started, :test_hook) { |_target, _opt, _pry_| _pry_.binding_stack = [Pry.binding_for(o)] }
+        Pry.config.hooks.add_hook(:when_started, :test_hook) do |_target, _opt, _pry_|
+          _pry_.binding_stack = [Pry.binding_for(o)]
+        end
 
         redirect_pry_io(InputTester.new("@value = true", "exit-all")) do
           Pry.start binding, hello: :baby
@@ -373,7 +391,10 @@ describe Pry::Hooks do
 
         begin
           redirect_pry_io(StringIO.new("raise great_escape"), StringIO.new) do
-            Pry.start o, hooks: Pry::Hooks.new.add_hook(:after_session, :cleanup) { array = nil }
+            Pry.start(
+              o,
+              hooks: Pry::Hooks.new.add_hook(:after_session, :cleanup) { array = nil }
+            )
           end
         rescue StandardError => ex
           exception = ex
@@ -393,7 +414,9 @@ describe Pry::Hooks do
       describe "before_eval hook" do
         describe "modifying input code" do
           it 'should replace input code with code determined by hook' do
-            hooks = Pry::Hooks.new.add_hook(:before_eval, :quirk) { |code, _pry| code.replace(":little_duck") }
+            hooks = Pry::Hooks.new.add_hook(:before_eval, :quirk) do |code, _pry|
+              code.replace(":little_duck")
+            end
             redirect_pry_io(InputTester.new(":jemima", "exit-all"), out = StringIO.new) do
               Pry.start(self, hooks: hooks)
             end
@@ -410,12 +433,21 @@ describe Pry::Hooks do
               end
             end
 
-            hooks = Pry::Hooks.new.add_hook(:before_eval, :quirk) { |code, _pry| code.replace(":little_duck") }
+            hooks = Pry::Hooks.new.add_hook(:before_eval, :quirk) do |code, _pry|
+              code.replace(":little_duck")
+            end
 
-            redirect_pry_io(InputTester.new("how-do-you-like-your-blue-eyed-boy-now-mister-death", "exit-all"), out = StringIO.new) do
+            redirect_pry_io(
+              InputTester.new(
+                "how-do-you-like-your-blue-eyed-boy-now-mister-death", "exit-all"
+              ),
+              out = StringIO.new
+            ) do
               Pry.start(self, hooks: hooks, commands: commands)
             end
-            expect(out.string).to match(/in hours of bitterness i imagine balls of sapphire, of metal/)
+            expect(out.string).to match(
+              /in hours of bitterness i imagine balls of sapphire, of metal/
+            )
             expect(out.string).not_to match(/little_duck/)
           end
         end
@@ -436,7 +468,10 @@ describe Pry::Hooks do
         end
 
         it "should print out a notice for each exception raised" do
-          expect(mock_pry("1")).to match(/after_eval hook failed: RuntimeError: Baddums\n.*after_eval hook failed: RuntimeError: Simbads/m)
+          expect(mock_pry("1")).to match(
+            /after_eval\shook\sfailed:\sRuntimeError:\sBaddums\n
+            .*after_eval\shook\sfailed:\sRuntimeError:\sSimbads/xm
+          )
         end
       end
     end

--- a/spec/indent_spec.rb
+++ b/spec/indent_spec.rb
@@ -190,7 +190,9 @@ TXT
   it "should indent correctly with nesting" do
     expect(@indent.indent("[[\n[]]\n]")).to eq "[[\n  []]\n]"
     expect(@indent.reset.indent("[[\n[]]\n]")).to eq "[[\n  []]\n]"
-    expect(@indent.reset.indent("[[{\n[] =>\n[]}]\n]")).to eq "[[{\n      [] =>\n  []}]\n]"
+    expect(@indent.reset.indent("[[{\n[] =>\n[]}]\n]")).to eq(
+      "[[{\n      [] =>\n  []}]\n]"
+    )
   end
 
   it "should not indent single-line ifs" do
@@ -215,11 +217,15 @@ TXT
   end
 
   it "should differentiate single/multi-line unless" do
-    expect(@indent.indent("foo unless bar\nunless foo\nbar\nend")).to eq "foo unless bar\nunless foo\n  bar\nend"
+    expect(@indent.indent("foo unless bar\nunless foo\nbar\nend")).to eq(
+      "foo unless bar\nunless foo\n  bar\nend"
+    )
   end
 
   it "should not indent single/multi-line until" do
-    expect(@indent.indent("%w{baz} until bar\nuntil foo\nbar\nend")).to eq "%w{baz} until bar\nuntil foo\n  bar\nend"
+    expect(@indent.indent("%w{baz} until bar\nuntil foo\nbar\nend")).to eq(
+      "%w{baz} until bar\nuntil foo\n  bar\nend"
+    )
   end
 
   it "should indent begin rescue end" do
@@ -253,12 +259,18 @@ INPUT
 
   it "should not indent inside strings" do
     expect(@indent.indent(%(def a\n"foo\nbar"\n  end))).to eq %(def a\n  "foo\nbar"\nend)
-    expect(@indent.indent(%(def a\nputs %w(foo\nbar), 'foo\nbar'\n  end))).to eq %(def a\n  puts %w(foo\nbar), 'foo\nbar'\nend)
+    expect(@indent.indent(%(def a\nputs %w(foo\nbar), 'foo\nbar'\n  end))).to eq(
+      %(def a\n  puts %w(foo\nbar), 'foo\nbar'\nend)
+    )
   end
 
   it "should not indent inside HEREDOCs" do
-    expect(@indent.indent(%(def a\nputs <<FOO\n bar\nFOO\nbaz\nend))).to eq %(def a\n  puts <<FOO\n bar\nFOO\n  baz\nend)
-    expect(@indent.indent(%(def a\nputs <<-'^^'\n bar\n\t^^\nbaz\nend))).to eq %(def a\n  puts <<-'^^'\n bar\n\t^^\n  baz\nend)
+    expect(@indent.indent(%(def a\nputs <<FOO\n bar\nFOO\nbaz\nend))).to eq(
+      %(def a\n  puts <<FOO\n bar\nFOO\n  baz\nend)
+    )
+    expect(@indent.indent(%(def a\nputs <<-'^^'\n bar\n\t^^\nbaz\nend))).to eq(
+      %(def a\n  puts <<-'^^'\n bar\n\t^^\n  baz\nend)
+    )
   end
 
   it "should not indent nested HEREDOCs" do
@@ -298,7 +310,8 @@ OUTPUT
       result = line.split("#").last.strip
       if result == ""
         it "should fail to parse nesting on line #{i + 1} of example_nesting.rb" do
-          expect { Pry::Indent.nesting_at(test, i + 1) }.to raise_error Pry::Indent::UnparseableNestingError
+          expect { Pry::Indent.nesting_at(test, i + 1) }
+            .to raise_error Pry::Indent::UnparseableNestingError
         end
       else
         it "should parse nesting on line #{i + 1} of example_nesting.rb" do

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -21,12 +21,16 @@ RSpec.describe 'The bin/pry CLI' do
     end
 
     it "forwards its remaining arguments as ARGV when - is passed" do
-      out = clean_output.call(`#{ruby} -I#{pry_dir} bin/pry -e #{code} - 1 -foo --bar --baz daz`)
+      out = clean_output.call(
+        `#{ruby} -I#{pry_dir} bin/pry -e #{code} - 1 -foo --bar --baz daz`
+      )
       expect(out).to eq(%w[1 -foo --bar --baz daz].inspect)
     end
 
     it "forwards its remaining arguments as ARGV when -- is passed" do
-      out = clean_output.call(`#{ruby} -I#{pry_dir} bin/pry -e #{code} -- 1 -foo --bar --baz daz`)
+      out = clean_output.call(
+        `#{ruby} -I#{pry_dir} bin/pry -e #{code} -- 1 -foo --bar --baz daz`
+      )
       expect(out).to eq(%w[1 -foo --bar --baz daz].inspect)
     end
   end
@@ -34,13 +38,19 @@ RSpec.describe 'The bin/pry CLI' do
   context '-I path' do
     it 'adds an additional path to $LOAD_PATH' do
       code = 'p($LOAD_PATH) and exit'
-      out = clean_output.call(`#{ruby} -I#{pry_dir} bin/pry -I /added/at/cli -e '#{code}'`)
+      out = clean_output.call(
+        `#{ruby} -I#{pry_dir} bin/pry -I /added/at/cli -e '#{code}'`
+      )
       expect(out).to include('/added/at/cli')
     end
 
     it 'adds multiple additional paths to $LOAD_PATH' do
       code = 'p($LOAD_PATH) and exit'
-      out = clean_output.call(`#{ruby} -I#{pry_dir} bin/pry -I /added-1/at/cli -I /added/at/cli/also -e '#{code}'`)
+      out = clean_output.call(
+        # rubocop:disable Metrics/LineLength
+        `#{ruby} -I#{pry_dir} bin/pry -I /added-1/at/cli -I /added/at/cli/also -e '#{code}'`
+        # rubocop:enable Metrics/LineLength
+      )
       expect(out).to include('/added-1/at/cli')
       expect(out).to include('/added/at/cli/also')
     end

--- a/spec/integration/hanami_spec.rb
+++ b/spec/integration/hanami_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe "Hanami integration" do
   end
 
   it "does not enter an infinite loop (#1471, #1621)" do
-    skip "prepend is not supported on this version of Ruby" if RUBY_VERSION.start_with? "1.9"
+    if RUBY_VERSION.start_with? "1.9"
+      skip "prepend is not supported on this version of Ruby"
+    end
     code = <<-RUBY
         require "pry"
         require "timeout"

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -7,19 +7,22 @@ describe Pry::Method do
   end
 
   describe ".from_str" do
-    it 'should look up instance methods if no methods available and no options provided' do
+    it 'looks up instance methods if no methods available and no options provided' do
       klass = Class.new { def hello; end }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass))
       expect(meth).to eq klass.instance_method(:hello)
     end
 
-    it 'should look up methods if no instance methods available and no options provided' do
+    it 'looks up methods if no instance methods available and no options provided' do
       klass = Class.new { def self.hello; end }
       meth = Pry::Method.from_str(:hello, Pry.binding_for(klass))
       expect(meth).to eq klass.method(:hello)
     end
 
-    it 'should look up instance methods first even if methods available and no options provided' do
+    it(
+      'looks up instance methods first even if methods available and no ' \
+      'options provided'
+    ) do
       klass = Class.new do
         def hello; end
 
@@ -35,7 +38,9 @@ describe Pry::Method do
 
         def self.hello; end
       end
-      meth = Pry::Method.from_str(:hello, Pry.binding_for(klass), "instance-methods" => true)
+      meth = Pry::Method.from_str(
+        :hello, Pry.binding_for(klass), "instance-methods" => true
+      )
       expect(meth).to eq klass.instance_method(:hello)
     end
 
@@ -69,13 +74,19 @@ describe Pry::Method do
       expect(meth).to eq klass.method(:hello)
     end
 
-    it 'should NOT look up instance methods using the Class#method syntax if no instance methods defined' do
+    it(
+      'should NOT look up instance methods using the Class#method syntax if ' \
+      'no instance methods defined'
+    ) do
       _klass = Class.new { def self.hello; end }
       meth = Pry::Method.from_str("_klass#hello", Pry.binding_for(binding))
       expect(meth).to eq nil
     end
 
-    it 'should NOT look up methods using the object.method syntax if no methods defined' do
+    it(
+      'should NOT look up methods using the object.method syntax if no ' \
+      'methods defined'
+    ) do
       _klass = Class.new { def hello; end }
       meth = Pry::Method.from_str("_klass.hello", Pry.binding_for(binding))
       expect(meth).to eq nil
@@ -112,13 +123,15 @@ describe Pry::Method do
     end
 
     it 'should not raise an exception if receiver does not exist' do
-      expect { Pry::Method.from_str("random_klass.meth", Pry.binding_for(binding)) }.to_not raise_error
+      expect { Pry::Method.from_str("random_klass.meth", Pry.binding_for(binding)) }
+        .to_not raise_error
     end
   end
 
   describe '.from_binding' do
     it 'should be able to pick a method out of a binding' do
-      expect(Pry::Method.from_binding(Class.new { def self.foo; binding; end }.foo).name).to eq "foo"
+      klass = Class.new { def self.foo; binding; end }.foo
+      expect(Pry::Method.from_binding(klass).name).to eq('foo')
     end
 
     it 'should NOT find a method from the toplevel binding' do
@@ -229,7 +242,10 @@ describe Pry::Method do
       expect(zuper.owner).to eq m
     end
 
-    it 'should be able to find super methods defined on super-classes when there are modules in the way' do
+    it(
+      'should be able to find super methods defined on super-classes when ' \
+      'there are modules in the way'
+    ) do
       a = Class.new { def rar; 4; end }
       m = Module.new { def mooo; 4; end }
       b = Class.new(a) { def rar; super; end; include m }
@@ -238,7 +254,7 @@ describe Pry::Method do
       expect(zuper.owner).to eq a
     end
 
-    it 'should be able to jump up multiple levels of bound method, even through modules' do
+    it 'jumps up multiple levels of bound method, even through modules' do
       a = Class.new { def rar; 4; end }
       m = Module.new { def rar; 4; end }
       b = Class.new(a) { def rar; super; end; include m }
@@ -259,7 +275,7 @@ describe Pry::Method do
       should_find_method('meth')
     end
 
-    it 'should be able to find private and protected instance methods defined in a class' do
+    it 'finds private and protected instance methods defined in a class' do
       @class = Class.new do
         protected
 
@@ -283,14 +299,14 @@ describe Pry::Method do
       should_find_method('meth')
     end
 
-    it 'should be able to find instance methods defined in modules included into this class' do
+    it 'finds instance methods defined in modules included into this class' do
       @class = Class.new do
         include(Module.new { def meth; 1; end })
       end
       should_find_method('meth')
     end
 
-    it 'should be able to find instance methods defined in modules included into super-classes' do
+    it 'finds instance methods defined in modules included into super-classes' do
       super_class = Class.new do
         include(Module.new { def meth; 1; end })
       end
@@ -303,7 +319,8 @@ describe Pry::Method do
         include(Module.new { def meth; 1; end })
       end
       @class = Class.new(super_class) { def meth; 2; end }
-      expect(Pry::Method.all_from_class(@class).detect { |x| x.name == 'meth' }.owner).to eq @class
+      expect(Pry::Method.all_from_class(@class).detect { |x| x.name == 'meth' }.owner)
+        .to eq @class
     end
 
     it 'should be able to find methods defined on a singleton class' do
@@ -405,8 +422,11 @@ describe Pry::Method do
       end
 
       it "should attribute overridden methods to the sub-class' singleton class" do
-        @class = Class.new(Class.new { class << self; def meth; 1; end; end }) { class << self; def meth; 1; end; end }
-        expect(Pry::Method.all_from_obj(@class).detect { |x| x.name == 'meth' }.owner).to eq(class << @class; self; end)
+        @class = Class.new(Class.new { class << self; def meth; 1; end; end }) do
+          class << self; def meth; 1; end; end
+        end
+        expect(Pry::Method.all_from_obj(@class).detect { |x| x.name == 'meth' }.owner)
+          .to eq(class << @class; self; end)
       end
 
       it "should attrbute overridden methods to the class not the module" do
@@ -416,12 +436,17 @@ describe Pry::Method do
           end
           extend(Module.new { def meth; 1; end })
         end
-        expect(Pry::Method.all_from_obj(@class).detect { |x| x.name == 'meth' }.owner).to eq(class << @class; self; end)
+        expect(Pry::Method.all_from_obj(@class).detect { |x| x.name == 'meth' }.owner)
+          .to eq(class << @class; self; end)
       end
 
-      it "should attribute overridden methods to the relevant singleton class in preference to Class" do
+      it(
+        "attributes overridden methods to the relevant singleton class in " \
+        "preference to Class"
+      ) do
         @class = Class.new { class << self; def allocate; 1; end; end }
-        expect(Pry::Method.all_from_obj(@class).detect { |x| x.name == 'allocate' }.owner).to eq(class << @class; self; end)
+        expect(Pry::Method.all_from_obj(@class).detect { |x| x.name == 'allocate' }.owner)
+          .to eq(class << @class; self; end)
       end
     end
 
@@ -444,15 +469,20 @@ describe Pry::Method do
       def eigen_class(obj); class << obj; self; end; end
 
       it "should look at a class and then its superclass" do
-        expect(Pry::Method.instance_resolution_order(LS::Next)).to eq [LS::Next] + Pry::Method.instance_resolution_order(LS::Top)
+        expect(Pry::Method.instance_resolution_order(LS::Next))
+          .to eq [LS::Next] + Pry::Method.instance_resolution_order(LS::Top)
       end
 
       it "should include the included modules between a class and its superclass" do
-        expect(Pry::Method.instance_resolution_order(LS::Low)).to eq [LS::Low, LS::P, LS::N, LS::M] + Pry::Method.instance_resolution_order(LS::Next)
+        expect(Pry::Method.instance_resolution_order(LS::Low)).to eq(
+          [LS::Low, LS::P, LS::N, LS::M] + Pry::Method.instance_resolution_order(LS::Next)
+        )
       end
 
       it "should not include modules extended into the class" do
-        expect(Pry::Method.instance_resolution_order(LS::Bottom)).to eq [LS::Bottom] + Pry::Method.instance_resolution_order(LS::Lower)
+        expect(Pry::Method.instance_resolution_order(LS::Bottom)).to eq(
+          [LS::Bottom] + Pry::Method.instance_resolution_order(LS::Lower)
+        )
       end
 
       it "should include included modules for Modules" do
@@ -461,20 +491,28 @@ describe Pry::Method do
 
       it "should include the singleton class of objects" do
         obj = LS::Low.new
-        expect(Pry::Method.resolution_order(obj)).to eq [eigen_class(obj)] + Pry::Method.instance_resolution_order(LS::Low)
+        expect(Pry::Method.resolution_order(obj)).to eq(
+          [eigen_class(obj)] + Pry::Method.instance_resolution_order(LS::Low)
+        )
       end
 
       it "should not include singleton classes of numbers" do
         target_class = 4.class
-        expect(Pry::Method.resolution_order(4)).to eq Pry::Method.instance_resolution_order(target_class)
+        expect(Pry::Method.resolution_order(4)).to eq(
+          Pry::Method.instance_resolution_order(target_class)
+        )
       end
 
       it "should include singleton classes for classes" do
-        expect(Pry::Method.resolution_order(LS::Low)).to eq [eigen_class(LS::Low)] + Pry::Method.resolution_order(LS::Next)
+        expect(Pry::Method.resolution_order(LS::Low)).to eq(
+          [eigen_class(LS::Low)] + Pry::Method.resolution_order(LS::Next)
+        )
       end
 
       it "should include modules included into singleton classes" do
-        expect(Pry::Method.resolution_order(LS::Lower)).to eq [eigen_class(LS::Lower), LS::N, LS::M] + Pry::Method.resolution_order(LS::Low)
+        expect(Pry::Method.resolution_order(LS::Lower)).to eq(
+          [eigen_class(LS::Lower), LS::N, LS::M] + Pry::Method.resolution_order(LS::Low)
+        )
       end
 
       it "should include modules at most once" do
@@ -482,10 +520,15 @@ describe Pry::Method do
       end
 
       it "should include modules at the point which they would be reached" do
-        expect(Pry::Method.resolution_order(LS::Bottom)).to eq [eigen_class(LS::Bottom), LS::O] + Pry::Method.resolution_order(LS::Lower)
+        expect(Pry::Method.resolution_order(LS::Bottom)).to eq(
+          [eigen_class(LS::Bottom), LS::O] + Pry::Method.resolution_order(LS::Lower)
+        )
       end
 
-      it "should include the Pry::Method.instance_resolution_order of Class after the singleton classes" do
+      it(
+        "includes the Pry::Method.instance_resolution_order of Class after " \
+        "the singleton classes"
+      ) do
         singleton_classes = [
           eigen_class(LS::Top), eigen_class(Object), eigen_class(BasicObject),
           *Pry::Method.instance_resolution_order(Class)

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -46,7 +46,8 @@ describe "test Pry defaults" do
         end
       end.new
 
-      expect { Pry.start(self, input: arity_zero_input, output: StringIO.new) }.to_not raise_error
+      expect { Pry.start(self, input: arity_zero_input, output: StringIO.new) }
+        .to_not raise_error
     end
 
     it 'should not pass in the prompt if the arity is -1' do
@@ -105,23 +106,30 @@ describe "test Pry defaults" do
 
   describe "pry return values" do
     it 'should return nil' do
-      expect(Pry.start(self, input: StringIO.new("exit-all"), output: StringIO.new)).to eq nil
+      expect(Pry.start(self, input: StringIO.new("exit-all"), output: StringIO.new))
+        .to eq nil
     end
 
     it 'should return the parameter given to exit-all' do
-      expect(Pry.start(self, input: StringIO.new("exit-all 10"), output: StringIO.new)).to eq 10
+      expect(Pry.start(self, input: StringIO.new("exit-all 10"), output: StringIO.new))
+        .to eq 10
     end
 
     it 'should return the parameter (multi word string) given to exit-all' do
-      expect(Pry.start(self, input: StringIO.new("exit-all \"john mair\""), output: StringIO.new)).to eq "john mair"
+      input = StringIO.new("exit-all \"john mair\"")
+      expect(Pry.start(self, input: input, output: StringIO.new)).to eq "john mair"
     end
 
     it 'should return the parameter (function call) given to exit-all' do
-      expect(Pry.start(self, input: StringIO.new("exit-all 'abc'.reverse"), output: StringIO.new)).to eq 'cba'
+      input = StringIO.new("exit-all 'abc'.reverse")
+      expect(Pry.start(self, input: input, output: StringIO.new)).to eq 'cba'
     end
 
     it 'should return the parameter (self) given to exit-all' do
-      expect(Pry.start("carl", input: StringIO.new("exit-all self"), output: StringIO.new)).to eq "carl"
+      pry = Pry.start(
+        "carl", input: StringIO.new("exit-all self"), output: StringIO.new
+      )
+      expect(pry).to eq "carl"
     end
   end
 
@@ -138,7 +146,7 @@ describe "test Pry defaults" do
       [a, b]
     end
 
-    it 'should set the prompt default, and the default should be overridable (single prompt)' do
+    it 'sets the prompt default, and the default should be overridable (single prompt)' do
       Pry.prompt = Pry::Prompt.new(:test, '', Array.new(2) { proc { '>' } })
       new_prompt = Pry::Prompt.new(:new_test, '', Array.new(2) { proc { 'A' } })
 
@@ -155,7 +163,7 @@ describe "test Pry defaults" do
       expect(get_prompts(pry)).to eq(%w[> >])
     end
 
-    it 'should set the prompt default, and the default should be overridable (multi prompt)' do
+    it 'sets the prompt default, and the default should be overridable (multi prompt)' do
       Pry.prompt = Pry::Prompt.new(:test, '', [proc { '>' }, proc { '*' }])
       new_prompt = Pry::Prompt.new(:new_test, '', [proc { 'A' }, proc { 'B' }])
 
@@ -264,7 +272,10 @@ describe "test Pry defaults" do
         end
       end
 
-      it "returns #<> format of the special-cased immediate object if #inspect is longer than maximum" do
+      it(
+        "returns #<> format of the special-cased immediate object if " \
+        "#inspect is longer than maximum"
+      ) do
         o = "o" * (MAX_LENGTH + 1)
         expect(Pry.view_clip(o, DEFAULT_OPTIONS)).to match(/#<String/)
       end
@@ -292,7 +303,9 @@ describe "test Pry defaults" do
       end
     end
 
-    describe "given a regular object with an #inspect string longer than the maximum specified" do
+    describe(
+      "given a regular object with an #inspect string longer than the maximum specified"
+    ) do
       describe "when the object is a regular one" do
         it "returns a string of the #<class name:object idish> format" do
           o = Object.new

--- a/spec/pry_output_spec.rb
+++ b/spec/pry_output_spec.rb
@@ -45,7 +45,8 @@ describe Pry do
     end
 
     it "should not be phased by un-inspectable things" do
-      expect(mock_pry("class NastyClass; undef pretty_inspect; end", "NastyClass.new")).to match(/#<.*NastyClass:0x.*?>/)
+      expect(mock_pry("class NastyClass; undef pretty_inspect; end", "NastyClass.new"))
+        .to match(/#<.*NastyClass:0x.*?>/)
     end
 
     it "doesn't leak colour for object literals" do
@@ -121,7 +122,8 @@ describe Pry do
     it "does not crash pry" do
       old_stdout = $stdout
       pry_eval = pry_tester(binding)
-      expect(pry_eval.eval("$stdout = Class.new { def write(*) end }.new", ":ok")).to eq(:ok)
+      expect(pry_eval.eval("$stdout = Class.new { def write(*) end }.new", ":ok"))
+        .to eq(:ok)
       $stdout = old_stdout
     end
   end

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -158,7 +158,10 @@ describe Pry do
         expect(Hello.const_defined?(:Nested)).to eq true
       end
 
-      it 'should suppress output if input ends in a ";" and is an Exception object (single line)' do
+      it(
+        'should suppress output if input ends in a ";" and is an Exception ' \
+        'object (single line)'
+      ) do
         expect(mock_pry("Exception.new;")).to eq ""
       end
 
@@ -181,7 +184,8 @@ describe Pry do
       it 'should not try to catch intended exceptions' do
         expect { mock_pry("raise SystemExit") }.to raise_error SystemExit
         # SIGTERM
-        expect { mock_pry("raise SignalException.new(15)") }.to raise_error SignalException
+        expect { mock_pry("raise SignalException.new(15)") }
+          .to raise_error SignalException
       end
 
       describe "multi-line input" do
@@ -289,7 +293,8 @@ describe Pry do
         end
 
         it 'can change the size of the history arrays' do
-          expect(pry_tester(memory_size: 1000).eval("[_out_, _in_].map(&:max_size)")).to eq [1000, 1000]
+          expect(pry_tester(memory_size: 1000).eval("[_out_, _in_].map(&:max_size)"))
+            .to eq [1000, 1000]
         end
 
         it 'store exceptions' do
@@ -332,7 +337,10 @@ describe Pry do
         end
 
         it 'should nest properly' do
-          Pry.config.input = InputTester.new("cd 1", "cd 2", "cd 3", "\"nest:\#\{(_pry_.binding_stack.size - 1)\}\"", "exit-all")
+          Pry.config.input = InputTester.new(
+            "cd 1", "cd 2", "cd 3",
+            "\"nest:\#\{(_pry_.binding_stack.size - 1)\}\"", "exit-all"
+          )
 
           Pry.config.output = @str_output
 
@@ -344,34 +352,50 @@ describe Pry do
       end
 
       describe "defining methods" do
-        it 'should define a method on the singleton class of an object when performing "def meth;end" inside the object' do
+        it(
+          'defines a method on the singleton class of an object when performing ' \
+          '"def meth;end" inside the object'
+        ) do
           [Object.new, {}, []].each do |val|
             pry_eval(val, 'def hello; end')
             expect(val.methods(false).map(&:to_sym).include?(:hello)).to eq true
           end
         end
 
-        it 'should define an instance method on the module when performing "def meth;end" inside the module' do
+        it(
+          'defines an instance method on the module when performing ' \
+          '"def meth;end" inside the module'
+        ) do
           hello = Module.new
           pry_eval(hello, "def hello; end")
-          expect(hello.instance_methods(false).map(&:to_sym).include?(:hello)).to eq true
+          expect(hello.instance_methods(false).map(&:to_sym).include?(:hello))
+            .to be_truthy
         end
 
-        it 'should define an instance method on the class when performing "def meth;end" inside the class' do
+        it(
+          'defines an instance method on the class when performing ' \
+          '"def meth;end" inside the class'
+        ) do
           hello = Class.new
           pry_eval(hello, "def hello; end")
-          expect(hello.instance_methods(false).map(&:to_sym).include?(:hello)).to eq true
+          expect(hello.instance_methods(false).map(&:to_sym).include?(:hello))
+            .to be_truthy
         end
 
-        it 'should define a method on the class of an object when performing "def meth;end" inside an immediate value or Numeric' do
-          # JRuby behaves different than CRuby here (seems it always has to some extent, see 'unless' below).
-          # It didn't seem trivial to work around. Skip for now.
+        it(
+          'defines a method on the class of an object when performing ' \
+          '"def meth;end" inside an immediate value or Numeric'
+        ) do
+          # JRuby behaves different than CRuby here (seems it always has to some
+          # extent, see 'unless' below). It didn't seem trivial to work
+          # around. Skip for now.
           skip "JRuby incompatibility" if Pry::Helpers::Platform.jruby?
           [
             :test, 0, true, false, nil, (0.0 unless Pry::Helpers::Platform.jruby?)
           ].each do |val|
             pry_eval(val, "def hello; end")
-            expect(val.class.instance_methods(false).map(&:to_sym).include?(:hello)).to eq true
+            expect(val.class.instance_methods(false).map(&:to_sym).include?(:hello))
+              .to be_truthy
           end
         end
       end

--- a/spec/pryrc_spec.rb
+++ b/spec/pryrc_spec.rb
@@ -39,7 +39,9 @@ describe Pry do
         File.chmod 0o000, dir
         Pry::LOCAL_RC_FILE.replace File.join(dir, '.pryrc')
         Pry.config.should_load_rc = true
-        expect { Pry.start(self, input: StringIO.new("exit-all\n"), output: StringIO.new) }.to_not raise_error
+        expect do
+          Pry.start(self, input: StringIO.new("exit-all\n"), output: StringIO.new)
+        end.to_not raise_error
         File.chmod 0o777, dir
       end
     end
@@ -48,7 +50,9 @@ describe Pry do
       old_home = ENV['HOME']
       ENV['HOME'] = nil
       Pry.config.should_load_rc = true
-      expect { Pry.start(self, input: StringIO.new("exit-all\n"), output: StringIO.new) }.to_not raise_error
+      expect do
+        Pry.start(self, input: StringIO.new("exit-all\n"), output: StringIO.new)
+      end.to_not raise_error
 
       ENV['HOME'] = old_home
     end
@@ -74,7 +78,8 @@ describe Pry do
         end
 
         @doing_it = lambda {
-          Pry.start(self, input: StringIO.new("Object::TEST_AFTER_RAISE=1\nexit-all\n"), output: StringIO.new)
+          input = StringIO.new("Object::TEST_AFTER_RAISE=1\nexit-all\n")
+          Pry.start(self, input: input, output: StringIO.new)
           putsed
         }
       end

--- a/spec/syntax_checking_spec.rb
+++ b/spec/syntax_checking_spec.rb
@@ -27,8 +27,10 @@ describe Pry do
     ["1 1"],
     ["puts :"]
   ] + [
-    ["def", "method(1"], # in this case the syntax error is "expecting ')'".
-    ["o = Object.new.tap{ def o.render;", "'MEH'", "}"] # in this case the syntax error is "expecting keyword_end".
+    # in this case the syntax error is "expecting ')'".
+    ["def", "method(1"],
+    # in this case the syntax error is "expecting keyword_end".
+    ["o = Object.new.tap{ def o.render;", "'MEH'", "}"]
   ]).compact.each do |foo|
     it "should raise an error on invalid syntax like #{foo.inspect}" do
       redirect_pry_io(InputTester.new(*foo), @str_output) do
@@ -40,7 +42,8 @@ describe Pry do
   end
 
   it "should not intefere with syntax errors explicitly raised" do
-    redirect_pry_io(InputTester.new('raise SyntaxError, "unexpected $end"'), @str_output) do
+    input_tester = InputTester.new('raise SyntaxError, "unexpected $end"')
+    redirect_pry_io(input_tester, @str_output) do
       Pry.start
     end
 
@@ -60,7 +63,12 @@ describe Pry do
   end
 
   it "should not clobber _ex_ on a SyntaxError in the repl" do
-    expect(mock_pry("raise RuntimeError, 'foo'", "puts foo)", "_ex_.is_a?(RuntimeError)")).to match(/^RuntimeError.*\nSyntaxError.*\n=> true/m)
+    output = mock_pry(
+      "raise RuntimeError, 'foo'",
+      "puts foo)",
+      "_ex_.is_a?(RuntimeError)"
+    )
+    expect(output).to match(/^RuntimeError.*\nSyntaxError.*\n=> true/m)
   end
 
   it "should allow whitespace delimeted strings" do

--- a/spec/unrescued_exceptions_spec.rb
+++ b/spec/unrescued_exceptions_spec.rb
@@ -5,13 +5,17 @@ describe "Pry.config.unrescued_exceptions" do
 
   it 'should rescue all exceptions NOT specified on unrescued_exceptions' do
     expect(Pry.config.unrescued_exceptions.include?(NameError)).to eq false
-    expect { Pry.start(self, input: StringIO.new("raise NameError\nexit"), output: @str_output) }.not_to raise_error
+    expect do
+      Pry.start(self, input: StringIO.new("raise NameError\nexit"), output: @str_output)
+    end.not_to raise_error
   end
 
   it 'should NOT rescue exceptions specified on unrescued_exceptions' do
     old_allowlist = Pry.config.unrescued_exceptions
     Pry.config.unrescued_exceptions = [NameError]
-    expect { Pry.start(self, input: StringIO.new("raise NameError"), output: @str_output) }.to raise_error NameError
+    expect do
+      Pry.start(self, input: StringIO.new("raise NameError"), output: @str_output)
+    end.to raise_error NameError
     Pry.config.unrescued_exceptions = old_allowlist
   end
 end

--- a/spec/wrapped_module_spec.rb
+++ b/spec/wrapped_module_spec.rb
@@ -48,19 +48,25 @@ describe Pry::WrappedModule do
 
     describe "ordering of candidates" do
       it 'should return class with largest number of methods as primary candidate' do
-        expect(Pry::WrappedModule(Host::CandidateTest).candidate(0).file).to match(/helper1/)
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(0).file)
+          .to match(/helper1/)
       end
 
-      it 'should return class with second largest number of methods as second ranked candidate' do
-        expect(Pry::WrappedModule(Host::CandidateTest).candidate(1).file).to match(/helper2/)
+      it(
+        'returns class with second largest number of methods as second ranked candidate'
+      ) do
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(1).file)
+          .to match(/helper2/)
       end
 
-      it 'should return class with third largest number of methods as third ranked candidate' do
-        expect(Pry::WrappedModule(Host::CandidateTest).candidate(2).file).to match(/#{__FILE__}/)
+      it 'returns class with third largest number of methods as third ranked candidate' do
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(2).file)
+          .to match(/#{__FILE__}/)
       end
 
       it 'should raise when trying to access non-existent candidate' do
-        expect { Pry::WrappedModule(Host::CandidateTest).candidate(3) }.to raise_error Pry::CommandError
+        expect { Pry::WrappedModule(Host::CandidateTest).candidate(3) }
+          .to raise_error Pry::CommandError
       end
     end
 
@@ -70,9 +76,10 @@ describe Pry::WrappedModule do
         expect(wm.source_location).to eq wm.candidate(0).source_location
       end
 
-      it 'should return the location of the outer module if an inner module has methods' do
+      it 'returns the location of the outer module if an inner module has methods' do
         wm = Pry::WrappedModule(Host::ForeverAlone)
-        expect(File.expand_path(wm.source_location.first)).to eq File.expand_path(__FILE__)
+        expect(File.expand_path(wm.source_location.first))
+          .to eq File.expand_path(__FILE__)
         expect(wm.source_location.last).to eq Host::FOREVER_ALONE_LINE
       end
 
@@ -88,20 +95,25 @@ describe Pry::WrappedModule do
       end
 
       it 'should return source for highest ranked candidate' do
-        expect(Pry::WrappedModule(Host::CandidateTest).candidate(0).source).to match(/test1/)
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(0).source)
+          .to match(/test1/)
       end
 
       it 'should return source for second ranked candidate' do
-        expect(Pry::WrappedModule(Host::CandidateTest).candidate(1).source).to match(/test4/)
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(1).source)
+          .to match(/test4/)
       end
 
       it 'should return source for third ranked candidate' do
-        expect(Pry::WrappedModule(Host::CandidateTest).candidate(2).source).to match(/test6/)
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(2).source)
+          .to match(/test6/)
       end
 
       it 'should return source for deeply nested class' do
-        expect(Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).source).to match(/nested_method/)
-        expect(Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).source.lines.count).to eq(3)
+        expect(Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).source)
+          .to match(/nested_method/)
+        mod = Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested)
+        expect(mod.source.lines.count).to eq(3)
       end
     end
 
@@ -112,19 +124,23 @@ describe Pry::WrappedModule do
       end
 
       it 'should return doc for highest ranked candidate' do
-        expect(Pry::WrappedModule(Host::CandidateTest).candidate(0).doc).to match(/rank 0/)
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(0).doc)
+          .to match(/rank 0/)
       end
 
       it 'should return doc for second ranked candidate' do
-        expect(Pry::WrappedModule(Host::CandidateTest).candidate(1).doc).to match(/rank 1/)
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(1).doc)
+          .to match(/rank 1/)
       end
 
       it 'should return doc for third ranked candidate' do
-        expect(Pry::WrappedModule(Host::CandidateTest).candidate(2).doc).to match(/rank 2/)
+        expect(Pry::WrappedModule(Host::CandidateTest).candidate(2).doc)
+          .to match(/rank 2/)
       end
 
       it 'should return docs for deeply nested class' do
-        expect(Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).doc).to match(/nested docs/)
+        expect(Pry::WrappedModule(Host::ForeverAlone::DoublyNested::TriplyNested).doc)
+          .to match(/nested docs/)
       end
     end
   end
@@ -160,7 +176,8 @@ describe Pry::WrappedModule do
     end
 
     example "of singleton classes of anonymous classes should not be empty" do
-      expect(Pry::WrappedModule.new(class << Class.new; self; end).method_prefix).to match(/#<Class:.*>./)
+      expect(Pry::WrappedModule.new(class << Class.new; self; end).method_prefix)
+        .to match(/#<Class:.*>./)
     end
   end
 
@@ -180,12 +197,15 @@ describe Pry::WrappedModule do
 
   describe ".singleton_instance" do
     it "should raise an exception when called on a non-singleton-class" do
-      expect { Pry::WrappedModule.new(Class).singleton_instance }.to raise_error ArgumentError
+      expect { Pry::WrappedModule.new(Class).singleton_instance }
+        .to raise_error ArgumentError
     end
 
     it "should return the attached object" do
-      expect(Pry::WrappedModule.new(class << "hi"; self; end).singleton_instance).to eq "hi"
-      expect(Pry::WrappedModule.new(class << Object; self; end).singleton_instance).to equal(Object)
+      expect(Pry::WrappedModule.new(class << "hi"; self; end).singleton_instance)
+        .to eq "hi"
+      expect(Pry::WrappedModule.new(class << Object; self; end).singleton_instance)
+        .to equal(Object)
     end
   end
 


### PR DESCRIPTION
I realise that some code might be less readable now, but now that we set a good
default limit, we protect the codebase from further mess. It's important to do
this to prevent adding more mess to already messy code that we have. :doctor: