### PR TITLE
commands/show_info: fix formatting error for C method header

### DIFF
--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -139,7 +139,7 @@ class Pry
 
       def method_header(code_object, line_num)
         h = ""
-        h << (code_object.c_method? ? "(C Method):" : ":#{line_num}:")
+        h << (code_object.c_method? ? ' (C Method):' : ":#{line_num}:")
         h << method_sections(code_object)[:owner]
         h << method_sections(code_object)[:visibility]
         h << method_sections(code_object)[:signature]

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -514,7 +514,7 @@ class Pry
     # @return [YARD::CodeObjects::MethodObject]
     # @raise [CommandError] when the method can't be found or `pry-doc` isn't installed.
     def pry_doc_info
-      if Pry.config.has_pry_doc
+      if defined?(PryDoc)
         Pry::MethodInfo.info_for(@method) ||
           raise(
             CommandError,


### PR DESCRIPTION
Fixes #2006 (show-source formatting bug in From)

In order to test this I had to build Pry from master locally and install
it. When I ran `String#initialize` I saw an error that `has_pry_doc` is
undefined on the Config class. This makes sense. This option is defined in the
pry-doc plugin.

As a workaround, I had to change the check to `defined?`. However, in the
future, we should make Pry plugin-agnostic - strictly no plugin checks in the
code.