### PR TITLE
Move `default_editor_for_platform` to Pry::Editor

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -18,6 +18,7 @@ require 'pry/class_command'
 require 'pry/block_command'
 require 'pry/command_set'
 require 'pry/syntax_highlighter'
+require 'pry/editor'
 
 Pry::Commands = Pry::CommandSet.new unless defined?(Pry::Commands)
 
@@ -49,7 +50,6 @@ require 'pry/inspector'
 require 'pry/color_printer'
 require 'pry/pager'
 require 'pry/terminal'
-require 'pry/editor'
 require 'pry/indent'
 require 'pry/object_path'
 require 'pry/output'

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -78,7 +78,7 @@ class Pry
 
         color: Pry::Helpers::BaseHelpers.use_ansi_codes?,
         default_window_size: 5,
-        editor: Pry.default_editor_for_platform,
+        editor: Pry::Editor.default,
         should_load_rc: true,
         should_load_local_rc: true,
         should_trap_interrupts: Pry::Helpers::Platform.jruby?,

--- a/lib/pry/editor.rb
+++ b/lib/pry/editor.rb
@@ -2,6 +2,16 @@ require 'shellwords'
 
 class Pry
   class Editor
+    def self.default
+      return ENV['VISUAL'] if ENV['VISUAL'] && !ENV['VISUAL'].empty?
+      return ENV['EDITOR'] if ENV['EDITOR'] && !ENV['EDITOR'].empty?
+      return 'notepad' if Helpers::Platform.windows?
+
+      %w[editor nano vi].find do |editor|
+        Kernel.system("which #{editor} > /dev/null 2>&1")
+      end
+    end
+
     include Pry::Helpers::CommandHelpers
 
     attr_reader :pry_instance

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -306,16 +306,6 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
     nil
   end
 
-  def self.default_editor_for_platform
-    return ENV['VISUAL'] if ENV['VISUAL'] && !ENV['VISUAL'].empty?
-    return ENV['EDITOR'] if ENV['EDITOR'] && !ENV['EDITOR'].empty?
-    return 'notepad' if Helpers::Platform.windows?
-
-    %w[editor nano vi].detect do |editor|
-      system("which #{editor} > /dev/null 2>&1")
-    end
-  end
-
   def self.auto_resize!
     Pry.config.input # by default, load Readline
 


### PR DESCRIPTION
The name strongly suggests that this method belongs to `Pry::Editor` and it
makes no sense to have it on `Pry` class.