### PR TITLE
Gemfile: lock rspec-expectations to v3.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,11 @@ gemspec
 gem 'rake', '~> 10.0'
 gem 'yard'
 gem 'rspec', '~> 3.8.0'
+
+# TODO: unlock version when the bug is fixed:
+# https://github.com/rspec/rspec-expectations/issues/1113
+gem 'rspec-expectations', '= 3.8.2'
+
 gem 'simplecov', '~> 0.16', require: false
 
 # Rubocop supports only >=2.2.0


### PR DESCRIPTION
v3.8.2 has a bug on Ruby 1.9.3:
https://github.com/rspec/rspec-expectations/issues/1113

```
TypeError: bind argument must be an instance of Kernel
```

Lock for now, unlock when (if) fixed version is released.