### PR TITLE
Move history file detection to Pry::History

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -19,6 +19,7 @@ require 'pry/block_command'
 require 'pry/command_set'
 require 'pry/syntax_highlighter'
 require 'pry/editor'
+require 'pry/history'
 
 Pry::Commands = Pry::CommandSet.new unless defined?(Pry::Commands)
 
@@ -64,7 +65,6 @@ require 'pry/wrapped_module/candidate'
 
 require 'pry/slop'
 require 'pry/cli'
-require 'pry/history'
 require 'pry/core_extensions'
 require 'pry/repl_file_loader'
 

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -119,21 +119,11 @@ class Pry
         file_completions: proc { Dir["."] },
         ls: Pry::Config.from_hash(Pry::Command::Ls::DEFAULT_OPTIONS),
         completer: Pry::InputCompleter,
-        history: Pry::Config.from_hash(
-          should_save: true, should_load: true
-        ).tap do |history|
-          history_file =
-            if File.exist?(File.expand_path('~/.pry_history'))
-              '~/.pry_history'
-            elsif ENV.key?('XDG_DATA_HOME') && ENV['XDG_DATA_HOME'] != ''
-              # See XDG Base Directory Specification at
-              # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
-              ENV['XDG_DATA_HOME'] + '/pry/pry_history'
-            else
-              '~/.local/share/pry/pry_history'
-            end
-          history.file = File.expand_path(history_file)
-        end,
+        history: {
+          should_save: true,
+          should_load: true,
+          file: Pry::History.default_file
+        },
         exec_string: ""
       )
     end

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -2,6 +2,20 @@ class Pry
   # The History class is responsible for maintaining the user's input history,
   # both internally and within Readline.
   class History
+    def self.default_file
+      history_file =
+        if File.exist?(File.expand_path('~/.pry_history'))
+          '~/.pry_history'
+        elsif ENV.key?('XDG_DATA_HOME') && ENV['XDG_DATA_HOME'] != ''
+          # See XDG Base Directory Specification at
+          # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
+          ENV['XDG_DATA_HOME'] + '/pry/pry_history'
+        else
+          '~/.local/share/pry/pry_history'
+        end
+      File.expand_path(history_file)
+    end
+
     attr_accessor :loader, :saver
 
     # @return [Fixnum] Number of lines in history when Pry first loaded.

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -1,7 +1,7 @@
 require 'tempfile'
 require 'rbconfig'
 
-describe Pry do
+RSpec.describe Pry::History do
   before do
     Pry.history.clear
 
@@ -17,6 +17,32 @@ describe Pry do
   after do
     Pry.history.clear
     Pry.history.instance_variable_set(:@original_lines, 0)
+  end
+
+  describe ".default_file" do
+    it "returns ~/.local/share/pry/pry_history" do
+      expect(described_class.default_file).to match('/.local/share/pry/pry_history')
+    end
+
+    context "when ~/.pry_history exists" do
+      before do
+        allow(File).to receive(:exist?)
+          .with(File.expand_path('~/.pry_history')).and_return(true)
+      end
+
+      it "returns ~/.pry_history" do
+        expect(described_class.default_file).to match('/.pry_history')
+      end
+    end
+
+    context "when $XDG_DATA_HOME is defined" do
+      before { ENV['XDG_DATA_HOME'] = '/my/path' }
+      after { ENV['XDG_DATA_HOME'] = nil }
+
+      it "returns config location relative to $XDG_DATA_HOME" do
+        expect(described_class.default_file).to eq('/my/path/pry/pry_history')
+      end
+    end
   end
 
   describe '#push' do


### PR DESCRIPTION
This makes `Pry::Config` a bit cleaner and history code is better off in
`Pry::History`, since it's probably the most expected location.