### PR TITLE
circle: update Dockerfiles to have make & gcc installed

### DIFF
--- a/.circleci/ruby-1.9.3p551/Dockerfile
+++ b/.circleci/ruby-1.9.3p551/Dockerfile
@@ -67,9 +67,9 @@ RUN set -ex \
     && gem update --system $RUBYGEMS_VERSION \
     && rm -r /usr/src/ruby-$RUBY_VERSION
 
-RUN apk add --no-cache git nano
+RUN apk add --no-cache git nano build-base
 
-RUN gem update --system
+RUN gem update --system 2.7.9
 
 RUN gem install bundler --version "$BUNDLER_VERSION" --force
 

--- a/.circleci/ruby-2.0.0p648/Dockerfile
+++ b/.circleci/ruby-2.0.0p648/Dockerfile
@@ -67,9 +67,9 @@ RUN set -ex \
     && gem update --system $RUBYGEMS_VERSION \
     && rm -r /usr/src/ruby-$RUBY_VERSION
 
-RUN apk add --no-cache git nano
+RUN apk add --no-cache git nano build-base
 
-RUN gem update --system
+RUN gem update --system 2.7.9
 
 RUN gem install bundler --version "$BUNDLER_VERSION" --force
 


### PR DESCRIPTION
This is needed in case we want to compile dependencies. Without `build-base` we
will be getting errors: https://circleci.com/gh/pry/pry/6102