### PR TITLE
color_printer_spec: refactor to modern style

### DIFF
--- a/spec/color_printer_spec.rb
+++ b/spec/color_printer_spec.rb
@@ -1,98 +1,43 @@
-describe Pry::ColorPrinter do
-  include Pry::Helpers::Text
-  let(:io) { StringIO.new }
-  let(:str) { strip_color(io.string.chomp) }
+RSpec.describe Pry::ColorPrinter do
+  let(:output) { StringIO.new }
 
-  describe '.pp' do
-    describe 'Object' do
-      it 'prints a string' do
-        Pry::ColorPrinter.pp(Object.new, io)
-        expect(str).to match(/\A#<Object:0x\w+>\z/)
-      end
-    end
-
-    describe 'Object subclass' do
-      before do
-        class ObjectF < Object
+  describe ".pp" do
+    context "when no exception is raised in #inspect" do
+      let(:healthy_class) do
+        Class.new do
           def inspect
-            'foo'
-          end
-        end
-
-        class ObjectG < Object
-          def inspect
-            raise
+            'string'
           end
         end
       end
 
-      after do
-        Object.send :remove_const, :ObjectF
-        Object.send :remove_const, :ObjectG
-      end
-
-      it 'prints a string' do
-        Pry::ColorPrinter.pp(ObjectF.new, io)
-        expect(str).to eq('foo')
-      end
-
-      it 'prints a string, even when an exception is raised' do
-        Pry::ColorPrinter.pp(ObjectG.new, io)
-        expect(str).to match(/\A#<ObjectG:0x\w+>\z/)
+      it "prints a string" do
+        described_class.pp(healthy_class.new, output)
+        expect(output.string).to eq("string\n")
       end
     end
 
-    describe 'BasicObject' do
-      it 'prints a string' do
-        Pry::ColorPrinter.pp(BasicObject.new, io)
-        expect(str).to match(/\A#<BasicObject:0x\w+>\z/)
-      end
-    end
-
-    describe 'BasicObject subclass' do
-      before do
-        class BasicF < BasicObject
-          def inspect
-            'foo'
-          end
-        end
-
-        class BasicG < BasicObject
+    context "when an exception is raised in #inspect" do
+      let(:broken_class) do
+        Class.new do
           def inspect
             raise
           end
         end
       end
 
-      after do
-        Object.__send__ :remove_const, :BasicF
-        Object.__send__ :remove_const, :BasicG
-      end
-
-      it 'prints a string' do
-        Pry::ColorPrinter.pp(BasicF.new, io)
-        expect(str).to eq("foo")
-      end
-
-      it 'prints a string, even when an exception is raised' do
-        Pry::ColorPrinter.pp(BasicG.new, io)
-        expect(str).to match(/\A#<BasicG:0x\w+>\z/)
+      it "still prints a string" do
+        described_class.pp(broken_class.new, output)
+        expect(output.string)
+          .to match(/\A\e\[32m#<#<Class:0x.+>:0x.+>\e\[0m\e\[0m\n\z/)
       end
     end
 
-    describe 'String' do
-      context 'with a single-line string' do
-        it 'pretty prints the string' do
-          Pry::ColorPrinter.pp('hello world', io)
-          expect(str).to eq('"hello world"')
-        end
-      end
-
-      context 'with a multi-line string' do
-        it 'pretty prints the string' do
-          Pry::ColorPrinter.pp("hello\nworld", io)
-          expect(str).to eq('"hello\nworld"')
-        end
+    context "when printing a BasicObject" do
+      it "prints a string" do
+        described_class.pp(BasicObject.new, output)
+        expect(output.string)
+          .to match(/\A\e\[32m#<BasicObject:0x.+>\e\[0m\e\[0m\n\z/)
       end
     end
   end


### PR DESCRIPTION
I deleted some specs because I am not sure about their significance. They seemed
to be duplicative.