### PR TITLE
Rename '_pry_' to 'pry_instance'

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,7 +51,7 @@ Metrics/BlockNesting:
 # Offense count: 19
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 308
+  Max: 317
 
 # Offense count: 32
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
   This will be removed in the next release.
 * Deprecated the `show-doc` command. The `show-source -d` is the new recommended
   way of reading docs ([#1934](https://github.com/pry/pry/pull/1934))
+* Deprecated `Pry::Command#_pry_`. Use `Pry::Command#pry_instance` instead
+  ([#1989](https://github.com/pry/pry/pull/1989))
 
 #### Breaking changes
 

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -63,8 +63,8 @@ class Pry
     include Pry::Helpers::CommandHelpers
 
     class << self
-      def lookup(str, _pry_, options = {})
-        co = new(str, _pry_, options)
+      def lookup(str, pry_instance, options = {})
+        co = new(str, pry_instance, options)
 
         co.default_lookup || co.method_or_class_lookup ||
           co.command_lookup || co.empty_lookup
@@ -73,23 +73,23 @@ class Pry
 
     attr_accessor :str
     attr_accessor :target
-    attr_accessor :_pry_
+    attr_accessor :pry_instance
     attr_accessor :super_level
 
-    def initialize(str, _pry_, options = {})
+    def initialize(str, pry_instance, options = {})
       options = {
         super: 0
       }.merge!(options)
 
       @str = str
-      @_pry_ = _pry_
-      @target = _pry_.current_context
+      @pry_instance = pry_instance
+      @target = pry_instance.current_context
       @super_level = options[:super]
     end
 
     # TODO: just make it so find_command_by_match_or_listing doesn't raise?
     def command_lookup
-      _pry_.commands.find_command_by_match_or_listing(str)
+      pry_instance.commands.find_command_by_match_or_listing(str)
     rescue StandardError
       nil
     end

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -242,7 +242,17 @@ class Pry
     attr_accessor :context
     attr_accessor :command_set
     attr_accessor :hooks
-    attr_accessor :_pry_
+
+    attr_accessor :pry_instance
+    alias _pry_= pry_instance=
+    def _pry_
+      loc = caller_locations(1..1).first
+      warn(
+        "#{loc.path}:#{loc.lineno}: warning: _pry_ is deprecated, use " \
+        "pry_instance instead"
+      )
+      pry_instance
+    end
 
     # The block we pass *into* a command so long as `:takes_block` is
     # not equal to `false`
@@ -262,7 +272,7 @@ class Pry
     # @example
     #   run "amend-line",  "5", 'puts "hello world"'
     def run(command_string, *args)
-      command_string = _pry_.config.command_prefix.to_s + command_string
+      command_string = pry_instance.config.command_prefix.to_s + command_string
       complete_string = "#{command_string} #{args.join(' ')}".rstrip
       command_set.process_line(complete_string, context)
     end
@@ -288,7 +298,7 @@ class Pry
       self.eval_string  = context[:eval_string]
       self.command_set  = context[:command_set]
       self.hooks        = context[:hooks]
-      self._pry_        = context[:pry_instance]
+      self.pry_instance = context[:pry_instance]
     end
 
     # @return [Object] The value of `self` inside the `target` binding.
@@ -304,7 +314,7 @@ class Pry
     #   state.my_state = "my state"  # this will not conflict with any
     #                                # `state.my_state` used in another command.
     def state
-      _pry_.command_state[match] ||= Pry::Config.from_hash({})
+      pry_instance.command_state[match] ||= Pry::Config.from_hash({})
     end
 
     # Revaluate the string (str) and perform interpolation.
@@ -421,7 +431,7 @@ class Pry
 
       block_string =
         if !Pry::Code.complete_expression?(prime_string)
-          _pry_.r(target, prime_string)
+          pry_instance.r(target, prime_string)
         else
           prime_string
         end

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -53,7 +53,7 @@ class Pry
     #   end
     #
     #   # From pry:
-    #   # pry(main)> _pry_.commands = MyCommands
+    #   # pry(main)> pry_instance.commands = MyCommands
     #   # pry(main)> greet john
     #   # Good afternoon John!
     #   # pry(main)> help greet
@@ -68,7 +68,7 @@ class Pry
     #   end
     #
     #   # From pry:
-    #   # pry(main)> _pry_.commands = MyCommands
+    #   # pry(main)> pry_instance.commands = MyCommands
     #   # pry(main)> number-10 john
     #   # hello john, nice number: 10
     #   # pry(main)> help number

--- a/lib/pry/commands/cat.rb
+++ b/lib/pry/commands/cat.rb
@@ -34,15 +34,18 @@ class Pry
       end
 
       def process
-        output = if opts.present?(:ex)
-                   ExceptionFormatter.new(_pry_.last_exception, _pry_, opts).format
-                 elsif opts.present?(:in)
-                   InputExpressionFormatter.new(_pry_.input_ring, opts).format
-                 else
-                   FileFormatter.new(args.first, _pry_, opts).format
-                 end
+        output =
+          if opts.present?(:ex)
+            ExceptionFormatter.new(
+              pry_instance.last_exception, pry_instance, opts
+            ).format
+          elsif opts.present?(:in)
+            InputExpressionFormatter.new(pry_instance.input_ring, opts).format
+          else
+            FileFormatter.new(args.first, pry_instance, opts).format
+          end
 
-        _pry_.pager.page output
+        pry_instance.pager.page output
       end
 
       def complete(search)

--- a/lib/pry/commands/cat/exception_formatter.rb
+++ b/lib/pry/commands/cat/exception_formatter.rb
@@ -4,18 +4,20 @@ class Pry
       class ExceptionFormatter < AbstractFormatter
         attr_reader :ex
         attr_reader :opts
-        attr_reader :_pry_
+        attr_reader :pry_instance
         include Pry::Helpers::Text
 
-        def initialize(exception, _pry_, opts)
+        def initialize(exception, pry_instance, opts)
           @ex = exception
           @opts = opts
-          @_pry_ = _pry_
+          @pry_instance = pry_instance
         end
 
         def format
           check_for_errors
-          set_file_and_dir_locals(backtrace_file, _pry_, _pry_.current_context)
+          set_file_and_dir_locals(
+            backtrace_file, pry_instance, pry_instance.current_context
+          )
           code = decorate(
             Pry::Code.from_file(backtrace_file)
               .between(*start_and_end_line_for_code_window)
@@ -27,7 +29,7 @@ class Pry
         private
 
         def code_window_size
-          _pry_.config.default_window_size || 5
+          pry_instance.config.default_window_size || 5
         end
 
         def backtrace_level

--- a/lib/pry/commands/cat/file_formatter.rb
+++ b/lib/pry/commands/cat/file_formatter.rb
@@ -4,21 +4,21 @@ class Pry
       class FileFormatter < AbstractFormatter
         attr_reader :file_with_embedded_line
         attr_reader :opts
-        attr_reader :_pry_
+        attr_reader :pry_instance
 
-        def initialize(file_with_embedded_line, _pry_, opts)
+        def initialize(file_with_embedded_line, pry_instance, opts)
           unless file_with_embedded_line
             raise CommandError, "Must provide a filename, --in, or --ex."
           end
 
           @file_with_embedded_line = file_with_embedded_line
           @opts = opts
-          @_pry_ = _pry_
+          @pry_instance = pry_instance
           @code_from_file = Pry::Code.from_file(file_name)
         end
 
         def format
-          set_file_and_dir_locals(file_name, _pry_, _pry_.current_context)
+          set_file_and_dir_locals(file_name, pry_instance, pry_instance.current_context)
           decorate(@code_from_file)
         end
 
@@ -39,7 +39,7 @@ class Pry
         end
 
         def code_window_size
-          _pry_.config.default_window_size || 7
+          pry_instance.config.default_window_size || 7
         end
 
         def decorate(content)

--- a/lib/pry/commands/cd.rb
+++ b/lib/pry/commands/cd.rb
@@ -25,14 +25,15 @@ class Pry
 
         if arg_string.strip == "-"
           unless state.old_stack.empty?
-            _pry_.binding_stack, state.old_stack = state.old_stack, _pry_.binding_stack
+            pry_instance.binding_stack, state.old_stack =
+              state.old_stack, pry_instance.binding_stack
           end
         else
-          stack = ObjectPath.new(arg_string, _pry_.binding_stack).resolve
+          stack = ObjectPath.new(arg_string, pry_instance.binding_stack).resolve
 
-          if stack && stack != _pry_.binding_stack
-            state.old_stack = _pry_.binding_stack
-            _pry_.binding_stack = stack
+          if stack && stack != pry_instance.binding_stack
+            state.old_stack = pry_instance.binding_stack
+            pry_instance.binding_stack = stack
           end
         end
       end

--- a/lib/pry/commands/change_inspector.rb
+++ b/lib/pry/commands/change_inspector.rb
@@ -14,7 +14,7 @@ class Pry
 
       def process(inspector)
         if inspector_map.key?(inspector)
-          _pry_.print = inspector_map[inspector][:value]
+          pry_instance.print = inspector_map[inspector][:value]
           output.puts "Switched to the '#{inspector}' inspector!"
         else
           raise Pry::CommandError, "'#{inspector}' isn't a known inspector!"

--- a/lib/pry/commands/change_prompt.rb
+++ b/lib/pry/commands/change_prompt.rb
@@ -27,7 +27,7 @@ class Pry
 
       def list_prompts
         prompts = Pry::Prompt.all.map do |name, prompt|
-          "#{bold(name)}#{red(' (selected)') if _pry_.prompt == prompt}\n" +
+          "#{bold(name)}#{red(' (selected)') if pry_instance.prompt == prompt}\n" +
             prompt.description
         end
         output.puts(prompts.join("\n" * 2))
@@ -35,7 +35,7 @@ class Pry
 
       def change_prompt(prompt)
         if Pry::Prompt[prompt]
-          _pry_.prompt = Pry::Prompt[prompt]
+          pry_instance.prompt = Pry::Prompt[prompt]
         else
           raise Pry::CommandError,
                 "'#{prompt}' isn't a known prompt. Run `change-prompt --list` " \

--- a/lib/pry/commands/clear_screen.rb
+++ b/lib/pry/commands/clear_screen.rb
@@ -7,9 +7,9 @@ class Pry
 
       def process
         if Pry::Helpers::Platform.windows?
-          _pry_.config.system.call(_pry_.output, 'cls', _pry_)
+          pry_instance.config.system.call(pry_instance.output, 'cls', pry_instance)
         else
-          _pry_.config.system.call(_pry_.output, 'clear', _pry_)
+          pry_instance.config.system.call(pry_instance.output, 'clear', pry_instance)
         end
       end
       Pry::Commands.add_command(self)

--- a/lib/pry/commands/code_collector.rb
+++ b/lib/pry/commands/code_collector.rb
@@ -5,7 +5,7 @@ class Pry
 
       attr_reader :args
       attr_reader :opts
-      attr_reader :_pry_
+      attr_reader :pry_instance
 
       # The name of the explicitly given file (if any).
       attr_accessor :file
@@ -18,10 +18,10 @@ class Pry
       @input_expression_ranges = []
       @output_result_ranges = []
 
-      def initialize(args, opts, _pry_)
+      def initialize(args, opts, pry_instance)
         @args = args
         @opts = opts
-        @_pry_ = _pry_
+        @pry_instance = pry_instance
       end
 
       # Add the `--lines`, `-o`, `-i`, `-s`, `-d` options.
@@ -82,7 +82,7 @@ class Pry
       #
       # @return [Pry::WrappedModule, Pry::Method, Pry::Command]
       def code_object
-        Pry::CodeObject.lookup(obj_name, _pry_, super: opts[:super])
+        Pry::CodeObject.lookup(obj_name, pry_instance, super: opts[:super])
       end
 
       # Given a string and a range, return the `range` lines of that
@@ -95,25 +95,25 @@ class Pry
         Array(content.lines.to_a[range]).join
       end
 
-      # The selected `_pry_.output_ring` as a string, as specified by
+      # The selected `pry_instance.output_ring` as a string, as specified by
       # the `-o` switch.
       #
       # @return [String]
       def pry_output_content
         pry_array_content_as_string(
-          _pry_.output_ring,
+          pry_instance.output_ring,
           self.class.output_result_ranges,
           &:pretty_inspect
         )
       end
 
-      # The selected `_pry_.input_ring` as a string, as specified by
+      # The selected `pry_instance.input_ring` as a string, as specified by
       # the `-i` switch.
       #
       # @return [String]
       def pry_input_content
         pry_array_content_as_string(
-          _pry_.input_ring, self.class.input_expression_ranges
+          pry_instance.input_ring, self.class.input_expression_ranges
         ) { |v| v }
       end
 

--- a/lib/pry/commands/disable_pry.rb
+++ b/lib/pry/commands/disable_pry.rb
@@ -20,7 +20,7 @@ class Pry
 
       def process
         ENV['DISABLE_PRY'] = 'true'
-        _pry_.run_command "exit"
+        pry_instance.run_command "exit"
       end
     end
 

--- a/lib/pry/commands/easter_eggs.rb
+++ b/lib/pry/commands/easter_eggs.rb
@@ -79,8 +79,8 @@ class Pry
     end
 
     command "test-ansi", "" do
-      prev_color = _pry_.config.color
-      _pry_.config.color = true
+      prev_color = pry_instance.config.color
+      pry_instance.config.color = true
 
       picture = unindent <<-'EOS'.gsub(/[[:alpha:]!]/) { |s| red(s) }
          ____      _______________________
@@ -103,7 +103,7 @@ class Pry
       output.puts "\n" * 6
       output.puts "** ENV['TERM'] is #{ENV['TERM']} **\n\n"
 
-      _pry_.config.color = prev_color
+      pry_instance.config.color = prev_color
     end
   end
 end

--- a/lib/pry/commands/edit/exception_patcher.rb
+++ b/lib/pry/commands/edit/exception_patcher.rb
@@ -2,12 +2,12 @@ class Pry
   class Command
     class Edit
       class ExceptionPatcher
-        attr_accessor :_pry_
+        attr_accessor :pry_instance
         attr_accessor :state
         attr_accessor :file_and_line
 
-        def initialize(_pry_, state, exception_file_and_line)
-          @_pry_ = _pry_
+        def initialize(pry_instance, state, exception_file_and_line)
+          @pry_instance = pry_instance
           @state = state
           @file_and_line = exception_file_and_line
         end
@@ -17,8 +17,8 @@ class Pry
           file_name, = file_and_line
           lines = state.dynamical_ex_file || File.read(file_name)
 
-          source = Pry::Editor.new(_pry_).edit_tempfile_with_content(lines)
-          _pry_.evaluate_ruby source
+          source = Pry::Editor.new(pry_instance).edit_tempfile_with_content(lines)
+          pry_instance.evaluate_ruby source
           state.dynamical_ex_file = source.split("\n")
         end
       end

--- a/lib/pry/commands/exit.rb
+++ b/lib/pry/commands/exit.rb
@@ -21,8 +21,8 @@ class Pry
       BANNER
 
       def process
-        if _pry_.binding_stack.one?
-          _pry_.run_command "exit-all #{arg_string}"
+        if pry_instance.binding_stack.one?
+          pry_instance.run_command "exit-all #{arg_string}"
         else
           # otherwise just pop a binding and return user supplied value
           process_pop_and_return
@@ -30,7 +30,7 @@ class Pry
       end
 
       def process_pop_and_return
-        popped_object = _pry_.binding_stack.pop.eval('self')
+        popped_object = pry_instance.binding_stack.pop.eval('self')
 
         # return a user-specified value if given otherwise return the object
         return target.eval(arg_string) unless arg_string.empty?

--- a/lib/pry/commands/exit_all.rb
+++ b/lib/pry/commands/exit_all.rb
@@ -18,7 +18,7 @@ class Pry
         exit_value = target.eval(arg_string)
 
         # clear the binding stack
-        _pry_.binding_stack.clear
+        pry_instance.binding_stack.clear
 
         # break out of the repl loop
         throw(:breakout, exit_value)

--- a/lib/pry/commands/help.rb
+++ b/lib/pry/commands/help.rb
@@ -48,7 +48,7 @@ class Pry
           help_text << help_text_for_commands(group_name, commands) if commands.any?
         end
 
-        _pry_.pager.page help_text.join("\n\n")
+        pry_instance.pager.page help_text.join("\n\n")
       end
 
       # Given a group name and an array of commands,
@@ -121,7 +121,7 @@ class Pry
       #
       # @param [Pry::Command] command
       def display_command(command)
-        _pry_.pager.page command.new.help
+        pry_instance.pager.page command.new.help
       end
 
       # Find a subset of a hash that matches the user's search term.

--- a/lib/pry/commands/hist.rb
+++ b/lib/pry/commands/hist.rb
@@ -78,7 +78,7 @@ class Pry
       def process_display
         @history = @history.with_line_numbers unless opts.present?(:'no-numbers')
 
-        _pry_.pager.open do |pager|
+        pry_instance.pager.open do |pager|
           @history.print_to_output(pager, true)
         end
       end
@@ -117,7 +117,7 @@ class Pry
         check_for_juxtaposed_replay(replay_sequence)
 
         replay_sequence.lines.each do |line|
-          _pry_.eval line, generated: true
+          pry_instance.eval line, generated: true
         end
       end
 

--- a/lib/pry/commands/import_set.rb
+++ b/lib/pry/commands/import_set.rb
@@ -16,7 +16,7 @@ class Pry
         raise CommandError, "Provide a command set name" if command_set.nil?
 
         set = target.eval(arg_string)
-        _pry_.commands.import set
+        pry_instance.commands.import set
       end
     end
 

--- a/lib/pry/commands/jump_to.rb
+++ b/lib/pry/commands/jump_to.rb
@@ -11,14 +11,14 @@ class Pry
 
       def process(break_level)
         break_level    = break_level.to_i
-        nesting_level  = _pry_.binding_stack.size - 1
+        nesting_level  = pry_instance.binding_stack.size - 1
         max_nest_level = nesting_level - 1
 
         case break_level
         when nesting_level
           output.puts "Already at nesting level #{nesting_level}"
         when 0..max_nest_level
-          _pry_.binding_stack = _pry_.binding_stack[0..break_level]
+          pry_instance.binding_stack = pry_instance.binding_stack[0..break_level]
         else
           output.puts "Invalid nest level. Must be between 0 and " \
             "#{max_nest_level}. Got #{break_level}."

--- a/lib/pry/commands/list_inspectors.rb
+++ b/lib/pry/commands/list_inspectors.rb
@@ -32,7 +32,7 @@ class Pry
       end
 
       def selected_inspector?(inspector)
-        _pry_.print == inspector[:value]
+        pry_instance.print == inspector[:value]
       end
       Pry::Commands.add_command(self)
     end

--- a/lib/pry/commands/ls.rb
+++ b/lib/pry/commands/ls.rb
@@ -8,7 +8,7 @@ class Pry
         protected_method_color: :blue,
         method_missing_color: :bright_red,
         local_var_color: :yellow,
-        pry_var_color: :default, # e.g. _, _pry_, _file_
+        pry_var_color: :default, # e.g. _, pry_instance, _file_
         instance_var_color: :blue, # e.g. @foo
         class_var_color: :bright_blue, # e.g. @@foo
         global_var_color: :default, # e.g. $CODERAY_DEBUG, $eventmachine_library
@@ -93,10 +93,10 @@ class Pry
           no_user_opts: no_user_opts?,
           opts: opts,
           args: args,
-          _pry_: _pry_
+          pry_instance: pry_instance
         )
 
-        _pry_.pager.page ls_entity.entities_table
+        pry_instance.pager.page ls_entity.entities_table
       end
 
       private

--- a/lib/pry/commands/ls/constants.rb
+++ b/lib/pry/commands/ls/constants.rb
@@ -9,8 +9,8 @@ class Pry
         end
         include Pry::Command::Ls::Interrogatable
 
-        def initialize(interrogatee, no_user_opts, opts, _pry_)
-          super(_pry_)
+        def initialize(interrogatee, no_user_opts, opts, pry_instance)
+          super(pry_instance)
           @interrogatee = interrogatee
           @no_user_opts = no_user_opts
           @default_switch = opts[:constants]

--- a/lib/pry/commands/ls/formatter.rb
+++ b/lib/pry/commands/ls/formatter.rb
@@ -3,11 +3,11 @@ class Pry
     class Ls < Pry::ClassCommand
       class Formatter
         attr_writer :grep
-        attr_reader :_pry_
+        attr_reader :pry_instance
 
-        def initialize(_pry_)
-          @_pry_ = _pry_
-          @target = _pry_.current_context
+        def initialize(pry_instance)
+          @pry_instance = pry_instance
+          @target = pry_instance.current_context
           @default_switch = nil
         end
 
@@ -20,7 +20,7 @@ class Pry
         private
 
         def color(type, str)
-          Pry::Helpers::Text.send _pry_.config.ls["#{type}_color"], str
+          Pry::Helpers::Text.send pry_instance.config.ls["#{type}_color"], str
         end
 
         # Add a new section to the output.
@@ -29,7 +29,7 @@ class Pry
           return '' if body.compact.empty?
 
           fancy_heading = Pry::Helpers::Text.bold(color(:heading, heading))
-          Pry::Helpers.tablify_or_one_line(fancy_heading, body, @_pry_.config)
+          Pry::Helpers.tablify_or_one_line(fancy_heading, body, @pry_instance.config)
         end
 
         def format_value(value)

--- a/lib/pry/commands/ls/globals.rb
+++ b/lib/pry/commands/ls/globals.rb
@@ -19,8 +19,8 @@ class Pry
              $CHILD_STATUS $SAFE $ERROR_INFO $ERROR_POSITION $LAST_MATCH_INFO
              $LAST_PAREN_MATCH $LAST_READ_LINE $MATCH $POSTMATCH $PREMATCH].freeze
 
-        def initialize(opts, _pry_)
-          super(_pry_)
+        def initialize(opts, pry_instance)
+          super(pry_instance)
           @default_switch = opts[:globals]
         end
 

--- a/lib/pry/commands/ls/instance_vars.rb
+++ b/lib/pry/commands/ls/instance_vars.rb
@@ -4,8 +4,8 @@ class Pry
       class InstanceVars < Pry::Command::Ls::Formatter
         include Pry::Command::Ls::Interrogatable
 
-        def initialize(interrogatee, no_user_opts, opts, _pry_)
-          super(_pry_)
+        def initialize(interrogatee, no_user_opts, opts, pry_instance)
+          super(pry_instance)
           @interrogatee = interrogatee
           @no_user_opts = no_user_opts
           @default_switch = opts[:ivars]

--- a/lib/pry/commands/ls/local_names.rb
+++ b/lib/pry/commands/ls/local_names.rb
@@ -2,11 +2,11 @@ class Pry
   class Command
     class Ls < Pry::ClassCommand
       class LocalNames < Pry::Command::Ls::Formatter
-        def initialize(no_user_opts, args, _pry_)
-          super(_pry_)
+        def initialize(no_user_opts, args, pry_instance)
+          super(pry_instance)
           @no_user_opts = no_user_opts
           @args = args
-          @sticky_locals = _pry_.sticky_locals
+          @sticky_locals = pry_instance.sticky_locals
         end
 
         def correct_opts?

--- a/lib/pry/commands/ls/local_vars.rb
+++ b/lib/pry/commands/ls/local_vars.rb
@@ -2,10 +2,10 @@ class Pry
   class Command
     class Ls < Pry::ClassCommand
       class LocalVars < Pry::Command::Ls::Formatter
-        def initialize(opts, _pry_)
-          super(_pry_)
+        def initialize(opts, pry_instance)
+          super(pry_instance)
           @default_switch = opts[:locals]
-          @sticky_locals = _pry_.sticky_locals
+          @sticky_locals = pry_instance.sticky_locals
         end
 
         def output_self

--- a/lib/pry/commands/ls/ls_entity.rb
+++ b/lib/pry/commands/ls/ls_entity.rb
@@ -2,7 +2,7 @@ class Pry
   class Command
     class Ls < Pry::ClassCommand
       class LsEntity
-        attr_reader :_pry_
+        attr_reader :pry_instance
 
         def initialize(opts)
           @interrogatee = opts[:interrogatee]
@@ -10,7 +10,7 @@ class Pry
           @opts = opts[:opts]
           @args = opts[:args]
           @grep = Grep.new(Regexp.new(opts[:opts][:G] || '.'))
-          @_pry_ = opts.delete(:_pry_)
+          @pry_instance = opts.delete(:pry_instance)
         end
 
         def entities_table
@@ -24,31 +24,31 @@ class Pry
         end
 
         def globals
-          grep Globals.new(@opts, _pry_)
+          grep Globals.new(@opts, pry_instance)
         end
 
         def constants
-          grep Constants.new(@interrogatee, @no_user_opts, @opts, _pry_)
+          grep Constants.new(@interrogatee, @no_user_opts, @opts, pry_instance)
         end
 
         def methods
-          grep(Methods.new(@interrogatee, @no_user_opts, @opts, _pry_))
+          grep(Methods.new(@interrogatee, @no_user_opts, @opts, pry_instance))
         end
 
         def self_methods
-          grep SelfMethods.new(@interrogatee, @no_user_opts, @opts, _pry_)
+          grep SelfMethods.new(@interrogatee, @no_user_opts, @opts, pry_instance)
         end
 
         def instance_vars
-          grep InstanceVars.new(@interrogatee, @no_user_opts, @opts, _pry_)
+          grep InstanceVars.new(@interrogatee, @no_user_opts, @opts, pry_instance)
         end
 
         def local_names
-          grep LocalNames.new(@no_user_opts, @args, _pry_)
+          grep LocalNames.new(@no_user_opts, @args, pry_instance)
         end
 
         def local_vars
-          LocalVars.new(@opts, _pry_)
+          LocalVars.new(@opts, pry_instance)
         end
 
         def entities

--- a/lib/pry/commands/ls/methods.rb
+++ b/lib/pry/commands/ls/methods.rb
@@ -5,8 +5,8 @@ class Pry
         include Pry::Command::Ls::Interrogatable
         include Pry::Command::Ls::MethodsHelper
 
-        def initialize(interrogatee, no_user_opts, opts, _pry_)
-          super(_pry_)
+        def initialize(interrogatee, no_user_opts, opts, pry_instance)
+          super(pry_instance)
           @interrogatee = interrogatee
           @no_user_opts = no_user_opts
           @default_switch = opts[:methods]
@@ -39,11 +39,11 @@ class Pry
         def below_ceiling
           ceiling = if @quiet_switch
                       [Pry::Method.safe_send(interrogatee_mod, :ancestors)[1]] +
-                        _pry_.config.ls.ceiling
+                        pry_instance.config.ls.ceiling
                     elsif @verbose_switch
                       []
                     else
-                      _pry_.config.ls.ceiling.dup
+                      pry_instance.config.ls.ceiling.dup
                     end
           ->(klass) { !ceiling.include?(klass) }
         end

--- a/lib/pry/commands/ls/self_methods.rb
+++ b/lib/pry/commands/ls/self_methods.rb
@@ -5,8 +5,8 @@ class Pry
         include Pry::Command::Ls::Interrogatable
         include Pry::Command::Ls::MethodsHelper
 
-        def initialize(interrogatee, no_user_opts, opts, _pry_)
-          super(_pry_)
+        def initialize(interrogatee, no_user_opts, opts, pry_instance)
+          super(pry_instance)
           @interrogatee = interrogatee
           @no_user_opts = no_user_opts
           @ppp_switch = opts[:ppp]

--- a/lib/pry/commands/nesting.rb
+++ b/lib/pry/commands/nesting.rb
@@ -12,7 +12,7 @@ class Pry
       def process
         output.puts 'Nesting status:'
         output.puts '--'
-        _pry_.binding_stack.each_with_index do |obj, level|
+        pry_instance.binding_stack.each_with_index do |obj, level|
           if level == 0
             output.puts "#{level}. #{Pry.view_clip(obj.eval('self'))} (Pry top level)"
           else

--- a/lib/pry/commands/play.rb
+++ b/lib/pry/commands/play.rb
@@ -37,7 +37,7 @@ class Pry
       end
 
       def process
-        @cc = CodeCollector.new(args, opts, _pry_)
+        @cc = CodeCollector.new(args, opts, pry_instance)
 
         perform_play
         show_input

--- a/lib/pry/commands/pry_backtrace.rb
+++ b/lib/pry/commands/pry_backtrace.rb
@@ -18,7 +18,10 @@ class Pry
       BANNER
 
       def process
-        _pry_.pager.page bold('Backtrace:') << "\n--\n" << _pry_.backtrace.join("\n")
+        text = bold('Backtrace:')
+        text << "\n--\n"
+        text << pry_instance.backtrace.join("\n")
+        pry_instance.pager.page(text)
       end
     end
 

--- a/lib/pry/commands/raise_up.rb
+++ b/lib/pry/commands/raise_up.rb
@@ -27,7 +27,7 @@ class Pry
 
         # Handle 'raise-up', 'raise-up "foo"', 'raise-up RuntimeError, 'farble'
         # in a rubyesque manner
-        target.eval("_pry_.raise_up#{captures[0]}")
+        target.eval("pry_instance.raise_up#{captures[0]}")
       end
     end
 

--- a/lib/pry/commands/reload_code.rb
+++ b/lib/pry/commands/reload_code.rb
@@ -47,7 +47,7 @@ class Pry
       end
 
       def reload_object(identifier)
-        code_object = Pry::CodeObject.lookup(identifier, _pry_)
+        code_object = Pry::CodeObject.lookup(identifier, pry_instance)
         check_for_reloadability(code_object, identifier)
         load code_object.source_file
         output.puts "#{identifier} was reloaded!"

--- a/lib/pry/commands/ri.rb
+++ b/lib/pry/commands/ri.rb
@@ -57,7 +57,7 @@ class Pry
 
         # Spin-up an RI insance.
         ri = RDoc::RI::PryDriver.new(
-          _pry_.pager, use_stdout: true, interactive: false
+          pry_instance.pager, use_stdout: true, interactive: false
         )
 
         begin

--- a/lib/pry/commands/save_file.rb
+++ b/lib/pry/commands/save_file.rb
@@ -24,7 +24,7 @@ class Pry
       end
 
       def process
-        @cc = CodeCollector.new(args, opts, _pry_)
+        @cc = CodeCollector.new(args, opts, pry_instance)
         raise CommandError, "Found no code to save." if @cc.content.empty?
 
         if !file_name

--- a/lib/pry/commands/shell_command.rb
+++ b/lib/pry/commands/shell_command.rb
@@ -24,7 +24,7 @@ class Pry
           if command_block
             command_block.call `#{cmd}`
           else
-            _pry_.config.system.call(output, cmd, _pry_)
+            pry_instance.config.system.call(output, cmd, pry_instance)
           end
         end
       end

--- a/lib/pry/commands/shell_mode.rb
+++ b/lib/pry/commands/shell_mode.rb
@@ -13,10 +13,10 @@ class Pry
         state.disabled ^= true
 
         if state.disabled
-          state.prev_prompt = _pry_.prompt
-          _pry_.prompt = Pry::Prompt[:shell]
+          state.prev_prompt = pry_instance.prompt
+          pry_instance.prompt = Pry::Prompt[:shell]
         else
-          _pry_.prompt = state.prev_prompt
+          pry_instance.prompt = state.prev_prompt
         end
       end
     end

--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -22,7 +22,7 @@ class Pry
       end
 
       def process
-        code_object = Pry::CodeObject.lookup(obj_name, _pry_, super: opts[:super])
+        code_object = Pry::CodeObject.lookup(obj_name, pry_instance, super: opts[:super])
         raise CommandError, no_definition_message unless code_object
 
         @original_code_object = code_object
@@ -47,7 +47,7 @@ class Pry
         end
 
         set_file_and_dir_locals(code_object.source_file)
-        _pry_.pager.page result
+        pry_instance.pager.page result
       end
 
       # This method checks whether the `code_object` is a WrappedModule, if it

--- a/lib/pry/commands/switch_to.rb
+++ b/lib/pry/commands/switch_to.rb
@@ -12,12 +12,12 @@ class Pry
       def process(selection)
         selection = selection.to_i
 
-        if selection < 0 || selection > _pry_.binding_stack.size - 1
+        if selection < 0 || selection > pry_instance.binding_stack.size - 1
           raise CommandError,
                 "Invalid binding index #{selection} - use `nesting` command " \
                 "to view valid indices."
         else
-          Pry.start(_pry_.binding_stack[selection])
+          Pry.start(pry_instance.binding_stack[selection])
         end
       end
     end

--- a/lib/pry/commands/toggle_color.rb
+++ b/lib/pry/commands/toggle_color.rb
@@ -12,12 +12,12 @@ class Pry
       BANNER
 
       def process
-        _pry_.color = color_toggle
-        output.puts "Syntax highlighting #{_pry_.color ? 'on' : 'off'}"
+        pry_instance.color = color_toggle
+        output.puts "Syntax highlighting #{pry_instance.color ? 'on' : 'off'}"
       end
 
       def color_toggle
-        !_pry_.color
+        !pry_instance.color
       end
 
       Pry::Commands.add_command(self)

--- a/lib/pry/commands/watch_expression.rb
+++ b/lib/pry/commands/watch_expression.rb
@@ -51,7 +51,7 @@ class Pry
       private
 
       def expressions
-        _pry_.config.watch_expressions ||= []
+        pry_instance.config.watch_expressions ||= []
       end
 
       def delete(index)
@@ -68,7 +68,7 @@ class Pry
         if expressions.empty?
           output.puts "No watched expressions"
         else
-          _pry_.pager.open do |pager|
+          pry_instance.pager.open do |pager|
             pager.puts "Listing all watched expressions:"
             pager.puts ""
             expressions.each_with_index do |expr, index|
@@ -89,15 +89,15 @@ class Pry
       # TODO: fix arguments.
       # https://github.com/pry/pry/commit/b031df2f2f5850ee6e9018f33d35f3485a9b0423
       def add_expression(_arguments)
-        expressions << Expression.new(_pry_, target, arg_string)
+        expressions << Expression.new(pry_instance, target, arg_string)
         output.puts "Watching #{Code.new(arg_string).highlighted}"
       end
 
       def add_hook
         hook = [:after_eval, :watch_expression]
-        unless _pry_.hooks.hook_exists?(*hook)
-          _pry_.hooks.add_hook(*hook) do |_, _pry_|
-            eval_and_print_changed _pry_.output
+        unless pry_instance.hooks.hook_exists?(*hook)
+          pry_instance.hooks.add_hook(*hook) do |_, pry_instance|
+            eval_and_print_changed pry_instance.output
           end
         end
       end

--- a/lib/pry/commands/watch_expression/expression.rb
+++ b/lib/pry/commands/watch_expression/expression.rb
@@ -2,10 +2,10 @@ class Pry
   class Command
     class WatchExpression
       class Expression
-        attr_reader :target, :source, :value, :previous_value, :_pry_
+        attr_reader :target, :source, :value, :previous_value, :pry_instance
 
-        def initialize(_pry_, target, source)
-          @_pry_ = _pry_
+        def initialize(pry_instance, target, source)
+          @pry_instance = pry_instance
           @target = target
           @source = Code.new(source).strip
         end

--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -104,7 +104,7 @@ class Pry
         pretty_code = code.with_line_numbers(use_line_numbers?)
           .with_marker(marker)
           .highlighted
-        _pry_.pager.page(
+        pry_instance.pager.page(
           "\n#{bold('From:')} #{location}:\n\n" << pretty_code << "\n"
         )
       end
@@ -192,7 +192,7 @@ class Pry
 
       def window_size
         if args.empty?
-          _pry_.config.default_window_size
+          pry_instance.config.default_window_size
         else
           args.first.to_i
         end

--- a/lib/pry/commands/wtf.rb
+++ b/lib/pry/commands/wtf.rb
@@ -51,7 +51,7 @@ class Pry
       private
 
       def exception
-        _pry_.last_exception
+        pry_instance.last_exception
       end
 
       def with_line_numbers(bt)

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -17,9 +17,9 @@ class Pry
         prompt: Pry::Prompt[:default],
         prompt_safe_contexts: Pry::Prompt::SAFE_CONTEXTS,
 
-        print: proc do |_output, value, _pry_|
-          _pry_.pager.open do |pager|
-            pager.print _pry_.config.output_prefix
+        print: proc do |_output, value, pry_instance|
+          pry_instance.pager.open do |pager|
+            pager.print pry_instance.config.output_prefix
             Pry::ColorPrinter.pp(value, pager, Pry::Terminal.width! - 1)
           end
         end,
@@ -61,10 +61,10 @@ class Pry
         # sessions.
         hooks: Pry::Hooks.new.add_hook(
           :before_session, :default
-        ) do |_out, _target, _pry_|
-          next if _pry_.quiet?
+        ) do |_out, _target, pry_instance|
+          next if pry_instance.quiet?
 
-          _pry_.run_command('whereami --quiet')
+          pry_instance.run_command('whereami --quiet')
         end,
 
         pager: true,
@@ -98,18 +98,18 @@ class Pry
         #   1. In an expression behave like `!` command.
         #   2. At top-level session behave like `exit` command.
         #   3. In a nested session behave like `cd ..`.
-        control_d_handler: proc do |eval_string, _pry_|
+        control_d_handler: proc do |eval_string, pry_instance|
           if !eval_string.empty?
             eval_string.replace('') # Clear input buffer.
-          elsif _pry_.binding_stack.one?
-            _pry_.binding_stack.clear
+          elsif pry_instance.binding_stack.one?
+            pry_instance.binding_stack.clear
             throw(:breakout)
           else
             # Otherwise, saves current binding stack as old stack and pops last
             # binding out of binding stack (the old stack still has that binding).
-            _pry_.command_state["cd"] ||= Pry::Config.from_hash({})
-            _pry_.command_state['cd'].old_stack = _pry_.binding_stack.dup
-            _pry_.binding_stack.pop
+            pry_instance.command_state["cd"] ||= Pry::Config.from_hash({})
+            pry_instance.command_state['cd'].old_stack = pry_instance.binding_stack.dup
+            pry_instance.binding_stack.pop
           end
         end,
 

--- a/lib/pry/config/behavior.rb
+++ b/lib/pry/config/behavior.rb
@@ -178,9 +178,9 @@ class Pry
       # traverse back to {#default}.
       #
       # @example
-      #   _pry_.config.prompt_name = 'foo'
-      #   _pry_.config.forget(:prompt_name)
-      #   _pry_.config.prompt_name # => 'pry'
+      #   pry_instance.config.prompt_name = 'foo'
+      #   pry_instance.config.forget(:prompt_name)
+      #   pry_instance.config.prompt_name # => 'pry'
       #
       # @param [#to_s] key
       #
@@ -268,12 +268,12 @@ class Pry
       # Eagerly loads keys into self directly from {#last_default}.
       #
       # @example
-      #  [1] pry(main)> _pry_.config.keys.size
+      #  [1] pry(main)> pry_instance.config.keys.size
       #  => 13
-      #  [2] pry(main)> _pry_.config.eager_load!;
+      #  [2] pry(main)> pry_instance.config.eager_load!;
       #  [warning] Pry.config.exception_whitelist is deprecated,
       #  please use Pry.config.unrescued_exceptions instead.
-      #  [3] pry(main)> _pry_.config.keys.size
+      #  [3] pry(main)> pry_instance.config.keys.size
       #  => 40
       #
       # @return [Array<String>, nil]
@@ -287,8 +287,8 @@ class Pry
 
       #
       # @example
-      #   # _pry_.config -> Pry.config -> Pry::Config.defaults
-      #   [1] pry(main)> _pry_.config.last_default
+      #   # pry_instance.config -> Pry.config -> Pry::Config.defaults
+      #   [1] pry(main)> pry_instance.config.last_default
       #
       # @return [Pry::Config::Behaviour]
       #   The last linked default, or nil if there is none.

--- a/lib/pry/config/lazy.rb
+++ b/lib/pry/config/lazy.rb
@@ -6,10 +6,10 @@ class Pry
     #
     # @example
     #   num = 19
-    #   _pry_.config.foo = Pry::Config::Lazy.new(&proc { num += 1 })
-    #   _pry_.config.foo # => 20
-    #   _pry_.config.foo # => 21
-    #   _pry_.config.foo # => 22
+    #   pry_instance.config.foo = Pry::Config::Lazy.new(&proc { num += 1 })
+    #   pry_instance.config.foo # => 20
+    #   pry_instance.config.foo # => 21
+    #   pry_instance.config.foo # => 22
     #
     # @api private
     # @since v0.12.0

--- a/lib/pry/editor.rb
+++ b/lib/pry/editor.rb
@@ -4,10 +4,10 @@ class Pry
   class Editor
     include Pry::Helpers::CommandHelpers
 
-    attr_reader :_pry_
+    attr_reader :pry_instance
 
-    def initialize(_pry_)
-      @_pry_ = _pry_
+    def initialize(pry_instance)
+      @pry_instance = pry_instance
     end
 
     def edit_tempfile_with_content(initial_content, line = 1)
@@ -21,7 +21,7 @@ class Pry
     end
 
     def invoke_editor(file, line, blocking = true)
-      unless _pry_.config.editor
+      unless pry_instance.config.editor
         raise CommandError,
               "Please set Pry.config.editor or export $VISUAL or $EDITOR"
       end
@@ -42,12 +42,12 @@ class Pry
     # all the flags we want as well as the file and line number we
     # want to open at.
     def build_editor_invocation_string(file, line, blocking)
-      if _pry_.config.editor.respond_to?(:call)
-        args = [file, line, blocking][0...(_pry_.config.editor.arity)]
-        _pry_.config.editor.call(*args)
+      if pry_instance.config.editor.respond_to?(:call)
+        args = [file, line, blocking][0...(pry_instance.config.editor.arity)]
+        pry_instance.config.editor.call(*args)
       else
         sanitized_file = Helpers::Platform.windows? ? file : Shellwords.escape(file)
-        editor = _pry_.config.editor
+        editor = pry_instance.config.editor
         flag = blocking_flag_for_editor(blocking)
         start_line = start_line_syntax_for_editor(sanitized_file, line)
         "#{editor} #{flag} #{start_line}"
@@ -131,7 +131,7 @@ class Pry
     #   # => textmate
     #
     def editor_name
-      File.basename(_pry_.config.editor).split(" ").first
+      File.basename(pry_instance.config.editor).split(" ").first
     end
   end
 end

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -60,8 +60,8 @@ class Pry
       # enabled). Infers where to send the output if used as a mixin.
       # DEPRECATED.
       def stagger_output(text, _out = nil)
-        if defined?(_pry_) && _pry_
-          _pry_.pager.page text
+        if defined?(pry_instance) && pry_instance
+          pry_instance.pager.page text
         else
           Pry.new.pager.page text
         end

--- a/lib/pry/helpers/command_helpers.rb
+++ b/lib/pry/helpers/command_helpers.rb
@@ -155,7 +155,7 @@ class Pry
         Range.new(a, b)
       end
 
-      def set_file_and_dir_locals(file_name, pry = _pry_, ctx = target)
+      def set_file_and_dir_locals(file_name, pry = pry_instance, ctx = target)
         return if !ctx || !file_name
 
         pry.last_file = File.expand_path(file_name)

--- a/lib/pry/output.rb
+++ b/lib/pry/output.rb
@@ -1,10 +1,10 @@
 class Pry
   class Output
-    attr_reader :_pry_
+    attr_reader :pry_instance
 
-    def initialize(_pry_)
-      @_pry_ = _pry_
-      @boxed_io = _pry_.config.output
+    def initialize(pry_instance)
+      @pry_instance = pry_instance
+      @boxed_io = pry_instance.config.output
     end
 
     def puts(*objs)
@@ -42,7 +42,7 @@ class Pry
     end
 
     def decolorize_maybe(str)
-      if _pry_.config.color
+      if pry_instance.config.color
         str
       else
         Pry::Helpers::Text.strip_color str

--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -6,10 +6,10 @@ class Pry
     class StopPaging < StandardError
     end
 
-    attr_reader :_pry_
+    attr_reader :pry_instance
 
-    def initialize(_pry_)
-      @_pry_ = _pry_
+    def initialize(pry_instance)
+      @pry_instance = pry_instance
     end
 
     # Send the given text through the best available pager (if
@@ -52,12 +52,12 @@ class Pry
     # you must rescue `Pry::Pager::StopPaging`. These requirements can be
     # avoided by using `.open` instead.
     def best_available
-      if !_pry_.config.pager
-        NullPager.new(_pry_.output)
+      if !pry_instance.config.pager
+        NullPager.new(pry_instance.output)
       elsif !SystemPager.available? || Helpers::Platform.jruby?
-        SimplePager.new(_pry_.output)
+        SimplePager.new(pry_instance.output)
       else
-        SystemPager.new(_pry_.output)
+        SystemPager.new(pry_instance.output)
       end
     end
 

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -151,7 +151,7 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
 
     @initial_session = false
 
-    # note these have to be loaded here rather than in pry_instance as
+    # note these have to be loaded here rather than in _pry_ as
     # we only want them loaded once per entire Pry lifetime.
     load_rc_files
   end

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -210,7 +210,7 @@ class Pry
     {
       _in_: input_ring,
       _out_: output_ring,
-      _pry_: self,
+      pry_instance: self,
       _ex_: last_exception && last_exception.wrapped_exception,
       _file_: last_file,
       _dir_: last_dir,
@@ -253,7 +253,7 @@ class Pry
       exit_value = catch(:breakout) do
         handle_line(line, options)
         # We use 'return !@stopped' here instead of 'return true' so that if
-        # handle_line has stopped this pry instance (e.g. by opening _pry_.repl and
+        # handle_line has stopped this pry instance (e.g. by opening pry_instance.repl and
         # then popping all the bindings) we still exit immediately.
         return !@stopped
       end
@@ -482,7 +482,7 @@ class Pry
       hooks.errors[e_before..-1].each do |e|
         output.puts "#{name} hook failed: #{e.class}: #{e.message}"
         output.puts e.backtrace.first.to_s
-        output.puts "(see _pry_.hooks.errors to debug)"
+        output.puts "(see pry_instance.hooks.errors to debug)"
       end
     end
   end
@@ -550,7 +550,7 @@ class Pry
       session_line: Pry.history.session_line_count + 1,
       history_line: Pry.history.history_line_count + 1,
       expr_number: input_ring.count,
-      _pry_: self,
+      pry_instance: self,
       binding_stack: binding_stack,
       input_ring: input_ring,
       eval_string: @eval_string,
@@ -562,7 +562,7 @@ class Pry
       # prompt (indicating multi-line expression).
       if prompt.is_a?(Pry::Prompt)
         prompt_proc = eval_string.empty? ? prompt.wait_proc : prompt.incomplete_proc
-        return prompt_proc.call(c.object, c.nesting_level, c._pry_)
+        return prompt_proc.call(c.object, c.nesting_level, c.pry_instance)
       end
 
       unless @prompt_warn
@@ -588,7 +588,7 @@ class Pry
     if prompt_proc.arity == 1
       prompt_proc.call(conf)
     else
-      prompt_proc.call(conf.object, conf.nesting_level, conf._pry_)
+      prompt_proc.call(conf.object, conf.nesting_level, conf.pry_instance)
     end
   end
   private :generate_prompt
@@ -630,7 +630,7 @@ class Pry
   undef :pager if method_defined? :pager
   # Returns the currently configured pager
   # @example
-  #   _pry_.pager.page text
+  #   pry_instance.pager.page text
   def pager
     Pry::Pager.new(self)
   end
@@ -638,7 +638,7 @@ class Pry
   undef :output if method_defined? :output
   # Returns an output device
   # @example
-  #   _pry_.output.puts "ohai!"
+  #   pry_instance.output.puts "ohai!"
   def output
     Pry::Output.new(self)
   end

--- a/lib/pry/repl_file_loader.rb
+++ b/lib/pry/repl_file_loader.rb
@@ -20,35 +20,35 @@ class Pry
 
     # Switch to interactive mode, i.e take input from the user
     # and use the regular print and exception handlers.
-    # @param [Pry] _pry_ the Pry instance to make interactive.
-    def interactive_mode(_pry_)
-      _pry_.config.input = Pry.config.input
-      _pry_.config.print = Pry.config.print
-      _pry_.config.exception_handler = Pry.config.exception_handler
-      Pry::REPL.new(_pry_).start
+    # @param [Pry] pry_instance the Pry instance to make interactive.
+    def interactive_mode(pry_instance)
+      pry_instance.config.input = Pry.config.input
+      pry_instance.config.print = Pry.config.print
+      pry_instance.config.exception_handler = Pry.config.exception_handler
+      Pry::REPL.new(pry_instance).start
     end
 
     # Switch to non-interactive mode. Essentially
     # this means there is no result output
     # and that the session becomes interactive when an exception is encountered.
-    # @param [Pry] _pry_ the Pry instance to make non-interactive.
-    def non_interactive_mode(_pry_, content)
-      _pry_.print = proc {}
-      _pry_.exception_handler = proc do |o, _e, _p_|
+    # @param [Pry] pry_instance the Pry instance to make non-interactive.
+    def non_interactive_mode(pry_instance, content)
+      pry_instance.print = proc {}
+      pry_instance.exception_handler = proc do |o, _e, _p_|
         _p_.run_command "cat --ex"
         o.puts "...exception encountered, going interactive!"
-        interactive_mode(_pry_)
+        interactive_mode(pry_instance)
       end
 
       content.lines.each do |line|
-        break unless _pry_.eval line, generated: true
+        break unless pry_instance.eval line, generated: true
       end
 
-      unless _pry_.eval_string.empty?
-        _pry_.output.puts(
-          "#{_pry_.eval_string}...exception encountered, going interactive!"
+      unless pry_instance.eval_string.empty?
+        pry_instance.output.puts(
+          "#{pry_instance.eval_string}...exception encountered, going interactive!"
         )
-        interactive_mode(_pry_)
+        interactive_mode(pry_instance)
       end
     end
 
@@ -58,13 +58,13 @@ class Pry
       s = self
 
       Pry::Commands.command "make-interactive", "Make the session interactive" do
-        s.interactive_mode(_pry_)
+        s.interactive_mode(pry_instance)
       end
 
       Pry::Commands.command(
         "load-file", "Load another file through the repl"
       ) do |file_name|
-        s.non_interactive_mode(_pry_, File.read(File.expand_path(file_name)))
+        s.non_interactive_mode(pry_instance, File.read(File.expand_path(file_name)))
       end
     end
 

--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -4,9 +4,9 @@ describe "commands" do
     @o = Object.new
 
     # Shortcuts. They save a lot of typing.
-    @bs1 = "Pad.bs1 = _pry_.binding_stack.dup"
-    @bs2 = "Pad.bs2 = _pry_.binding_stack.dup"
-    @bs3 = "Pad.bs3 = _pry_.binding_stack.dup"
+    @bs1 = "Pad.bs1 = pry_instance.binding_stack.dup"
+    @bs2 = "Pad.bs2 = pry_instance.binding_stack.dup"
+    @bs3 = "Pad.bs3 = pry_instance.binding_stack.dup"
 
     @self = "Pad.self = self"
 
@@ -223,7 +223,7 @@ describe "commands" do
 
     it 'should run a command in the context of a session' do
       pry_tester(Object.new).tap do |t|
-        t.eval "@session_ivar = 10", "_pry_.run_command('ls')"
+        t.eval "@session_ivar = 10", "pry_instance.run_command('ls')"
         expect(t.last_output).to match(/@session_ivar/)
       end
     end
@@ -372,7 +372,7 @@ describe "commands" do
     expect(tester.eval(*<<-RUBY.split("\n"))).to match(/instance variables:\s+@x/m)
       @x = nil
       cd 7
-      _pry_.commands.instance_eval { command('bing') { |arg| run arg } }
+      pry_instance.commands.instance_eval { command('bing') { |arg| run arg } }
       cd ..
       bing ls
     RUBY

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -634,7 +634,7 @@ describe Pry::CommandSet do
       expect(inside.eval_string).to eq(ctx[:eval_string])
       expect(inside.output).to eq(ctx[:output])
       expect(inside.target).to eq(ctx[:target])
-      expect(inside._pry_).to eq(ctx[:pry_instance])
+      expect(inside.pry_instance).to eq(ctx[:pry_instance])
     end
 
     it 'should add command_set to context' do

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -164,7 +164,7 @@ describe "Pry::Command" do
 
         expect(inside.eval_string).to eq("eval-string")
         expect(inside.__send__(:command_set)).to eq(@set)
-        expect(inside._pry_).to eq(context[:pry_instance])
+        expect(inside.pry_instance).to eq(context[:pry_instance])
       end
     end
   end

--- a/spec/commands/cat_spec.rb
+++ b/spec/commands/cat_spec.rb
@@ -82,7 +82,7 @@ describe "cat" do
         begin
           this raises error
         rescue => e
-          _pry_.last_exception = e
+          pry_instance.last_exception = e
         end
       EOS
       expect(@t.eval('cat --ex')).to match(/\d+:(\s*) this raises error/)

--- a/spec/commands/cd_spec.rb
+++ b/spec/commands/cd_spec.rb
@@ -133,7 +133,7 @@ describe 'cd' do
     describe 'when using ^D (Control-D) key press' do
       it 'should keep correct old binding' do
         @t.eval 'cd :john_dogg', 'cd :mon_dogg', 'cd :kyr_dogg',
-                'Pry::Config.defaults.control_d_handler.call("", _pry_)'
+                'Pry::Config.defaults.control_d_handler.call("", pry_instance)'
         expect(@t.mapped_binding_stack).to eq [@o, :john_dogg, :mon_dogg]
 
         @t.eval 'cd -'

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -219,7 +219,7 @@ describe "edit" do
         Pad.le = @t.last_exception
         redirect_pry_io(InputTester.new("def broken_method", "binding.pry", "end",
                                         "broken_method",
-                                        "_pry_.last_exception = Pad.le",
+                                        "pry_instance.last_exception = Pad.le",
                                         "edit --ex -n", "exit-all", "exit-all")) do
           Object.new.pry
         end

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -42,7 +42,7 @@ describe "hist" do
     @hist.push "cd 2"
 
     @t.eval("hist --replay 0..2")
-    stack = @t.eval("Pad.stack = _pry_.binding_stack.dup")
+    stack = @t.eval("Pad.stack = pry_instance.binding_stack.dup")
     expect(stack.map { |b| b.eval("self") }).to eq [TOPLEVEL_BINDING.eval("self"), 1, 2]
   end
 

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -247,7 +247,7 @@ describe "ls" do
   describe "when no arguments given" do
     describe "when at the top-level" do
       it "should show local variables" do
-        expect(pry_eval("ls")).to match(/_pry_/)
+        expect(pry_eval("ls")).to match(/pry_instance/)
         expect(pry_eval("arbitrar = 1", "ls")).to match(/arbitrar/)
       end
     end

--- a/spec/commands/play_spec.rb
+++ b/spec/commands/play_spec.rb
@@ -15,14 +15,14 @@ describe "play" do
       # end
 
       # describe "integer" do
-      #   it "should process one line from _pry_.last_file" do
+      #   it "should process one line from pry_instance.last_file" do
       #     @t.process_command 'play --lines 1', @eval_str
       #     @eval_str.should =~ /bing = :bing\n/
       #   end
       # end
 
       # describe "range" do
-      #   it "should process multiple lines at once from _pry_.last_file" do
+      #   it "should process multiple lines at once from pry_instance.last_file" do
       #     @t.process_command 'play --lines 1..3', @eval_str
       #     [/bing = :bing\n/, /bang = :bang\n/, /bong = :bong\n/].each { |str|
       #       @eval_str.should =~ str

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -148,7 +148,7 @@ describe "show-doc" do
       expect(t.eval("show-doc _c#initialize")).to match(/_c.new :foo/)
       # I don't want the test to rely on which colour codes are there, just to
       # assert that "something" is being colourized.
-      t.eval("_pry_.color = true")
+      t.eval("pry_instance.color = true")
       expect(t.eval("show-doc _c#initialize")).not_to match(/_c.new :foo/)
     end
 
@@ -164,7 +164,7 @@ describe "show-doc" do
       expect(t.eval("show-doc _c#initialize")).to match(/_c.new\(:foo\)/)
       # I don't want the test to rely on which colour codes are there, just to
       # assert that "something" is being colourized.
-      t.eval("_pry_.color = true")
+      t.eval("pry_instance.color = true")
       expect(t.eval("show-doc _c#initialize")).not_to match(/_c.new\(:foo\)/)
     end
 

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -759,7 +759,7 @@ describe "show-source" do
 
       it 'should show source for a command defined inside pry' do
         pry_eval %{
-          _pry_.commands.create_command "foo", "babble" do
+          pry_instance.commands.create_command "foo", "babble" do
             def process() :body_of_foo end
           end
         }

--- a/spec/control_d_handler_spec.rb
+++ b/spec/control_d_handler_spec.rb
@@ -2,7 +2,7 @@ describe 'Pry::Config.defaults.control_d_handler' do
   describe "control-d press" do
     before do
       # Simulates a ^D press.
-      @control_d = "Pry::Config.defaults.control_d_handler.call('', _pry_)"
+      @control_d = "Pry::Config.defaults.control_d_handler.call('', pry_instance)"
     end
 
     describe "in an expression" do
@@ -26,14 +26,14 @@ describe 'Pry::Config.defaults.control_d_handler' do
       it 'should pop last binding from the binding stack' do
         t = pry_tester
         t.eval "cd Object.new"
-        expect(t.eval("_pry_.binding_stack.size")).to eq 2
-        expect(t.eval("_pry_.eval(nil)")).to equal true
-        expect(t.eval("_pry_.binding_stack.size")).to eq 1
+        expect(t.eval("pry_instance.binding_stack.size")).to eq 2
+        expect(t.eval("pry_instance.eval(nil)")).to equal true
+        expect(t.eval("pry_instance.binding_stack.size")).to eq 1
       end
 
       it "breaks out of the parent session" do
         ReplTester.start do
-          input  'Pry::REPL.new(_pry_, :target => 10).start'
+          input  'Pry::REPL.new(pry_instance, :target => 10).start'
           output ''
           prompt(/10.*> $/)
 

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -366,8 +366,10 @@ describe Pry::Hooks do
         o = Object.new
         class << o; attr_accessor :value; end
 
-        Pry.config.hooks.add_hook(:when_started, :test_hook) do |_target, _opt, _pry_|
-          _pry_.binding_stack = [Pry.binding_for(o)]
+        Pry.config.hooks.add_hook(
+          :when_started, :test_hook
+        ) do |_target, _opt, pry_instance|
+          pry_instance.binding_stack = [Pry.binding_for(o)]
         end
 
         redirect_pry_io(InputTester.new("@value = true", "exit-all")) do

--- a/spec/pry_repl_spec.rb
+++ b/spec/pry_repl_spec.rb
@@ -28,7 +28,7 @@ describe Pry::REPL do
   describe "eval_string and binding_stack" do
     it "shouldn't break if we start a nested REPL" do
       ReplTester.start do
-        input  'Pry::REPL.new(_pry_, :target => 10).start'
+        input  'Pry::REPL.new(pry_instance, :target => 10).start'
         output ''
         prompt(/10.*> $/)
 
@@ -45,7 +45,7 @@ describe Pry::REPL do
 
     it "shouldn't break if we start a nested instance" do
       ReplTester.start do
-        input  'Pry.start(10, _pry_.config)'
+        input  'Pry.start(10, pry_instance.config)'
         output ''
         prompt(/10.*> $/)
 
@@ -66,11 +66,11 @@ describe Pry::REPL do
         output ''
         prompt(/10.*> $/)
 
-        input '_pry_.binding_stack.pop'
+        input 'pry_instance.binding_stack.pop'
         output(/^=> #<Binding/)
         prompt(/main.*> $/)
 
-        input '_pry_.binding_stack.pop'
+        input 'pry_instance.binding_stack.pop'
         output(/^=> #<Binding/)
         assert_exited
       end

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -341,7 +341,7 @@ describe Pry do
         it 'should nest properly' do
           Pry.config.input = InputTester.new(
             "cd 1", "cd 2", "cd 3",
-            "\"nest:\#\{(_pry_.binding_stack.size - 1)\}\"", "exit-all"
+            "\"nest:\#\{(pry_instance.binding_stack.size - 1)\}\"", "exit-all"
           )
 
           Pry.config.output = @str_output

--- a/spec/sticky_locals_spec.rb
+++ b/spec/sticky_locals_spec.rb
@@ -1,17 +1,19 @@
 describe "Sticky locals (_file_ and friends)" do
   it 'locals should all exist upon initialization' do
-    expect { pry_eval '_file_', '_dir_', '_ex_', '_pry_', '_' }.to_not raise_error
+    expect { pry_eval '_file_', '_dir_', '_ex_', 'pry_instance', '_' }
+      .to_not raise_error
   end
 
   it 'locals should still exist after cd-ing into a new context' do
-    expect { pry_eval 'cd 0', '_file_', '_dir_', '_ex_', '_pry_', '_' }.to_not raise_error
+    expect { pry_eval('cd 0', '_file_', '_dir_', '_ex_', 'pry_instance', '_') }
+      .to_not raise_error
   end
 
-  it 'locals should keep value after cd-ing (_pry_)' do
+  it 'locals should keep value after cd-ing (pry_instance)' do
     pry_tester.tap do |t|
-      pry = t.eval '_pry_'
+      pry = t.eval 'pry_instance'
       t.eval 'cd 0'
-      expect(t.eval('_pry_')).to eq(pry)
+      expect(t.eval('pry_instance')).to eq(pry)
     end
   end
 
@@ -157,13 +159,13 @@ describe "Sticky locals (_file_ and friends)" do
 
     it 'should create a new sticky local' do
       t = pry_tester
-      t.eval "_pry_.add_sticky_local(:test_local){ :test_value }"
+      t.eval "pry_instance.add_sticky_local(:test_local){ :test_value }"
       expect(t.eval("test_local")).to eq(:test_value)
     end
 
     it 'should still exist after cd-ing into new binding' do
       t = pry_tester
-      t.eval "_pry_.add_sticky_local(:test_local){ :test_value }"
+      t.eval "pry_instance.add_sticky_local(:test_local){ :test_value }"
       t.eval "cd Object.new"
       expect(t.eval("test_local")).to eq(:test_value)
     end


### PR DESCRIPTION
Although `_pry_` is a well-established name, it is confusing. `pry_instance` is
a clearer name (arguably the best name). This change was dictated by Rubocop but
I support it. Therefore, I decided to do it, but I realise it's a big change.

`Pry::Command` deprecates `_pry_` and emits a warning. This seems to be the only
place where `_pry_` is used publicly.

Another place where it may affect the user is the sticky locals area. I don't
think it will be a big issue there, though.