### PR TITLE
Catch expand_path error for ~/.pryrc if login name can't be found

### DIFF
--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -5,14 +5,22 @@ class Pry
   HOME_RC_FILE =
     if ENV.key?('PRYRC')
       ENV['PRYRC']
-    elsif File.exist?(File.expand_path('~/.pryrc'))
-      '~/.pryrc'
-    elsif ENV.key?('XDG_CONFIG_HOME') && ENV['XDG_CONFIG_HOME'] != ''
-      # See XDG Base Directory Specification at
-      # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
-      ENV['XDG_CONFIG_HOME'] + '/pry/pryrc'
     else
-      '~/.config/pry/pryrc'
+      pryrc = begin
+                File.expand_path('~/.pryrc')
+              rescue ArgumentError
+                # couldn't find login name -- expanding `~'
+                nil
+              end
+      if pryrc && File.exist?(pryrc)
+        '~/.pryrc'
+      elsif ENV.key?('XDG_CONFIG_HOME') && ENV['XDG_CONFIG_HOME'] != ''
+        # See XDG Base Directory Specification at
+        # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
+        ENV['XDG_CONFIG_HOME'] + '/pry/pryrc'
+      else
+        '~/.config/pry/pryrc'
+      end
     end
   LOCAL_RC_FILE = "./.pryrc".freeze
 


### PR DESCRIPTION
On one of our hosts the rails app would not load because of the following error:
```
couldn't find login name -- expanding `~' (ArgumentError)
  bundle/ruby/2.6.0/gems/pry-0.12.2/lib/pry/pry_class.rb:5:in `expand_path'
  bundle/ruby/2.6.0/gems/pry-0.12.2/lib/pry/pry_class.rb:5:in `<class:Pry>'
  bundle/ruby/2.6.0/gems/pry-0.12.2/lib/pry/pry_class.rb:1:in `<top (required)>'
  bundle/ruby/2.6.0/gems/pry-0.12.2/lib/pry.rb:119:in `require'
  bundle/ruby/2.6.0/gems/pry-0.12.2/lib/pry.rb:119:in `<top (required)>'
  bundle/ruby/2.6.0/gems/pry-byebug-3.7.0/lib/pry-byebug.rb:3:in `require'
  bundle/ruby/2.6.0/gems/pry-byebug-3.7.0/lib/pry-byebug.rb:3:in `<top (required)>'
  ruby/lib/ruby/gems/2.6.0/gems/bundler-1.17.3/lib/bundler/runtime.rb:81:in `require'
```

This should capture any error from expand_path and continue normally.