### PR TITLE
config: add `rc_file` that allows specifying `pryrc` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Added `Pry::Config::LazyValue` & `Pry::Config::MemoizedValue`, which allow
   storing callable procs in the config
   ([#2024](https://github.com/pry/pry/pull/2024))
+* Added the `rc_file` config option that tells Pry the path to `pryrc`
+  ([#2027](https://github.com/pry/pry/pull/2027))
 
 #### API changes
 

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -151,6 +151,10 @@ class Pry
     # @return [String]
     attribute :output_prefix
 
+    # @return [String]
+    # @since ?.?.?
+    attribute :rc_file
+
     def initialize
       merge!(
         input: MemoizedValue.new { lazy_readline },
@@ -181,6 +185,7 @@ class Pry
         color: Pry::Helpers::BaseHelpers.use_ansi_codes?,
         default_window_size: 5,
         editor: Pry::Editor.default,
+        rc_file: default_rc_file,
         should_load_rc: true,
         should_load_local_rc: true,
         should_trap_interrupts: Pry::Helpers::Platform.jruby?,
@@ -270,6 +275,20 @@ class Pry
         " * Use the pry-coolline gem, a pure-ruby alternative to Readline"
       )
       raise
+    end
+
+    def default_rc_file
+      if ENV.key?('PRYRC')
+        ENV['PRYRC']
+      elsif File.exist?(File.expand_path('~/.pryrc'))
+        '~/.pryrc'
+      elsif ENV.key?('XDG_CONFIG_HOME') && ENV['XDG_CONFIG_HOME'] != ''
+        # See XDG Base Directory Specification at
+        # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
+        ENV['XDG_CONFIG_HOME'] + '/pry/pryrc'
+      else
+        '~/.config/pry/pryrc'
+      end
     end
   end
 end

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -2,18 +2,6 @@ require 'stringio'
 require 'pathname'
 
 class Pry
-  HOME_RC_FILE =
-    if ENV.key?('PRYRC')
-      ENV['PRYRC']
-    elsif File.exist?(File.expand_path('~/.pryrc'))
-      '~/.pryrc'
-    elsif ENV.key?('XDG_CONFIG_HOME') && ENV['XDG_CONFIG_HOME'] != ''
-      # See XDG Base Directory Specification at
-      # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
-      ENV['XDG_CONFIG_HOME'] + '/pry/pryrc'
-    else
-      '~/.config/pry/pryrc'
-    end
   LOCAL_RC_FILE = "./.pryrc".freeze
 
   class << self
@@ -78,8 +66,8 @@ class Pry
     puts "Error loading #{file}: #{e}\n#{e.backtrace.first}"
   end
 
-  # Load HOME_RC_FILE and LOCAL_RC_FILE if appropriate
-  # This method can also be used to reload the files if they have changed.
+  # Load RC files if appropriate This method can also be used to reload the
+  # files if they have changed.
   def self.load_rc_files
     rc_files_to_load.each do |file|
       critical_section do
@@ -91,7 +79,7 @@ class Pry
   # Load the local RC file (./.pryrc)
   def self.rc_files_to_load
     files = []
-    files << HOME_RC_FILE if Pry.config.should_load_rc
+    files << Pry.config.rc_file if Pry.config.should_load_rc
     files << LOCAL_RC_FILE if Pry.config.should_load_local_rc
     files.map { |file| real_path_to(file) }.compact.uniq
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -40,6 +40,46 @@ RSpec.describe Pry::Config do
   specify { expect(subject.history_load).to eq(true).or be(false) }
   specify { expect(subject.history_file).to be_a(String) }
   specify { expect(subject.exec_string).to be_a(String) }
+  specify { expect(subject.rc_file).to be_a(String) }
+
+  describe "#rc_file" do
+    context "when $PRYRC env variable is set" do
+      before { ENV['PRYRC'] = '/foo/pryrc' }
+      after { ENV.delete('PRYRC') }
+
+      it "defaults to the value of PRYRC env variable" do
+        expect(subject.rc_file).to eq('/foo/pryrc')
+      end
+    end
+
+    context "when ~/.pryrc exists" do
+      before do
+        allow(File).to receive(:exist?)
+        expect(File).to receive(:exist?)
+          .with(File.expand_path('~/.pryrc')).and_return(true)
+      end
+
+      it "defaults ~/.pryrc" do
+        expect(subject.rc_file).to eq('~/.pryrc')
+      end
+    end
+
+    context "when $XDG_CONFIG_HOME is defined" do
+      before do
+        allow(File).to receive(:exist?)
+        expect(File).to receive(:exist?)
+          .with(File.expand_path('~/.pryrc')).and_return(false)
+
+        ENV['XDG_CONFIG_HOME'] = '/xdg_home'
+      end
+
+      after { ENV.delete('XDG_CONFIG_HOME') }
+
+      it "defaults $XDG_CONFIG_HOME/pry/pryrc" do
+        expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+      end
+    end
+  end
 
   describe "#merge!" do
     it "merges given hash with the config instance" do

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Pry::History do
     context "when ~/.pry_history exists" do
       before do
         allow(File).to receive(:exist?)
+        expect(File).to receive(:exist?)
           .with(File.expand_path('~/.pry_history')).and_return(true)
       end
 

--- a/spec/pryrc_spec.rb
+++ b/spec/pryrc_spec.rb
@@ -1,7 +1,7 @@
 describe Pry do
   describe 'loading rc files' do
     before do
-      stub_const('Pry::HOME_RC_FILE', 'spec/fixtures/testrc')
+      Pry.config.rc_file = 'spec/fixtures/testrc'
       stub_const('Pry::LOCAL_RC_FILE', 'spec/fixtures/testrc/../testrc')
 
       Pry.instance_variable_set(:@initial_session, true)
@@ -25,7 +25,7 @@ describe Pry do
     # Resolving symlinks doesn't work on jruby 1.9 [jruby issue #538]
     unless Pry::Helpers::Platform.jruby_19?
       it "should not load the rc file twice if it's symlinked differently" do
-        stub_const('Pry::HOME_RC_FILE', 'spec/fixtures/testrc')
+        Pry.config.rc_file = 'spec/fixtures/testrc'
         stub_const('Pry::LOCAL_RC_FILE', 'spec/fixtures/testlinkrc')
 
         Pry.start(self, input: StringIO.new("exit-all\n"), output: StringIO.new)
@@ -66,7 +66,7 @@ describe Pry do
 
     describe "that raise exceptions" do
       before do
-        Pry::HOME_RC_FILE.replace "spec/fixtures/testrcbad"
+        Pry.config.rc_file = 'spec/fixtures/testrcbad'
         Pry.config.should_load_local_rc = false
 
         putsed = nil


### PR DESCRIPTION
Keeping this in a constant makes it really hard to test. Moving it to the config
and making it configurable seems to be sensible. Now we have a new option and a
lot of tests.