### PR TITLE
Delete `requires_gem` remnants

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -82,7 +82,6 @@ class Pry
 
       def default_options(match)
         {
-          requires_gem: [],
           keep_retval: false,
           argument_required: false,
           interpolate: true,

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -29,10 +29,6 @@ class Pry
     # @option options [Boolean] :keep_retval Whether or not to use return value
     #   of the block for return of `command` or just to return `nil`
     #   (the default).
-    # @option options [Array<String>] :requires_gem Whether the command has
-    #   any gem dependencies, if it does and dependencies not met then
-    #   command is disabled and a stub proc giving instructions to
-    #   install command is provided.
     # @option options [Boolean] :interpolate Whether string #{} based
     #   interpolation is applied to the command arguments before
     #   executing the command. Defaults to true.

--- a/lib/pry/commands/easter_eggs.rb
+++ b/lib/pry/commands/easter_eggs.rb
@@ -1,9 +1,5 @@
 class Pry
   Pry::Commands.instance_eval do
-    command "nyan-cat", "", requires_gem: ["nyancat"] do
-      run ".nyancat"
-    end
-
     command(%r{!s/(.*?)/(.*?)}, "") do |source, dest|
       eval_string.gsub!(/#{source}/) { dest }
       run "show-input"

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -686,7 +686,6 @@ describe "Pry::Command" do
     describe "command options hash" do
       it "is always present" do
         options_hash = {
-          requires_gem: [],
           keep_retval: false,
           argument_required: false,
           interpolate: true,


### PR DESCRIPTION
Continues the removal of `install-command` started in
https://github.com/pry/pry/pull/1979.

We also delete the `nyan-cat` command because it depends on that API.