### PR TITLE
 Delete commands/disabled_commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@
 * Deleted commands: `gem-cd`, `gem-install`, `gem-list`, `gem-open`,
   `gem-readme`, `gem-search`, `gem-stats`
   ([#1981](https://github.com/pry/pry/pull/1981))
+* Deleted deprecated commands: `edit-method` and `show-command`
+  ([#1981](https://github.com/pry/pry/pull/1981))
 
 #### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,9 @@
   `gem-readme`, `gem-search`, `gem-stats`
   ([#1981](https://github.com/pry/pry/pull/1981))
 * Deleted deprecated commands: `edit-method` and `show-command`
-  ([#1981](https://github.com/pry/pry/pull/1981))
+  ([#2001](https://github.com/pry/pry/pull/2001))
+* Deleted `Pry::Command#disabled_commands`
+  ([#2001](https://github.com/pry/pry/pull/2001))
 
 #### Bug fixes
 

--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -90,7 +90,6 @@ require 'pry/commands/change_prompt'
 require 'pry/commands/clear_screen'
 require 'pry/commands/code_collector'
 require 'pry/commands/disable_pry'
-require 'pry/commands/disabled_commands'
 require 'pry/commands/easter_eggs'
 
 require 'pry/commands/edit'

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -34,7 +34,7 @@ class Pry
     #   executing the command. Defaults to true.
     # @option options [String] :listing The listing name of the
     #   command. That is the name by which the command is looked up by
-    #   help and by show-command. Necessary for commands with regex matches.
+    #   help and by show-source. Necessary for commands with regex matches.
     # @option options [Boolean] :use_prefix Whether the command uses
     #   `Pry.config.command_prefix` prefix (if one is defined). Defaults
     #   to true.

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -236,17 +236,6 @@ class Pry
       @commands.delete(cmd.match)
     end
 
-    def disabled_command(disabled_command_name, message, matcher = disabled_command_name)
-      create_command(disabled_command_name) do
-        match matcher
-        description ""
-
-        define_method(:process) do
-          output.puts "DISABLED: #{message}"
-        end
-      end
-    end
-
     # Sets or gets the description for a command (replacing the old
     # description). Returns current description if no description
     # parameter provided.

--- a/lib/pry/commands/disable_pry.rb
+++ b/lib/pry/commands/disable_pry.rb
@@ -14,7 +14,7 @@ class Pry
         the end.
 
         As alternatives, consider using `exit!` to force the current Ruby process
-        to quit immediately; or using `edit-method -p` to remove the `binding.pry`
+        to quit immediately; or using `edit -p` to remove the `binding.pry`
         from the code.
       BANNER
 

--- a/lib/pry/commands/disabled_commands.rb
+++ b/lib/pry/commands/disabled_commands.rb
@@ -1,2 +1,0 @@
-Pry::Commands.disabled_command("edit-method", "Use `edit` instead.")
-Pry::Commands.disabled_command("show-command", "Use show-source [command_name] instead.")


### PR DESCRIPTION
These comands were 'disabled' 6 years ago, it's about damn time to delete them.

We also delete `CommandSet#disabled_commands`. 

* the name of the method is not a verb, which is confusing
* commands have aliases
* we can deprecate commands at the place where they are defined. We would've
  avoided this case with `edit-method` where the command was deprecated for
  years but never removed. This is because it was deprecated using
  `#disabled_commands` at an unexpected location.