### PR TITLE
Add Pry::Warning

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -25,6 +25,7 @@ require 'pry/exception_handler'
 require 'pry/system_command_handler'
 require 'pry/control_d_handler'
 require 'pry/command_state'
+require 'pry/warning'
 
 Pry::Commands = Pry::CommandSet.new unless defined?(Pry::Commands)
 

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -288,11 +288,7 @@ class Pry
     end
 
     def _pry_
-      loc = caller_locations(1..1).first
-      warn(
-        "#{loc.path}:#{loc.lineno}: warning: _pry_ is deprecated, use " \
-        "pry_instance instead"
-      )
+      Pry::Warning.warn('_pry_ is deprecated, use pry_instance instead')
       pry_instance
     end
 

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -132,19 +132,17 @@ class Pry
     # @deprecated Use a `Pry::Prompt` instance directly
     def [](key)
       key = key.to_s
-      loc = caller_locations(1..1).first
-
       if %w[name description].include?(key)
-        warn(
-          "#{loc.path}:#{loc.lineno}: warning: `Pry::Prompt[:#{@name}][:#{key}]` " \
-          "is deprecated. Use `#{self.class}##{key}` instead"
+        Pry::Warning.warn(
+          "`Pry::Prompt[:#{@name}][:#{key}]` is deprecated. " \
+          "Use `#{self.class}##{key}` instead"
         )
         public_send(key)
       elsif key.to_s == 'value'
-        warn(
-          "#{loc.path}:#{loc.lineno}: warning: `#{self.class}[:#{@name}][:value]` " \
-          "is deprecated. Use `#{self.class}#prompt_procs` instead or an " \
-          "instance of `#{self.class}` directly"
+        Pry::Warning.warn(
+          "`#{self.class}[:#{@name}][:value]` is deprecated. Use " \
+          "`#{self.class}#prompt_procs` instead or an instance of " \
+          "`#{self.class}` directly"
         )
         @prompt_procs
       end

--- a/lib/pry/warning.rb
+++ b/lib/pry/warning.rb
@@ -1,0 +1,25 @@
+class Pry
+  # @api private
+  # @since ?.?.?
+  module Warning
+    # Prints a warning message with exact file and line location, similar to how
+    # Ruby's -W prints warnings.
+    #
+    # @param [String] message
+    # @return [void]
+    def self.warn(message)
+      if Kernel.respond_to?(:caller_locations)
+        location = caller_locations(1..1).first
+        path = location.path
+        lineno = location.lineno
+      else
+        # Ruby 1.9.3 support.
+        frame = caller.first.split(':') # rubocop:disable Performance/Caller
+        path = frame.first
+        lineno = frame[1]
+      end
+
+      Kernel.warn("#{path}:#{lineno}: warning: #{message}")
+    end
+  end
+end

--- a/spec/warning_spec.rb
+++ b/spec/warning_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Pry::Warning do
+  describe "#warn" do
+    it "prints a warning with file and line" do
+      expect(Kernel).to receive(:warn).with(
+        "#{__FILE__}:#{__LINE__ + 2}: warning: foo bar"
+      )
+      described_class.warn('foo bar')
+    end
+  end
+end


### PR DESCRIPTION
Quite often, when we deprecate APIs, we want to print a warning. Such a warning
would be hard to track without a file and line location. We are trying to be a
good citizen and print warnings like Ruby does it.