### PR TITLE
Reduce the influence of Pry::Config

### DIFF
--- a/lib/pry/inspector.rb
+++ b/lib/pry/inspector.rb
@@ -2,7 +2,7 @@ class Pry
   class Inspector
     MAP = {
       "default" => {
-        value: Pry::Config.defaults.print,
+        value: Pry.config.print,
         description: <<-DESCRIPTION.each_line.map(&:lstrip!)
           The default Pry inspector. It has paging and color support, and uses
           pretty_inspect when printing an object.

--- a/lib/pry/plugins.rb
+++ b/lib/pry/plugins.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 class Pry
   class PluginManager
     PRY_PLUGIN_PREFIX = /^pry-/.freeze
@@ -57,7 +59,7 @@ class Pry
       # Does not reload plugin if it's already active.
       def activate!
         # Create the configuration object for the plugin.
-        Pry.config.send("#{gem_name.tr('-', '_')}=", Pry::Config.from_hash({}))
+        Pry.config.send("#{gem_name.tr('-', '_')}=", OpenStruct.new)
 
         begin
           require gem_name unless active?

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -81,7 +81,7 @@ class Pry
   #  Returns a value store for an instance of Pry running on the current thread.
   #
   def self.current
-    Thread.current[:__pry__] ||= Pry::Config.from_hash({})
+    Thread.current[:__pry__] ||= {}
   end
 
   # Load the given file in the context of `Pry.toplevel_binding`

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -1,4 +1,5 @@
 require 'method_source'
+require 'ostruct'
 
 ##
 # Pry is a powerful alternative to the standard IRB shell for Ruby. It
@@ -537,7 +538,7 @@ class Pry
     object = current_binding.eval('self')
     open_token = @indent.open_delimiters.last || @indent.stack.last
 
-    c = Pry::Config.assign(
+    c = OpenStruct.new(
       object: object,
       nesting_level: binding_stack.size - 1,
       open_token: open_token,

--- a/spec/commands/cd_spec.rb
+++ b/spec/commands/cd_spec.rb
@@ -129,7 +129,7 @@ describe 'cd' do
     describe 'when using ^D (Control-D) key press' do
       it 'should keep correct old binding' do
         @t.eval 'cd :john_dogg', 'cd :mon_dogg', 'cd :kyr_dogg',
-                'Pry::Config.defaults.control_d_handler.call("", pry_instance)'
+                'Pry.config.control_d_handler.call("", pry_instance)'
         expect(@t.mapped_binding_stack).to eq [@o, :john_dogg, :mon_dogg]
 
         @t.eval 'cd -'

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -411,7 +411,7 @@ describe Pry::Hooks do
 
     describe "after_session hook" do
       it 'should always run, even if uncaught exception bubbles out of repl' do
-        o = Pry::Config.new
+        o = OpenStruct.new
         o.great_escape = Class.new(StandardError)
 
         old_ew = Pry.config.unrescued_exceptions

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'rspec'
 require 'pry/testable'
 require 'English'
 require 'stringio'
+require 'ostruct'
 
 Dir['./spec/support/**/*.rb'].map do |file|
   require file
@@ -22,9 +23,7 @@ class Module
   # rubocop:enable Style/AccessModifierDeclarations
 end
 
-Pad = Class.new do
-  include Pry::Config::Behavior
-end.new(nil)
+Pad = OpenStruct.new
 
 # to help with tracking down bugs that cause an infinite loop in the test suite
 if ENV["SET_TRACE_FUNC"]


### PR DESCRIPTION
This is one of preliminary steps for #1843 (Rework the Pry config).

In this commit we replace calls to `Pry::Config` where possible, therefore we
reduce coupling between the config and other components.