### PR TITLE
Fix offences of the Style/FrozenStringLiteralComment cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,3 +71,9 @@ Gemspec/RequiredRubyVersion:
 
 Style/ModuleFunction:
   Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+  Exclude:
+    - 'spec/fixtures/example_nesting.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 gemspec
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rake/clean'
 require 'rubygems/package_task'
 

--- a/bin/pry
+++ b/bin/pry
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 $0 = 'pry'
 
 require 'pry'

--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pry/version'
 require 'pry/last_exception'
 require 'pry/forwardable'

--- a/lib/pry/basic_object.rb
+++ b/lib/pry/basic_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class BasicObject < BasicObject
     [:Kernel, :File, :Dir, :LoadError, :ENV, :Pry].each do |constant|

--- a/lib/pry/block_command.rb
+++ b/lib/pry/block_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # A super-class for Commands that are created with a single block.
   #

--- a/lib/pry/class_command.rb
+++ b/lib/pry/class_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # A super-class of Commands with structure.
   #

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 class Pry

--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -256,12 +256,12 @@ class Pry
     # @return [String] a formatted representation (based on the configuration of
     #   the object).
     def to_s
-      print_to_output("", false)
+      print_to_output(''.dup, false)
     end
 
     # @return [String] a (possibly highlighted) copy of the source code.
     def highlighted
-      print_to_output("", true)
+      print_to_output(''.dup, true)
     end
 
     # Writes a formatted representation (based on the configuration of the

--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'method_source'
 
 class Pry

--- a/lib/pry/code/code_file.rb
+++ b/lib/pry/code/code_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'method_source'
 
 class Pry

--- a/lib/pry/code/code_range.rb
+++ b/lib/pry/code/code_range.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Code
     # Represents a range of lines in a code listing.

--- a/lib/pry/code/loc.rb
+++ b/lib/pry/code/loc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Code
     # Represents a line of code (which may, in fact, contain multiple lines if

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # This class is responsible for taking a string (identifying a
   # command/class/method/etc) and returning the relevant type of object.

--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pp'
 require 'English'
 

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delegate'
 require 'shellwords'
 

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -354,7 +354,7 @@ class Pry
     # @param [String] val The line of input
     # @return [Array]
     def tokenize(val)
-      val.replace(interpolate_string(val)) if command_options[:interpolate]
+      val = interpolate_string(val) if command_options[:interpolate]
 
       self.class.command_regex =~ val
 

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class NoCommandError < StandardError
     def initialize(match, owner)

--- a/lib/pry/command_state.rb
+++ b/lib/pry/command_state.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 
 class Pry

--- a/lib/pry/commands/amend_line.rb
+++ b/lib/pry/commands/amend_line.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class AmendLine < Pry::ClassCommand

--- a/lib/pry/commands/bang.rb
+++ b/lib/pry/commands/bang.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Bang < Pry::ClassCommand

--- a/lib/pry/commands/bang_pry.rb
+++ b/lib/pry/commands/bang_pry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class BangPry < Pry::ClassCommand

--- a/lib/pry/commands/cat.rb
+++ b/lib/pry/commands/cat.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Cat < Pry::ClassCommand

--- a/lib/pry/commands/cat/abstract_formatter.rb
+++ b/lib/pry/commands/cat/abstract_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Cat

--- a/lib/pry/commands/cat/exception_formatter.rb
+++ b/lib/pry/commands/cat/exception_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Cat

--- a/lib/pry/commands/cat/file_formatter.rb
+++ b/lib/pry/commands/cat/file_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Cat

--- a/lib/pry/commands/cat/input_expression_formatter.rb
+++ b/lib/pry/commands/cat/input_expression_formatter.rb
@@ -16,10 +16,10 @@ class Pry
           raise CommandError, "No input expressions!" if numbered_input_items.empty?
 
           if numbered_input_items.length > 1
-            content = ""
+            content = ''
             numbered_input_items.each do |i, s|
-              content << "#{Helpers::Text.bold(i.to_s)}:\n"
-              content << decorate(Pry::Code(s).with_indentation(2)).to_s
+              content += "#{Helpers::Text.bold(i.to_s)}:\n"
+              content += decorate(Pry::Code(s).with_indentation(2)).to_s
             end
 
             content

--- a/lib/pry/commands/cat/input_expression_formatter.rb
+++ b/lib/pry/commands/cat/input_expression_formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Cat

--- a/lib/pry/commands/cd.rb
+++ b/lib/pry/commands/cd.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Cd < Pry::ClassCommand

--- a/lib/pry/commands/change_inspector.rb
+++ b/lib/pry/commands/change_inspector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ChangeInspector < Pry::ClassCommand

--- a/lib/pry/commands/change_prompt.rb
+++ b/lib/pry/commands/change_prompt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ChangePrompt < Pry::ClassCommand

--- a/lib/pry/commands/clear_screen.rb
+++ b/lib/pry/commands/clear_screen.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ClearScreen < Pry::ClassCommand

--- a/lib/pry/commands/code_collector.rb
+++ b/lib/pry/commands/code_collector.rb
@@ -144,7 +144,7 @@ class Pry
           end
 
           ranged_array = Array(array[range]) || []
-          ranged_array.compact.each { |v| all << yield(v) }
+          ranged_array.compact.each { |v| all += yield(v) }
         end
 
         all

--- a/lib/pry/commands/code_collector.rb
+++ b/lib/pry/commands/code_collector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class CodeCollector

--- a/lib/pry/commands/disable_pry.rb
+++ b/lib/pry/commands/disable_pry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class DisablePry < Pry::ClassCommand

