### PR TITLE
commands/watch_expression: use command state instead of config

### DIFF
--- a/lib/pry/commands/watch_expression.rb
+++ b/lib/pry/commands/watch_expression.rb
@@ -51,7 +51,7 @@ class Pry
       private
 
       def expressions
-        pry_instance.config.watch_expressions ||= []
+        state.watch_expressions ||= []
       end
 
       def delete(index)


### PR DESCRIPTION
It seems like this command defines options on the config as the user uses
Pry. This is wrong. We have command state API for this purpose. Configuration
should be done before Pry is initialized.