### PR TITLE
Factor out all CodeRay code to Pry::SyntaxHighlighter

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -15,6 +15,7 @@ require 'pry/hooks'
 require 'pry/input_completer'
 require 'pry/command'
 require 'pry/command_set'
+require 'pry/syntax_highlighter'
 
 Pry::Commands = Pry::CommandSet.new unless defined?(Pry::Commands)
 

--- a/lib/pry/code/code_file.rb
+++ b/lib/pry/code/code_file.rb
@@ -82,8 +82,8 @@ class Pry
     # @param [String] filename
     # @param [Symbol] default (:unknown) the file type to assume if none could be
     #   detected.
-    # @return [Symbol, nil] The CodeRay type of a file from its extension, or
-    #   `nil` if `:unknown`.
+    # @return [Symbol, nil] The SyntaxHighlighter type of a file from its
+    #   extension, or `nil` if `:unknown`.
     def type_from_filename(filename, default = :unknown)
       _, @code_type = EXTENSIONS.find do |k, _|
         k.any? { |ext| ext == File.extname(filename) }

--- a/lib/pry/code/loc.rb
+++ b/lib/pry/code/loc.rb
@@ -54,7 +54,7 @@ class Pry
       # @param [Symbol] code_type
       # @return [void]
       def colorize(code_type)
-        tuple[0] = CodeRay.scan(line, code_type).term
+        tuple[0] = SyntaxHighlighter.highlight(line, code_type)
       end
 
       # Prepends the line number `lineno` to the `line`.

--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -4,16 +4,16 @@ require 'coderay'
 # PP subclass for streaming inspect output in color.
 class Pry
   class ColorPrinter < ::PP
+    Pry::SyntaxHighlighter.overwrite_coderay_comment_token!
+
     OBJ_COLOR = begin
-      code = CodeRay::Encoders::Terminal::TOKEN_COLORS[:keyword]
+      code = Pry::SyntaxHighlighter.keyword_token_color
       if code.start_with? "\e"
         code
       else
         "\e[0m\e[0;#{code}m"
       end
     end
-
-    CodeRay::Encoders::Terminal::TOKEN_COLORS[:comment][:self] = "\e[1;34m"
 
     def self.pp(obj, out = $DEFAULT_OUTPUT, width = 79, newline = "\n")
       q = ColorPrinter.new(out, width, newline)
@@ -29,7 +29,7 @@ class Pry
       elsif str.start_with?('#<') || str == '=' || str == '>'
         super highlight_object_literal(str), width
       else
-        super CodeRay.scan(str, :ruby).term, width
+        super(SyntaxHighlighter.highlight(str), width)
       end
     end
 

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -40,7 +40,7 @@ class Pry
       end
 
       def colorize_code(code)
-        CodeRay.scan(code, :ruby).term
+        SyntaxHighlighter.highlight(code)
       end
 
       def highlight(string, regexp, highlight_color = :bright_yellow)

--- a/lib/pry/helpers/documentation_helpers.rb
+++ b/lib/pry/helpers/documentation_helpers.rb
@@ -14,7 +14,9 @@ class Pry
 
       def process_rdoc(comment)
         comment = comment.dup
-        last_match_ruby = proc { CodeRay.scan(Regexp.last_match(1), :ruby).term }
+        last_match_ruby = proc do
+          SyntaxHighlighter.highlight(Regexp.last_match(1))
+        end
         comment.gsub(%r{<code>(?:\s*\n)?(.*?)\s*</code>}m, &last_match_ruby)
           .gsub(%r{<em>(?:\s*\n)?(.*?)\s*</em>}m) { "\e[1m#{Regexp.last_match(1)}\e[0m" }
           .gsub(%r{<i>(?:\s*\n)?(.*?)\s*</i>}m) { "\e[1m#{Regexp.last_match(1)}\e[0m" }

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -280,7 +280,7 @@ class Pry
     # @param [String] string The Ruby to lex
     # @return [Array] An Array of pairs of [token_value, token_type]
     def tokenize(string)
-      tokens = CodeRay.scan(string, :ruby)
+      tokens = SyntaxHighlighter.tokenize(string)
       tokens = tokens.tokens.each_slice(2) if tokens.respond_to?(:tokens) # Coderay 1.0.0
       tokens.to_a
     end

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -557,7 +557,7 @@ class Pry
     def method_name_from_first_line(first_ln)
       return nil if first_ln.strip !~ /^def /
 
-      tokens = CodeRay.scan(first_ln, :ruby)
+      tokens = SyntaxHighlighter.tokenize(first_ln)
       tokens = tokens.tokens.each_slice(2) if tokens.respond_to?(:tokens)
       tokens.each_cons(2) do |t1, t2|
         if t2.last == :method || t2.last == :ident && t1 == [".", :operator]

--- a/lib/pry/syntax_highlighter.rb
+++ b/lib/pry/syntax_highlighter.rb
@@ -1,0 +1,24 @@
+require 'coderay'
+
+class Pry
+  # @api private
+  # @since ?.?.?
+  class SyntaxHighlighter
+    def self.highlight(code, language = :ruby)
+      tokenize(code, language).term
+    end
+
+    def self.tokenize(code, language = :ruby)
+      CodeRay.scan(code, language)
+    end
+
+    def self.keyword_token_color
+      CodeRay::Encoders::Terminal::TOKEN_COLORS[:keyword]
+    end
+
+    # Sets comment token to blue (black by default), so it's more legible.
+    def self.overwrite_coderay_comment_token!
+      CodeRay::Encoders::Terminal::TOKEN_COLORS[:comment][:self] = "\e[1;34m"
+    end
+  end
+end

--- a/spec/pager_spec.rb
+++ b/spec/pager_spec.rb
@@ -23,7 +23,7 @@ describe "Pry::Pager" do
     end
 
     def record_string_with_color_codes
-      @pt.record(CodeRay.scan("0123456789", :ruby).term + "\n")
+      @pt.record(Pry::SyntaxHighlighter.highlight('0123456789') + "\n")
     end
 
     it "records short lines that don't add up to a page" do

--- a/spec/pry_output_spec.rb
+++ b/spec/pry_output_spec.rb
@@ -77,7 +77,7 @@ describe Pry do
     it "should colorize strings as though they were ruby" do
       pry = Pry.new
       accumulator = StringIO.new
-      colorized   = CodeRay.scan("[1]", :ruby).term
+      colorized = Pry::SyntaxHighlighter.highlight('[1]')
       pry.config.output = accumulator
       pry.config.print.call(accumulator, [1], pry)
       expect(accumulator.string).to eq("=> #{colorized}\n")


### PR DESCRIPTION
This moves all the code related syntax highlighting and tokenization to a
wrapper class of CodeRay. Benefits:

* we reduce duplication (no need to call `scan(code, :ruby).term` everywhere)
* swapping CodeRay becomes easier because it's isolated in one class