--- a/lib/pry/commands/easter_eggs.rb
+++ b/lib/pry/commands/easter_eggs.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   Pry::Commands.instance_eval do
     command(%r{!s/(.*?)/(.*?)}, "") do |source, dest|

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -71,9 +71,7 @@ class Pry
           initial_temp_file_content,
           initial_temp_file_content.lines.count
         )
-        silence_warnings do
-          eval_string.replace content
-        end
+        pry_instance.eval_string = content
         Pry.history.push(content)
       end
 

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Edit < Pry::ClassCommand

--- a/lib/pry/commands/edit/exception_patcher.rb
+++ b/lib/pry/commands/edit/exception_patcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Edit

--- a/lib/pry/commands/edit/file_and_line_locator.rb
+++ b/lib/pry/commands/edit/file_and_line_locator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Edit

--- a/lib/pry/commands/exit.rb
+++ b/lib/pry/commands/exit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Exit < Pry::ClassCommand

--- a/lib/pry/commands/exit_all.rb
+++ b/lib/pry/commands/exit_all.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ExitAll < Pry::ClassCommand

--- a/lib/pry/commands/exit_program.rb
+++ b/lib/pry/commands/exit_program.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ExitProgram < Pry::ClassCommand

--- a/lib/pry/commands/find_method.rb
+++ b/lib/pry/commands/find_method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class FindMethod < Pry::ClassCommand

--- a/lib/pry/commands/find_method.rb
+++ b/lib/pry/commands/find_method.rb
@@ -99,7 +99,7 @@ class Pry
       # if `-c` was not given
       def additional_info(header, method)
         if opts.content?
-          ": " << colorize_code(matched_method_lines(header, method))
+          ': ' + colorize_code(matched_method_lines(header, method))
         else
           ""
         end

--- a/lib/pry/commands/fix_indent.rb
+++ b/lib/pry/commands/fix_indent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class FixIndent < Pry::ClassCommand

--- a/lib/pry/commands/fix_indent.rb
+++ b/lib/pry/commands/fix_indent.rb
@@ -14,7 +14,7 @@ class Pry
 
       def process
         indented_str = Pry::Indent.indent(eval_string)
-        eval_string.replace indented_str
+        pry_instance.eval_string = indented_str
       end
     end
 

--- a/lib/pry/commands/help.rb
+++ b/lib/pry/commands/help.rb
@@ -60,7 +60,7 @@ class Pry
       # @param [Array<Pry::Command>] commands
       # @return [String] The generated help string.
       def help_text_for_commands(name, commands)
-        "#{bold(name.capitalize)}\n" << commands.map do |command|
+        "#{bold(name.capitalize)}\n" + commands.map do |command|
           "  #{command.options[:listing].to_s.ljust(18)} " \
           "#{command.description.capitalize}"
         end.join("\n")

--- a/lib/pry/commands/help.rb
+++ b/lib/pry/commands/help.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Help < Pry::ClassCommand

--- a/lib/pry/commands/hist.rb
+++ b/lib/pry/commands/hist.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Hist < Pry::ClassCommand

--- a/lib/pry/commands/import_set.rb
+++ b/lib/pry/commands/import_set.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ImportSet < Pry::ClassCommand

--- a/lib/pry/commands/jump_to.rb
+++ b/lib/pry/commands/jump_to.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class JumpTo < Pry::ClassCommand

--- a/lib/pry/commands/list_inspectors.rb
+++ b/lib/pry/commands/list_inspectors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ListInspectors < Pry::ClassCommand

--- a/lib/pry/commands/ls.rb
+++ b/lib/pry/commands/ls.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/constants.rb
+++ b/lib/pry/commands/ls/constants.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/formatter.rb
+++ b/lib/pry/commands/ls/formatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/formatter.rb
+++ b/lib/pry/commands/ls/formatter.rb
@@ -35,7 +35,7 @@ class Pry
         end
 
         def format_value(value)
-          Pry::ColorPrinter.pp(value, '')
+          Pry::ColorPrinter.pp(value, ''.dup)
         end
 
         def correct_opts?

--- a/lib/pry/commands/ls/globals.rb
+++ b/lib/pry/commands/ls/globals.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/grep.rb
+++ b/lib/pry/commands/ls/grep.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/instance_vars.rb
+++ b/lib/pry/commands/ls/instance_vars.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/interrogatable.rb
+++ b/lib/pry/commands/ls/interrogatable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/jruby_hacks.rb
+++ b/lib/pry/commands/ls/jruby_hacks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/local_names.rb
+++ b/lib/pry/commands/ls/local_names.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/local_vars.rb
+++ b/lib/pry/commands/ls/local_vars.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/ls_entity.rb
+++ b/lib/pry/commands/ls/ls_entity.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/methods.rb
+++ b/lib/pry/commands/ls/methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/methods_helper.rb
+++ b/lib/pry/commands/ls/methods_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/ls/self_methods.rb
+++ b/lib/pry/commands/ls/self_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand

--- a/lib/pry/commands/nesting.rb
+++ b/lib/pry/commands/nesting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Nesting < Pry::ClassCommand

--- a/lib/pry/commands/play.rb
+++ b/lib/pry/commands/play.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Play < Pry::ClassCommand

--- a/lib/pry/commands/pry_backtrace.rb
+++ b/lib/pry/commands/pry_backtrace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class PryBacktrace < Pry::ClassCommand

--- a/lib/pry/commands/pry_version.rb
+++ b/lib/pry/commands/pry_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Version < Pry::ClassCommand

--- a/lib/pry/commands/raise_up.rb
+++ b/lib/pry/commands/raise_up.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # N.B. using a regular expresion here so that "raise-up 'foo'" does the right thing.
   class Command

--- a/lib/pry/commands/reload_code.rb
+++ b/lib/pry/commands/reload_code.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ReloadCode < Pry::ClassCommand

