### PR TITLE
Delete Pry::ExtendCommandBundle

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -5,12 +5,6 @@ require 'pry/exceptions'
 require 'pry/helpers/base_helpers'
 require 'pry/hooks'
 
-class Pry
-  # This is to keep from breaking under Rails 3.2 for people who are doing that
-  # IRB = Pry thing.
-  module ExtendCommandBundle; end
-end
-
 require 'method_source'
 require 'shellwords'
 require 'stringio'


### PR DESCRIPTION
This hack is already covered in pry-rails:
https://github.com/rweng/pry-rails/blob/8bea87dfef849f6f1c5e1f9d22a6a6ff238b025f/lib/pry-rails/railtie.rb#L12-L14

`IRB = Pry` is discouraged and people should use pry-rails instead.