### PR TITLE
rubocop: fix offences of the Lint/EmptyWhen cop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,11 +13,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'pry.gemspec'
 
-# Offense count: 2
-Lint/EmptyWhen:
-  Exclude:
-    - 'lib/pry/input_completer.rb'
-
 # Offense count: 6
 Lint/HandleExceptions:
   Exclude:

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -35,12 +35,6 @@ class Pry
       yield
     ].freeze
 
-    Operators = %w[
-      % & * ** + - /
-      < << <= <=> == === =~ > >= >>
-      [] []= ^ ! != !~
-    ].freeze
-
     WORD_ESCAPE_STR = " \t\n\"\\'`><=;|&{(".freeze
 
     def initialize(input, pry = nil)
@@ -220,13 +214,9 @@ class Pry
 
     def select_message(path, receiver, message, candidates)
       candidates.grep(/^#{message}/).collect do |e|
-        case e
-        when /^[a-zA-Z_]/
-          path.call(receiver + "." << e)
-        when /^[0-9]/
-        when *Operators
-          # receiver + " " << e
-        end
+        next unless e =~ /^[a-zA-Z_]/
+
+        path.call(receiver + "." << e)
       end.compact
     end
 


### PR DESCRIPTION
I am not sure what's the story behind this dead code but it is no-op and it
shouldn't harm removing it.