--- a/lib/pry/commands/reset.rb
+++ b/lib/pry/commands/reset.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Reset < Pry::ClassCommand

--- a/lib/pry/commands/ri.rb
+++ b/lib/pry/commands/ri.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 class Pry

--- a/lib/pry/commands/save_file.rb
+++ b/lib/pry/commands/save_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class SaveFile < Pry::ClassCommand

--- a/lib/pry/commands/shell_command.rb
+++ b/lib/pry/commands/shell_command.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ShellCommand < Pry::ClassCommand

--- a/lib/pry/commands/shell_mode.rb
+++ b/lib/pry/commands/shell_mode.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ShellMode < Pry::ClassCommand

--- a/lib/pry/commands/show_doc.rb
+++ b/lib/pry/commands/show_doc.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ShowDoc < Command::ShowInfo

--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ShowInfo < Pry::ClassCommand

--- a/lib/pry/commands/show_info.rb
+++ b/lib/pry/commands/show_info.rb
@@ -75,7 +75,7 @@ class Pry
       end
 
       def content_and_header_for_code_object(code_object)
-        header(code_object) << content_for(code_object)
+        header(code_object) + content_for(code_object)
       end
 
       def content_and_headers_for_all_module_candidates(mod)
@@ -84,13 +84,13 @@ class Pry
         mod.number_of_candidates.times do |v|
           candidate = mod.candidate(v)
           begin
-            result << "\nCandidate #{v + 1}/#{mod.number_of_candidates}: " \
+            result += "\nCandidate #{v + 1}/#{mod.number_of_candidates}: " \
                       "#{candidate.source_file}:#{candidate.source_line}\n"
             content = content_for(candidate)
 
-            result << "Number of lines: #{content.lines.count}\n\n" << content
+            result += "Number of lines: #{content.lines.count}\n\n" + content
           rescue Pry::RescuableException
-            result << "\nNo content found.\n"
+            result += "\nNo content found.\n"
             next
           end
         end
@@ -108,17 +108,17 @@ class Pry
         content = content_for(code_object)
 
         h = "\n#{bold('From:')} #{file_name}"
-        h << code_object_header(code_object, line_num)
-        h << "\n#{bold('Number of lines:')} " << "#{content.lines.count}\n\n"
+        h += code_object_header(code_object, line_num)
+        h += "\n#{bold('Number of lines:')} " + "#{content.lines.count}\n\n"
         if @used_super
-          h << bold('** Warning:')
-          h << " Cannot find code for #{@original_code_object.nonblank_name}. " \
+          h += bold('** Warning:')
+          h += " Cannot find code for #{@original_code_object.nonblank_name}. " \
                "Showing superclass #{code_object.nonblank_name} instead. **\n\n"
         end
 
         if content.lines.none?
-          h << bold('** Warning:')
-          h << " Cannot find code for '#{code_object.name}' (source_location is nil)"
+          h += bold('** Warning:')
+          h += " Cannot find code for '#{code_object.name}' (source_location is nil)"
         end
 
         h
@@ -141,23 +141,23 @@ class Pry
 
       def method_header(code_object, line_num)
         h = ""
-        h << (code_object.c_method? ? ' (C Method):' : ":#{line_num}:")
-        h << method_sections(code_object)[:owner]
-        h << method_sections(code_object)[:visibility]
-        h << method_sections(code_object)[:signature]
+        h += (code_object.c_method? ? ' (C Method):' : ":#{line_num}:")
+        h += method_sections(code_object)[:owner]
+        h += method_sections(code_object)[:visibility]
+        h += method_sections(code_object)[:signature]
         h
       end
 
       def module_header(code_object, line_num)
         h = ""
-        h << ":#{line_num}\n"
-        h << bold(code_object.module? ? "Module" : "Class")
-        h << " #{bold('name:')} #{code_object.nonblank_name}"
+        h += ":#{line_num}\n"
+        h += bold(code_object.module? ? "Module" : "Class")
+        h += " #{bold('name:')} #{code_object.nonblank_name}"
 
         if code_object.number_of_candidates > 1
-          h << bold("\nNumber of monkeypatches: ")
-          h << code_object.number_of_candidates.to_s
-          h << ". Use the `-a` option to display all available monkeypatches"
+          h += bold("\nNumber of monkeypatches: ")
+          h += code_object.number_of_candidates.to_s
+          h += ". Use the `-a` option to display all available monkeypatches"
         end
         h
       end

--- a/lib/pry/commands/show_input.rb
+++ b/lib/pry/commands/show_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ShowInput < Pry::ClassCommand

--- a/lib/pry/commands/show_source.rb
+++ b/lib/pry/commands/show_source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ShowSource < Command::ShowInfo

--- a/lib/pry/commands/stat.rb
+++ b/lib/pry/commands/stat.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Stat < Pry::ClassCommand

--- a/lib/pry/commands/switch_to.rb
+++ b/lib/pry/commands/switch_to.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class SwitchTo < Pry::ClassCommand

--- a/lib/pry/commands/toggle_color.rb
+++ b/lib/pry/commands/toggle_color.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class ToggleColor < Pry::ClassCommand

--- a/lib/pry/commands/watch_expression.rb
+++ b/lib/pry/commands/watch_expression.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class WatchExpression < Pry::ClassCommand

--- a/lib/pry/commands/watch_expression/expression.rb
+++ b/lib/pry/commands/watch_expression/expression.rb
@@ -14,7 +14,7 @@ class Pry
 
         def eval!
           @previous_value = value
-          @value = Pry::ColorPrinter.pp(target_eval(target, source), "")
+          @value = Pry::ColorPrinter.pp(target_eval(target, source), ''.dup)
         end
 
         def to_s

--- a/lib/pry/commands/watch_expression/expression.rb
+++ b/lib/pry/commands/watch_expression/expression.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class WatchExpression

