### PR TITLE
exceptions: delete ExtendCommandBundle

### DIFF
--- a/lib/pry/exceptions.rb
+++ b/lib/pry/exceptions.rb
@@ -78,9 +78,4 @@ class Pry
 
   # indicates obsolete API
   class ObsoleteError < StandardError; end
-
-  # This is to keep from breaking under Rails 3.2 for people who are doing that
-  # IRB = Pry thing.
-  module ExtendCommandBundle
-  end
 end


### PR DESCRIPTION
Should've been deleted in 5ff0578f9640a1e28aa2c7f6b7beba7a6dee30f8.
I had no idea it existed here.