### PR TITLE
Resolve config warnings about redefined method

### DIFF
--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -108,9 +108,6 @@ class Pry
     # @return [Integer] how many input/output lines to keep in memory
     attribute :memory_size
 
-    # @return [Proc]
-    attribute :control_d_handler
-
     # @return [Proc] The proc that runs system commands
     attribute :system
 
@@ -263,6 +260,7 @@ class Pry
       @custom_attrs = @custom_attrs.dup
     end
 
+    attr_reader :control_d_handler
     def control_d_handler=(value)
       proxy_proc =
         if value.arity == 2

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -16,7 +16,6 @@ class Pry
     attr_accessor :quiet
     attr_accessor :last_internal_error
     attr_accessor :config
-    attr_writer :history
 
     def_delegators :@plugin_manager, :plugins, :load_plugins, :locate_plugins
 


### PR DESCRIPTION
I spotted "method redefined" warnings while working with Pry in another project,
which used `--warnings`. It would be nice to enable `--warnings` in RSpec,
however it's a bit tricky because our test suite has a lot of violations (on
purpose). We should strive to fix all possible warnings, though (especially
those that occur in `lib/`).