--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -107,7 +107,7 @@ class Pry
           .with_marker(marker)
           .highlighted
         pry_instance.pager.page(
-          "\n#{bold('From:')} #{location}:\n\n" << pretty_code << "\n"
+          "\n#{bold('From:')} #{location}:\n\n" + pretty_code + "\n"
         )
       end
 

--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'method_source'
 
 class Pry

--- a/lib/pry/commands/wtf.rb
+++ b/lib/pry/commands/wtf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Command
     class Wtf < Pry::ClassCommand

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 
 class Pry

--- a/lib/pry/config/attributable.rb
+++ b/lib/pry/config/attributable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Config
     # Attributable provides the ability to create "attribute"

--- a/lib/pry/config/lazy_value.rb
+++ b/lib/pry/config/lazy_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Config
     # LazyValue is a Proc (block) wrapper. It is meant to be used as a

--- a/lib/pry/config/memoized_value.rb
+++ b/lib/pry/config/memoized_value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Config
     # MemoizedValue is a Proc (block) wrapper. It is meant to be used as a

--- a/lib/pry/config/value.rb
+++ b/lib/pry/config/value.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Config
     # Value holds a value for the given attribute and decides how it should

--- a/lib/pry/control_d_handler.rb
+++ b/lib/pry/control_d_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # @api private
   # @since ?.?.?

--- a/lib/pry/core_extensions.rb
+++ b/lib/pry/core_extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # @return [Array] Code of the method used when implementing Pry's
   #   __binding__, along with line indication to be used with instance_eval (and

--- a/lib/pry/editor.rb
+++ b/lib/pry/editor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'shellwords'
 
 class Pry

--- a/lib/pry/exception_handler.rb
+++ b/lib/pry/exception_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # @api private
   # @since ?.?.?

--- a/lib/pry/exceptions.rb
+++ b/lib/pry/exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # As a REPL, we often want to catch any unexpected exceptions that may have
   # been raised; however we don't want to go overboard and prevent the user

--- a/lib/pry/forwardable.rb
+++ b/lib/pry/forwardable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   module Forwardable
     require 'forwardable'

--- a/lib/pry/helpers.rb
+++ b/lib/pry/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "pry/helpers/base_helpers"
 require "pry/helpers/options_helpers"
 require "pry/helpers/command_helpers"

--- a/lib/pry/helpers/base_helpers.rb
+++ b/lib/pry/helpers/base_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   module Helpers
     module BaseHelpers

--- a/lib/pry/helpers/command_helpers.rb
+++ b/lib/pry/helpers/command_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 
 class Pry

--- a/lib/pry/helpers/documentation_helpers.rb
+++ b/lib/pry/helpers/documentation_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   module Helpers
     # This class contains methods useful for extracting

--- a/lib/pry/helpers/options_helpers.rb
+++ b/lib/pry/helpers/options_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   module Helpers
     module OptionsHelpers

--- a/lib/pry/helpers/platform.rb
+++ b/lib/pry/helpers/platform.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rbconfig'
 
 class Pry

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   module Helpers
     def self.tablify_or_one_line(heading, things, config = Pry.config)

--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   module Helpers
     # The methods defined on {Text} are available to custom commands via

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # The History class is responsible for maintaining the user's input history,
   # both internally and within Readline.

--- a/lib/pry/hooks.rb
+++ b/lib/pry/hooks.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # Implements a hooks system for Pry. A hook is a callable that is associated
   # with an event. A number of events are currently provided by Pry, these

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   ##
   # Pry::Indent is a class that can be used to indent a number of lines

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # taken from irb
 # Implements tab completion for Readline in Pry
 class Pry

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -94,7 +94,7 @@ class Pry
         when SYMBOL_REGEXP # Symbol
           if Symbol.respond_to?(:all_symbols)
             sym = Regexp.quote(Regexp.last_match(1))
