### PR TITLE
warning: print file and line of the calling frame

### DIFF
--- a/lib/pry/warning.rb
+++ b/lib/pry/warning.rb
@@ -9,12 +9,12 @@ class Pry
     # @return [void]
     def self.warn(message)
       if Kernel.respond_to?(:caller_locations)
-        location = caller_locations(1..1).first
+        location = caller_locations(2..2).first
         path = location.path
         lineno = location.lineno
       else
         # Ruby 1.9.3 support.
-        frame = caller.first.split(':') # rubocop:disable Performance/Caller
+        frame = caller[1].split(':') # rubocop:disable Performance/Caller
         path = frame.first
         lineno = frame[1]
       end

--- a/spec/warning_spec.rb
+++ b/spec/warning_spec.rb
@@ -1,9 +1,7 @@
 RSpec.describe Pry::Warning do
   describe "#warn" do
-    it "prints a warning with file and line" do
-      expect(Kernel).to receive(:warn).with(
-        "#{__FILE__}:#{__LINE__ + 2}: warning: foo bar"
-      )
+    it "prints message with file and line of the calling frame" do
+      expect(Kernel).to receive(:warn).with(/.+\.rb:\d+: warning: foo bar/)
       described_class.warn('foo bar')
     end
   end


### PR DESCRIPTION
We want to print the calling frame, so we can point out who exactly triggered
it. The current behaviour is less useful (we print the line that called the
warning).