### PR TITLE
terminal: rename 'bang' methods to normal ones

### DIFF
--- a/lib/pry/color_printer.rb
+++ b/lib/pry/color_printer.rb
@@ -11,7 +11,7 @@ class Pry
     def self.default(_output, value, pry_instance)
       pry_instance.pager.open do |pager|
         pager.print pry_instance.config.output_prefix
-        pp(value, pager, Pry::Terminal.width! - 1)
+        pp(value, pager, Pry::Terminal.width - 1)
       end
     end
 

--- a/lib/pry/helpers/table.rb
+++ b/lib/pry/helpers/table.rb
@@ -5,7 +5,7 @@ class Pry
     def self.tablify_or_one_line(heading, things, config = Pry.config)
       plain_heading = Pry::Helpers::Text.strip_color(heading)
       attempt = Table.new(things, column_count: things.size)
-      if attempt.fits_on_line?(Terminal.width! - plain_heading.size - 2)
+      if attempt.fits_on_line?(Terminal.width - plain_heading.size - 2)
         "#{heading}: #{attempt}\n"
       else
         "#{heading}: \n#{tablify_to_screen_width(things, { indent: '  ' }, config)}\n"
@@ -16,10 +16,10 @@ class Pry
       options ||= {}
       things = things.compact
       if (indent = options[:indent])
-        usable_width = Terminal.width! - indent.size
+        usable_width = Terminal.width - indent.size
         tablify(things, usable_width, config).to_s.gsub(/^/, indent)
       else
-        tablify(things, Terminal.width!, config).to_s
+        tablify(things, Terminal.width, config).to_s
       end
     end
 

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -394,7 +394,7 @@ class Pry
       line_to_measure = Pry::Helpers::Text.strip_color(prompt) << code
       whitespace = ' ' * overhang
 
-      cols = Terminal.width!
+      cols = Terminal.width
       lines = cols == 0 ? 1 : (line_to_measure.length / cols + 1).to_i
 
       if Helpers::Platform.windows_ansi?

--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -88,11 +88,11 @@ class Pry
       private
 
       def height
-        @height ||= Pry::Terminal.height!
+        @height ||= Pry::Terminal.height
       end
 
       def width
-        @width ||= Pry::Terminal.width!
+        @width ||= Pry::Terminal.width
       end
     end
 

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -300,7 +300,7 @@ Readline version #{Readline::VERSION} detected - will not auto_resize! correctly
 
     trap :WINCH do
       begin
-        Readline.set_screen_size(*Terminal.size!)
+        Readline.set_screen_size(*Terminal.size)
       rescue StandardError => e
         warn "\nPry.auto_resize!'s Readline.set_screen_size failed: #{e}"
       end

--- a/lib/pry/terminal.rb
+++ b/lib/pry/terminal.rb
@@ -12,18 +12,18 @@ class Pry
       end
 
       # Return a screen size or a default if that fails.
-      def size!(default = [27, 80])
+      def size(default = [27, 80])
         screen_size || default
       end
 
       # Return a screen width or the default if that fails.
-      def width!
-        size![1]
+      def width
+        size[1]
       end
 
       # Return a screen height or the default if that fails.
-      def height!
-        size![0]
+      def height
+        size[0]
       end
 
       def actual_screen_size


### PR DESCRIPTION
To be perfectly honest, I have no idea why these methods have exclamation
marks. Maybe because they may require `io/console`? Even then, there's nothing
dangerous in this.