### PR TITLE
Ensure history file existence prior to expansion.

### DIFF
--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -123,7 +123,7 @@ class Pry
     end
 
     def history_file_path
-      File.expand_path(@file_path || Pry.config.history.file)
+      history_file and File.expand_path(@file_path || Pry.config.history.file)
     end
 
     def invalid_readline_line?(line)


### PR DESCRIPTION
Ensures that the history file exists prior to attempting to expand it's path.

Re-creation:
1) Create a .pryrc file with `Pry.config.history.file` pointing to a non-existent, non-dot file.

  - Note: It appears this could be another issue, as pointing to a non-existent dot file is fine?

2) Attempt to open pry

Please let me know if I need to change my PR in any way; this is my first so I'm not quite sure if I did it correctly.  Thank you!
