### PR TITLE
Improve ColorPrinter and its unit tests

### DIFF
--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -6,15 +6,6 @@ class Pry
   class ColorPrinter < ::PP
     Pry::SyntaxHighlighter.overwrite_coderay_comment_token!
 
-    OBJ_COLOR = begin
-      code = Pry::SyntaxHighlighter.keyword_token_color
-      if code.start_with? "\e"
-        code
-      else
-        "\e[0m\e[0;#{code}m"
-      end
-    end
-
     def self.pp(obj, out = $DEFAULT_OUTPUT, width = 79, newline = "\n")
       q = ColorPrinter.new(out, width, newline)
       q.guard_inspect_key { q.pp obj }
@@ -66,7 +57,9 @@ class Pry
     private
 
     def highlight_object_literal(object_literal)
-      "#{OBJ_COLOR}#{object_literal}\e[0m"
+      code = Pry::SyntaxHighlighter.keyword_token_color
+      obj_color = code.start_with?("\e") ? code : "\e[0m\e[0;#{code}m"
+      "#{obj_color}#{object_literal}\e[0m"
     end
   end
 end

--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -6,52 +6,33 @@ class Pry
   class ColorPrinter < ::PP
     Pry::SyntaxHighlighter.overwrite_coderay_comment_token!
 
-    def self.pp(obj, out = $DEFAULT_OUTPUT, width = 79, newline = "\n")
-      q = ColorPrinter.new(out, width, newline)
-      q.guard_inspect_key { q.pp obj }
-      q.flush
-      out << "\n"
+    def self.pp(obj, output = $DEFAULT_OUTPUT, max_width = 79)
+      queue = ColorPrinter.new(output, max_width, "\n")
+      queue.guard_inspect_key { queue.pp(obj) }
+      queue.flush
+      output << "\n"
     end
 
-    def text(str, width = str.length)
-      # Don't recolorize output with color [Issue #751]
+    def pp(object)
+      return super unless object.is_a?(String)
+
+      # Avoid calling Ruby 2.4+ String#pretty_print that prints multiline
+      # Strings prettier
+      text(object.inspect)
+    rescue StandardError => exception
+      raise if exception.is_a?(Pry::Pager::StopPaging)
+
+      text(highlight_object_literal(inspect_object(object)))
+    end
+
+    def text(str, max_width = str.length)
       if str.include?("\e[")
-        super "#{str}\e[0m", width
-      elsif str.start_with?('#<') || str == '=' || str == '>'
-        super highlight_object_literal(str), width
+        super("#{str}\e[0m", max_width)
+      elsif str.start_with?('#<') || %w[= >].include?(str)
+        super(highlight_object_literal(str), max_width)
       else
-        super(SyntaxHighlighter.highlight(str), width)
+        super(SyntaxHighlighter.highlight(str), max_width)
       end
-    end
-
-    def pp(obj)
-      if obj.is_a?(String)
-        # Avoid calling Ruby 2.4+ String#pretty_print that prints multiline
-        # Strings prettier
-        text(obj.inspect)
-      else
-        super
-      end
-    rescue StandardError => e
-      raise if e.is_a? Pry::Pager::StopPaging
-
-      begin
-        str = obj.inspect
-      rescue StandardError
-        # Read the class name off of the singleton class to provide a default
-        # inspect.
-        singleton = class << obj; self; end
-        ancestors = Pry::Method.safe_send(singleton, :ancestors)
-        klass  = ancestors.reject { |k| k == singleton }.first
-        obj_id = begin
-                   obj.__id__.to_s(16)
-                 rescue StandardError
-                   0
-                 end
-        str    = "#<#{klass}:0x#{obj_id}>"
-      end
-
-      text highlight_object_literal(str)
     end
 
     private
@@ -60,6 +41,17 @@ class Pry
       code = Pry::SyntaxHighlighter.keyword_token_color
       obj_color = code.start_with?("\e") ? code : "\e[0m\e[0;#{code}m"
       "#{obj_color}#{object_literal}\e[0m"
+    end
+
+    def inspect_object(object)
+      object.inspect
+    rescue StandardError
+      # Read the class name off of the singleton class to provide a default
+      # inspect.
+      singleton = class << object; self; end
+      ancestors = Pry::Method.safe_send(singleton, :ancestors)
+      klass = ancestors.find { |k| k != singleton }
+      "#<#{klass}:0x#{object.__id__.to_s(16)}>"
     end
   end
 end

--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -1,7 +1,7 @@
 require 'pp'
 
-# PP subclass for streaming inspect output in color.
 class Pry
+  # PP subclass for streaming inspect output in color.
   class ColorPrinter < ::PP
     Pry::SyntaxHighlighter.overwrite_coderay_comment_token!
 

--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -1,4 +1,5 @@
 require 'pp'
+require 'English'
 
 class Pry
   # PP subclass for streaming inspect output in color.

--- a/spec/color_printer_spec.rb
+++ b/spec/color_printer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Pry::ColorPrinter do
         end
       end
 
-      it "prints a string" do
+      it "prints a string with a newline" do
         described_class.pp(healthy_class.new, output)
         expect(output.string).to eq("string\n")
       end
@@ -38,6 +38,61 @@ RSpec.describe Pry::ColorPrinter do
         described_class.pp(BasicObject.new, output)
         expect(output.string)
           .to match(/\A\e\[32m#<BasicObject:0x.+>\e\[0m\e\[0m\n\z/)
+      end
+    end
+
+    context "when #inspect returns an object literal" do
+      let(:klass) do
+        Class.new do
+          def inspect
+            '#<Object:0x00007fe86bab53c8>'
+          end
+        end
+      end
+
+      it "prints the object inspect" do
+        described_class.pp(klass.new, output)
+        expect(output.string).to eq("\e[32m#<Object:0x00007fe86bab53c8>\e[0m\n")
+      end
+
+      context "and when SyntaxHighlighter returns a token starting with '\e'" do
+        before do
+          expect(Pry::SyntaxHighlighter).to receive(:keyword_token_color)
+            .and_return("\e[32m")
+        end
+
+        it "prints the object as is" do
+          described_class.pp(klass.new, output)
+          expect(output.string).to eq("\e[32m#<Object:0x00007fe86bab53c8>\e[0m\n")
+        end
+      end
+
+      context "and when SyntaxHighlighter returns a token that doesn't start with '\e'" do
+        before do
+          expect(Pry::SyntaxHighlighter).to receive(:keyword_token_color)
+            .and_return('token')
+        end
+
+        it "prints the object with escape characters" do
+          described_class.pp(klass.new, output)
+          expect(output.string)
+            .to eq("\e[0m\e[0;tokenm#<Object:0x00007fe86bab53c8>\e[0m\n")
+        end
+      end
+    end
+
+    context "when #inspect raises Pry::Pager::StopPaging" do
+      let(:klass) do
+        Class.new do
+          def inspect
+            raise Pry::Pager::StopPaging
+          end
+        end
+      end
+
+      it "propagates the error" do
+        expect { described_class.pp(klass.new, output) }
+          .to raise_error(Pry::Pager::StopPaging)
       end
     end
   end


### PR DESCRIPTION
I added some unit tests and made a cosmetic refactoring of ColorPrinter.

Changes:

* method extractions
* indentation fixes
* brackets for methods
* clearer variable names

There was also a bug that was introduced when I was fixing Rubocop offences: $DEFAULT_OUTPUT wasn't defined and we needed to require 'English'.