-            candidates = Symbol.all_symbols.collect { |s| ":" << s.id2name }
+            candidates = Symbol.all_symbols.collect { |s| ":" + s.id2name }
             candidates.grep(/^#{sym}/)
           else
             []
@@ -102,7 +102,7 @@ class Pry
         when TOPLEVEL_LOOKUP_REGEXP # Absolute Constant or class methods
           receiver = Regexp.last_match(1)
           candidates = Object.constants.collect(&:to_s)
-          candidates.grep(/^#{receiver}/).collect { |e| "::" << e }
+          candidates.grep(/^#{receiver}/).collect { |e| "::" + e }
         when CONSTANT_REGEXP # Constant
           message = Regexp.last_match(1)
           begin
@@ -230,7 +230,7 @@ class Pry
       candidates.grep(/^#{message}/).collect do |e|
         next unless e =~ /^[a-zA-Z_]/
 
-        path.call(receiver + "." << e)
+        path.call(receiver + "." + e)
       end.compact
     end
 

--- a/lib/pry/input_lock.rb
+++ b/lib/pry/input_lock.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # There is one InputLock per input (such as STDIN) as two REPLs on the same
   # input makes things delirious. InputLock serializes accesses to the input so

--- a/lib/pry/inspector.rb
+++ b/lib/pry/inspector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Inspector
     MAP = {

--- a/lib/pry/last_exception.rb
+++ b/lib/pry/last_exception.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # {Pry::LastException} is a proxy class who wraps an Exception object for
 # {Pry#last_exception}. it extends the exception object with methods that

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'method_source'
 
 class Pry

--- a/lib/pry/method/disowned.rb
+++ b/lib/pry/method/disowned.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Method
     # A Disowned Method is one that's been removed from the class on which it was defined.

--- a/lib/pry/method/patcher.rb
+++ b/lib/pry/method/patcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Method
     class Patcher

--- a/lib/pry/method/weird_method_locator.rb
+++ b/lib/pry/method/weird_method_locator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Method
     # This class is responsible for locating the *real* `Pry::Method`

--- a/lib/pry/object_path.rb
+++ b/lib/pry/object_path.rb
@@ -37,13 +37,13 @@ class Pry
 
           loop do
             # Scan for as long as we don't see a slash
-            next_segment << scanner.scan(%r{[^/]*})
+            next_segment += scanner.scan(%r{[^/]*})
 
             if complete?(next_segment) || scanner.eos?
               scanner.getch # consume the slash
               break
             else
-              next_segment << scanner.getch # append the slash
+              next_segment += scanner.getch # append the slash
             end
           end
 

--- a/lib/pry/object_path.rb
+++ b/lib/pry/object_path.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'strscan'
 
 class Pry

--- a/lib/pry/output.rb
+++ b/lib/pry/output.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Output
     attr_reader :pry_instance

--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A pager is an `IO`-like object that accepts text and either prints it
 # immediately, prints it one page at a time, or streams it to an external
 # program to print one page at a time.

--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -170,7 +170,7 @@ class Pry
           write_to_pager str
         else
           @tracker.record str
-          @buffer << str
+          @buffer += str
 
           write_to_pager @buffer if @tracker.page?
         end

--- a/lib/pry/plugins.rb
+++ b/lib/pry/plugins.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 
 class Pry

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # Prompt represents the Pry prompt, which can be used with Readline-like
   # libraries. It defines a few default prompts (default prompt, simple prompt,

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 require 'pathname'
 

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'method_source'
 require 'ostruct'
 

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -81,7 +81,7 @@ class Pry
   def initialize(options = {})
     @binding_stack = []
     @indent        = Pry::Indent.new
-    @eval_string   = ""
+    @eval_string   = ''.dup
     @backtrace     = options.delete(:backtrace) || caller
     target = options.delete(:target)
     @config = self.class.config.merge(options)
@@ -229,7 +229,7 @@ class Pry
   # Reset the current eval string. If the user has entered part of a multiline
   # expression, this discards that input.
   def reset_eval_string
-    @eval_string = ""
+    @eval_string = ''.dup
   end
 
   # Pass a line of input to Pry.
@@ -345,7 +345,7 @@ class Pry
         # the command that was invoked was non-void (had a return value) and so we make
         # the value of the current expression equal to the return value
         # of the command.
-        @eval_string.replace "::Pry.current[:pry_cmd_result].retval\n"
+        @eval_string = "::Pry.current[:pry_cmd_result].retval\n"
       end
       true
     else
@@ -608,7 +608,7 @@ class Pry
     inject_sticky_locals!
     begin
       unless process_command_safely(line)
-        @eval_string << "#{line.chomp}\n" if !line.empty? || !@eval_string.empty?
+        @eval_string += "#{line.chomp}\n" if !line.empty? || !@eval_string.empty?
       end
     rescue RescuableException => e
       self.last_exception = e

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class REPL
     extend Pry::Forwardable

--- a/lib/pry/repl_file_loader.rb
+++ b/lib/pry/repl_file_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # A class to manage the loading of files through the REPL loop.
   # This is an interesting trick as it processes your file as if it

--- a/lib/pry/ring.rb
+++ b/lib/pry/ring.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # A ring is a thread-safe fixed-capacity array to which you can only add
   # elements. Older entries are overwritten as you add new elements, so that the

--- a/lib/pry/slop.rb
+++ b/lib/pry/slop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # rubocop:disable Metrics/ClassLength
   class Slop

--- a/lib/pry/slop/commands.rb
+++ b/lib/pry/slop/commands.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Slop
     class Commands

--- a/lib/pry/slop/option.rb
+++ b/lib/pry/slop/option.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Slop
     class Option

--- a/lib/pry/slop/option.rb
+++ b/lib/pry/slop/option.rb
@@ -127,12 +127,12 @@ class Pry
         out = "    #{short ? "-#{short}, " : ' ' * 4}"
 
         if long
-          out << "--#{long}"
+          out += "--#{long}"
           size = long.size
           diff = @slop.config[:longest_flag] - size
-          out << (' ' * (diff + 6))
+          out += (' ' * (diff + 6))
         else
-          out << (' ' * (@slop.config[:longest_flag] + 8))
+          out += (' ' * (@slop.config[:longest_flag] + 8))
         end
 
         "#{out}#{description}"

--- a/lib/pry/syntax_highlighter.rb
+++ b/lib/pry/syntax_highlighter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'coderay'
 
 class Pry

--- a/lib/pry/system_command_handler.rb
+++ b/lib/pry/system_command_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # @api private
   # @since ?.?.?

--- a/lib/pry/terminal.rb
+++ b/lib/pry/terminal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class Terminal
     class << self

--- a/lib/pry/testable.rb
+++ b/lib/pry/testable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # good idea ???
 # if you're testing pry plugin you should require pry by yourself, no?
 require 'pry' unless defined?(Pry)

--- a/lib/pry/testable/evalable.rb
+++ b/lib/pry/testable/evalable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   module Testable
     module Evalable

--- a/lib/pry/testable/mockable.rb
+++ b/lib/pry/testable/mockable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 class Pry

--- a/lib/pry/testable/pry_tester.rb
+++ b/lib/pry/testable/pry_tester.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 class Pry

--- a/lib/pry/testable/utility.rb
+++ b/lib/pry/testable/utility.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 
 class Pry

--- a/lib/pry/testable/variables.rb
+++ b/lib/pry/testable/variables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   module Testable
     module Variables

--- a/lib/pry/version.rb
+++ b/lib/pry/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   VERSION = '0.12.2'.freeze
 end

--- a/lib/pry/warning.rb
+++ b/lib/pry/warning.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   # @api private
   # @since ?.?.?

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class << self
     # If the given object is a `Pry::WrappedModule`, return it unaltered. If it's

--- a/lib/pry/wrapped_module/candidate.rb
+++ b/lib/pry/wrapped_module/candidate.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Pry
   class WrappedModule
     # This class represents a single candidate for a module/class definition.

--- a/pry.gemspec
+++ b/pry.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../lib/pry/version', __FILE__)
 
 Gem::Specification.new do |s|

--- a/spec/block_command_spec.rb
+++ b/spec/block_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::BlockCommand do
   subject { Class.new(described_class).new }
 

--- a/spec/class_command_spec.rb
+++ b/spec/class_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::ClassCommand do
   describe ".inherited" do
     context "when match is defined" do

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::CLI do
   before { described_class.reset }
 

--- a/spec/code_object_spec.rb
+++ b/spec/code_object_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::CodeObject do
   let(:pry) do
     Pry.new.tap { |p| p.binding_stack = [binding] }

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'method_source'
 require 'tempfile'
 

--- a/spec/color_printer_spec.rb
+++ b/spec/color_printer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::ColorPrinter do
   let(:output) { StringIO.new }
 

--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "commands" do
   before do
     @str_output = StringIO.new

--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -452,7 +452,6 @@ describe "commands" do
   ) do
     klass = Pry::CommandSet.new do
       command "hello", "", keep_retval: true do
-        eval_string.replace("6")
         7
       end
     end

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::CommandSet do
   let(:set) do
     Pry::CommandSet.new { import(Pry::Commands) }

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 RSpec.describe Pry::Command do

--- a/spec/command_state_spec.rb
+++ b/spec/command_state_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::CommandState do
   describe ".default" do
     it "returns the default command state" do

--- a/spec/commands/amend_line_spec.rb
+++ b/spec/commands/amend_line_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "amend-line" do
   before do
     @t = pry_tester

--- a/spec/commands/bang_spec.rb
+++ b/spec/commands/bang_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "!" do
   before do
     @t = pry_tester

--- a/spec/commands/cat/file_formatter_spec.rb
+++ b/spec/commands/cat/file_formatter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry::Command::Cat::FileFormatter do
   before do
     @p   = Pry.new

--- a/spec/commands/cat_spec.rb
+++ b/spec/commands/cat_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 
 describe "cat" do

--- a/spec/commands/cd_spec.rb
+++ b/spec/commands/cd_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe 'cd' do
   before do
     @o = Object.new

--- a/spec/commands/clear_screen_spec.rb
+++ b/spec/commands/clear_screen_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "clear-screen" do
   before do
     @t = pry_tester

--- a/spec/commands/disable_pry_spec.rb
+++ b/spec/commands/disable_pry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "disable-pry" do
   before do
     @t = pry_tester

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'tempfile'
 

--- a/spec/commands/exit_all_spec.rb
+++ b/spec/commands/exit_all_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "exit-all" do
   before { @pry = Pry.new }
 

--- a/spec/commands/exit_program_spec.rb
+++ b/spec/commands/exit_program_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "exit-program" do
   it 'should raise SystemExit' do
     expect { pry_eval('exit-program') }.to raise_error SystemExit

--- a/spec/commands/exit_spec.rb
+++ b/spec/commands/exit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "exit" do
   before { @pry = Pry.new(target: :outer, output: StringIO.new) }
 

--- a/spec/commands/find_method_spec.rb
+++ b/spec/commands/find_method_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "find-method" do
   MyKlass = Class.new do
     def hello

--- a/spec/commands/help_spec.rb
+++ b/spec/commands/help_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "help" do
   before do
     @oldset = Pry.config.commands

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "hist" do
   before do
     Pry.history.clear

--- a/spec/commands/jump_to_spec.rb
+++ b/spec/commands/jump_to_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "jump-to" do
   let(:obj) { Object.new }
 

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "ls" do
   describe "bug #1407" do
     it "behaves as usual when a method of the same name exists." do

--- a/spec/commands/play_spec.rb
+++ b/spec/commands/play_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This command needs a TONNE more tests for it, but i can't figure out
 # how to do them yet, and i really want to release. Sorry. Someone
 # come along and do a better job.

--- a/spec/commands/play_spec.rb
+++ b/spec/commands/play_spec.rb
@@ -37,6 +37,7 @@ describe "play" do
     it 'should play a file' do
       @t.process_command 'play spec/fixtures/whereami_helper.rb'
       expect(@t.eval_string).to eq unindent(<<-STR)
+        # frozen_string_literal: true
         # rubocop:disable Layout/EmptyLineBetweenDefs
         class Cor
           def a; end
@@ -50,16 +51,18 @@ describe "play" do
 
     it 'should output file contents with print option' do
       @t.process_command 'play --print spec/fixtures/whereami_helper.rb'
-      expect(@t.last_output).to eq unindent(<<-STR)
-        1: # rubocop:disable Layout/EmptyLineBetweenDefs
-        2: class Cor
-        3:   def a; end
-        4:   def b; end
-        5:   def c; end
-        6:   def d; end
-        7: end
-        8: # rubocop:enable Layout/EmptyLineBetweenDefs
-      STR
+      expect(@t.last_output).to eq(
+        " 1: \# frozen_string_literal: true\n" \
+        " 2: \n" \
+        " 3: \# rubocop:disable Layout/EmptyLineBetweenDefs\n" \
+        " 4: class Cor\n" \
+        " 5:   def a; end\n" \
+        " 6:   def b; end\n" \
+        " 7:   def c; end\n" \
+        " 8:   def d; end\n" \
+        " 9: end\n" \
+        "10: \# rubocop:enable Layout/EmptyLineBetweenDefs\n"
+      )
     end
   end
 

--- a/spec/commands/raise_up_spec.rb
+++ b/spec/commands/raise_up_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "raise-up" do
   before do
     @self  = "Pad.self = self"

--- a/spec/commands/reload_code_spec.rb
+++ b/spec/commands/reload_code_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "reload_code" do
   describe "reload_current_file" do
     it 'raises an error source code not found' do

--- a/spec/commands/ri_command_spec.rb
+++ b/spec/commands/ri_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "ri" do
   it "prints an error message without an argument" do
     expect(pry_eval("ri")).to include(

--- a/spec/commands/save_file_spec.rb
+++ b/spec/commands/save_file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 
 describe "save-file" do

--- a/spec/commands/shell_command_spec.rb
+++ b/spec/commands/shell_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry::Command::ShellCommand do
   describe 'cd' do
     before do

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fixtures/show_source_doc_examples"
 
 describe "show-doc" do

--- a/spec/commands/show_input_spec.rb
+++ b/spec/commands/show_input_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "show-input" do
   before do
     @t = pry_tester

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "fixtures/show_source_doc_examples"
 
 describe "show-source" do

--- a/spec/commands/watch_expression_spec.rb
+++ b/spec/commands/watch_expression_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "watch expression" do
   # Custom eval that will:
   # 1) Create an instance of pry that can use for multiple calls

--- a/spec/commands/whereami_spec.rb
+++ b/spec/commands/whereami_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'method_source'
 
 describe "whereami" do

--- a/spec/commands/wtf_spec.rb
+++ b/spec/commands/wtf_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "wtf?!" do
   let(:tester) do
     pry_tester do

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "readline" unless defined?(Readline)
 require "pry/input_completer"
 

--- a/spec/config/attributable_spec.rb
+++ b/spec/config/attributable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::Config::Attributable do
   subject { klass.new }
 

--- a/spec/config/lazy_value_spec.rb
+++ b/spec/config/lazy_value_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::Config::LazyValue do
   describe "#call" do
     subject { described_class.new { rand } }

--- a/spec/config/memoized_value_spec.rb
+++ b/spec/config/memoized_value_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::Config::MemoizedValue do
   describe "#call" do
     subject { described_class.new { rand } }

--- a/spec/config/value_spec.rb
+++ b/spec/config/value_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::Config::Value do
   describe "#call" do
     context "when given value is a MemoizedValue" do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::Config do
   specify { expect(subject.input).to respond_to(:readline) }
   specify { expect(subject.output).to be_an(IO) }

--- a/spec/control_d_handler_spec.rb
+++ b/spec/control_d_handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::ControlDHandler do
   context "when given eval string is non-empty" do
     let(:pry_instance) do

--- a/spec/documentation_helper_spec.rb
+++ b/spec/documentation_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry::Helpers::DocumentationHelpers do
   before do
     @helper = Pry::Helpers::DocumentationHelpers

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 describe Pry::Editor do

--- a/spec/exception_handler_spec.rb
+++ b/spec/exception_handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::ExceptionHandler do
   describe ".handle_exception" do
     let(:output) { StringIO.new }

--- a/spec/fixtures/Gemfile
+++ b/spec/fixtures/Gemfile
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'

--- a/spec/fixtures/candidate_helper1.rb
+++ b/spec/fixtures/candidate_helper1.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rank 0
 class CandidateTest
   def test1; end

--- a/spec/fixtures/candidate_helper2.rb
+++ b/spec/fixtures/candidate_helper2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rank 1
 class CandidateTest
   def test4; end

--- a/spec/fixtures/show_source_doc_examples.rb
+++ b/spec/fixtures/show_source_doc_examples.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # used by show_source_spec.rb and show_doc_spec.rb
 class TestClassForShowSource
   # doc

--- a/spec/fixtures/whereami_helper.rb
+++ b/spec/fixtures/whereami_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Layout/EmptyLineBetweenDefs
 class Cor
   def a; end

--- a/spec/helpers/command_helpers_spec.rb
+++ b/spec/helpers/command_helpers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::Helpers::CommandHelpers do
   describe "#temp_file" do
     it "yields a tempfile" do

--- a/spec/helpers/table_spec.rb
+++ b/spec/helpers/table_spec.rb
@@ -22,7 +22,8 @@ describe 'Formatting Table' do
     def try_round_trip(expected)
       things = expected.split(/\s+/).sort
       actual = Pry::Helpers.tablify(things, FAKE_COLUMNS).to_s.strip
-      [expected, actual].each { |e| e.gsub!(/\s+$/, '') }
+      expected = expected.gsub(/\s+$/, '')
+      actual = actual.gsub(/\s+$/, '')
       if actual != expected
         bar = '-' * 25
         puts \

--- a/spec/helpers/table_spec.rb
+++ b/spec/helpers/table_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe 'Formatting Table' do
   it 'knows about colorized fitting' do
     t = Pry::Helpers::Table.new %w[hihi], column_count: 1

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tempfile'
 require 'rbconfig'
 

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry::Hooks do
   before do
     @hooks = Pry::Hooks.new

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -123,14 +123,14 @@ describe Pry::Hooks do
       end
 
       it 'should preserve hook order' do
-        name = ""
+        name = ''
         h1 = Pry::Hooks.new
-        h1.add_hook(:test_hook, :testing3) { name << "h" }
-        h1.add_hook(:test_hook, :testing4) { name << "n" }
+        h1.add_hook(:test_hook, :testing3) { name += "h" }
+        h1.add_hook(:test_hook, :testing4) { name += "n" }
 
         h2 = Pry::Hooks.new
-        h2.add_hook(:test_hook, :testing1) { name << "j" }
-        h2.add_hook(:test_hook, :testing2) { name << "o" }
+        h2.add_hook(:test_hook, :testing1) { name += "j" }
+        h2.add_hook(:test_hook, :testing2) { name += "o" }
 
         h2.merge!(h1)
         h2.exec_hook(:test_hook)

--- a/spec/indent_spec.rb
+++ b/spec/indent_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Please keep in mind that any hash signs ("#") in the heredoc strings are
 # placed on purpose. Without these editors might remove the whitespace on empty
 # lines.

--- a/spec/integration/bundler_spec.rb
+++ b/spec/integration/bundler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rbconfig'
 
 RSpec.describe 'Bundler' do

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rbconfig'
 
 RSpec.describe 'The bin/pry CLI' do

--- a/spec/integration/hanami_spec.rb
+++ b/spec/integration/hanami_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "shellwords"
 require 'rbconfig'
 

--- a/spec/integration/readline_spec.rb
+++ b/spec/integration/readline_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # These specs ensure that Pry doesn't require readline until the first time a
 # REPL is started.
 

--- a/spec/method/patcher_spec.rb
+++ b/spec/method/patcher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry::Method::Patcher do
   # rubocop:disable Style/SingleLineMethods
   before do

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 describe Pry::Method do

--- a/spec/pager_spec.rb
+++ b/spec/pager_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "Pry::Pager" do
   describe "PageTracker" do
     before do

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry::Prompt do
   describe ".[]" do
     it "accesses prompts" do

--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 _version = 1
 
 describe "test Pry defaults" do

--- a/spec/pry_output_spec.rb
+++ b/spec/pry_output_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry do
   describe "output failsafe" do
     after { Pry.config.print = Pry::Config.new.print }

--- a/spec/pry_repl_spec.rb
+++ b/spec/pry_repl_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry::REPL do
   it "should let you run commands in the middle of multiline expressions" do
     ReplTester.start do

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry do
   before do
     @str_output = StringIO.new

--- a/spec/pryrc_spec.rb
+++ b/spec/pryrc_spec.rb
@@ -39,7 +39,7 @@ describe Pry do
     it "should not load the pryrc if pryrc's directory permissions do not allow this" do
       Dir.mktmpdir do |dir|
         File.chmod 0o000, dir
-        Pry::LOCAL_RC_FILE.replace File.join(dir, '.pryrc')
+        stub_const('Pry::LOCAL_RC_FILE', File.join(dir, '.pryrc'))
         Pry.config.should_load_rc = true
         expect do
           Pry.start(self, input: StringIO.new("exit-all\n"), output: StringIO.new)

--- a/spec/pryrc_spec.rb
+++ b/spec/pryrc_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry do
   describe 'loading rc files' do
     before do

--- a/spec/ring_spec.rb
+++ b/spec/ring_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry::Ring do
   let(:ring) { described_class.new(3) }
 

--- a/spec/run_command_spec.rb
+++ b/spec/run_command_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "Pry.run_command" do
   before do
     o = Object.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.start

--- a/spec/sticky_locals_spec.rb
+++ b/spec/sticky_locals_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "Sticky locals (_file_ and friends)" do
   it 'locals should all exist upon initialization' do
     expect { pry_eval '_file_', '_dir_', '_ex_', 'pry_instance', '_' }

--- a/spec/support/mock_pry.rb
+++ b/spec/support/mock_pry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def mock_pry(*args)
   args.flatten!
   binding = args.first.is_a?(Binding) ? args.shift : binding()

--- a/spec/support/repl_tester.rb
+++ b/spec/support/repl_tester.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'delegate'
 
 # This is for super-high-level integration testing.

--- a/spec/syntax_checking_spec.rb
+++ b/spec/syntax_checking_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry do
   before do
     @str_output = StringIO.new

--- a/spec/system_command_handler_spec.rb
+++ b/spec/system_command_handler_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'stringio'
 
 RSpec.describe Pry::SystemCommandHandler do

--- a/spec/unrescued_exceptions_spec.rb
+++ b/spec/unrescued_exceptions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe "Pry.config.unrescued_exceptions" do
   before do
     @str_output = StringIO.new

--- a/spec/warning_spec.rb
+++ b/spec/warning_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Pry::Warning do
   describe "#warn" do
     it "prints message with file and line of the calling frame" do

--- a/spec/wrapped_module_spec.rb
+++ b/spec/wrapped_module_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Pry::WrappedModule do
   describe "#initialize" do
     it "should raise an exception when a non-module is passed" do

--- a/spec/wrapped_module_spec.rb
+++ b/spec/wrapped_module_spec.rb
@@ -185,7 +185,8 @@ describe Pry::WrappedModule do
 
   describe ".singleton_class?" do
     it "should be true for singleton classes" do
-      expect(Pry::WrappedModule.new(class << ""; self; end).singleton_class?).to eq true
+      mod = Pry::WrappedModule.new(class << Object.new; self; end)
+      expect(mod).to be_singleton_class
     end
 
     it "should be false for normal classes" do
@@ -204,10 +205,12 @@ describe Pry::WrappedModule do
     end
 
     it "should return the attached object" do
-      expect(Pry::WrappedModule.new(class << "hi"; self; end).singleton_instance)
-        .to eq "hi"
-      expect(Pry::WrappedModule.new(class << Object; self; end).singleton_instance)
-        .to equal(Object)
+      instance = Object.new
+      mod = class << instance; self; end
+      expect(Pry::WrappedModule.new(mod).singleton_instance).to eq(instance)
+
+      klass = class << Object; self; end
+      expect(Pry::WrappedModule.new(klass).singleton_instance).to equal(Object)
     end
   end
 


### PR DESCRIPTION
Fixes #1824 (Enabling `# frozen_string_literal: true` in `~/.pryc` crashes most
operations)
