### PR TITLE
Move Pry::DEFAULT_HOOKS to Config

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -6,15 +6,6 @@ require 'pry/helpers/base_helpers'
 require 'pry/hooks'
 
 class Pry
-  # The default hooks - display messages when beginning and ending Pry sessions.
-  DEFAULT_HOOKS = Pry::Hooks.new.add_hook(
-    :before_session, :default
-  ) do |_out, _target, _pry_|
-    next if _pry_.quiet?
-
-    _pry_.run_command("whereami --quiet")
-  end
-
   # The default print
   DEFAULT_PRINT = proc do |_output, value, _pry_|
     _pry_.pager.open do |pager|

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -28,7 +28,17 @@ class Pry
           )
           Pry::DEFAULT_UNRESCUED_EXCEPTIONS
         end,
-        hooks: Pry::DEFAULT_HOOKS,
+
+        # The default hooks - display messages when beginning and ending Pry
+        # sessions.
+        hooks: Pry::Hooks.new.add_hook(
+          :before_session, :default
+        ) do |_out, _target, _pry_|
+          next if _pry_.quiet?
+
+          _pry_.run_command('whereami --quiet')
+        end,
+
         pager: true,
         system: Pry::DEFAULT_SYSTEM,
         color: Pry::Helpers::BaseHelpers.use_ansi_codes?,

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -373,17 +373,19 @@ describe "test Pry defaults" do
         binding,
         input: InputTester.new("1", "exit-all"),
         output: @str_output,
-        hooks: Pry::DEFAULT_HOOKS
+        hooks: Pry::Config.defaults.hooks
       )
 
       expect(@str_output.string).to match(/[w]hereami by default/)
     end
 
     it 'should hide whereami if quiet is set' do
-      Pry.new(input: InputTester.new("exit-all"),
-              output: @str_output,
-              quiet: true,
-              hooks: Pry::DEFAULT_HOOKS)
+      Pry.new(
+        input: InputTester.new('exit-all'),
+        output: @str_output,
+        quiet: true,
+        hooks: Pry::Config.defaults.hooks
+      )
 
       expect(@str_output.string).to eq ""
     end


### PR DESCRIPTION
Default values make sense inside config, where we already define all default
values.