### PR TITLE
Fix tests that fail based on user's environment

### DIFF
--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -25,20 +25,15 @@ RSpec.describe Pry::History do
     let(:xdg_name) { 'XDG_DATA_HOME' }
     let(:default_path) { File.expand_path '~/.pry_history' }
 
-    around do |spec|
-      xdg_val = ENV[xdg_name]
-      begin spec.call
-      ensure ENV[xdg_name] = xdg_val
-      end
-    end
-
     def stub_hist(options)
       has_default = options.fetch :has_default
       xdg_home    = options.fetch :xdg_home
       allow(File).to receive(:exist?) # there's a test helper hook that hits this
-      expect(File).to receive(:exist?)
-        .with(default_path).and_return(has_default)
-      ENV[xdg_name] = xdg_home # for ENV, setting to nil is equivalent to deleting
+      allow(File).to receive(:exist?).with(default_path).and_return(has_default)
+      allow(ENV).to receive(:[])
+      allow(ENV).to receive(:key?)
+      allow(ENV).to receive(:[]).with(xdg_name).and_return(xdg_home)
+      allow(ENV).to receive(:key?).with(xdg_name).and_return(!!xdg_home)
     end
 
     it "returns ~/.local/share/pry/pry_history" do

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -26,18 +26,19 @@ RSpec.describe Pry::History do
     let(:default_path) { File.expand_path '~/.pry_history' }
 
     around do |spec|
-      xdg_val = ENV.delete xdg_name
+      xdg_val = ENV[xdg_name]
       begin spec.call
       ensure ENV[xdg_name] = xdg_val
       end
     end
 
-    # note that setting xdg_name to nil will delete it from the env vars
-    def stub_hist(has_default:, xdg_home:)
+    def stub_hist(options)
+      has_default = options.fetch :has_default
+      xdg_home    = options.fetch :xdg_home
       allow(File).to receive(:exist?) # there's a test helper hook that hits this
       expect(File).to receive(:exist?)
         .with(default_path).and_return(has_default)
-      ENV[xdg_name] = xdg_home
+      ENV[xdg_name] = xdg_home # for ENV, setting to nil is equivalent to deleting
     end
 
     it "returns ~/.local/share/pry/pry_history" do

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -22,27 +22,39 @@ RSpec.describe Pry::History do
   end
 
   describe ".default_file" do
+    let(:xdg_name) { 'XDG_DATA_HOME' }
+    let(:default_path) { File.expand_path '~/.pry_history' }
+
+    around do |spec|
+      xdg_val = ENV.delete xdg_name
+      begin spec.call
+      ensure ENV[xdg_name] = xdg_val
+      end
+    end
+
+    # note that setting xdg_name to nil will delete it from the env vars
+    def stub_hist(has_default:, xdg_home:)
+      allow(File).to receive(:exist?) # there's a test helper hook that hits this
+      expect(File).to receive(:exist?)
+        .with(default_path).and_return(has_default)
+      ENV[xdg_name] = xdg_home
+    end
+
     it "returns ~/.local/share/pry/pry_history" do
+      stub_hist has_default: false, xdg_home: nil
       expect(described_class.default_file).to match('/.local/share/pry/pry_history')
     end
 
     context "when ~/.pry_history exists" do
-      before do
-        allow(File).to receive(:exist?)
-        expect(File).to receive(:exist?)
-          .with(File.expand_path('~/.pry_history')).and_return(true)
-      end
-
       it "returns ~/.pry_history" do
-        expect(described_class.default_file).to match('/.pry_history')
+        stub_hist has_default: true, xdg_home: nil
+        expect(described_class.default_file).to eq default_path
       end
     end
 
     context "when $XDG_DATA_HOME is defined" do
-      before { ENV['XDG_DATA_HOME'] = '/my/path' }
-      after { ENV['XDG_DATA_HOME'] = nil }
-
       it "returns config location relative to $XDG_DATA_HOME" do
+        stub_hist has_default: false, xdg_home: '/my/path'
         expect(described_class.default_file).to eq('/my/path/pry/pry_history')
       end
     end


### PR DESCRIPTION
These tests were failing on my machine. I think it is because I have a `~/.pry_history` file. I modified them to not depend on the state of my machine.

I tried to write the helper function it in a way where you could easily test other configurations than the ones in the example (eg the existing tests don't say what should happen when the default file exists and the `XDG_DATA_PATH` exists).

On my branch:

```sh
$ git co fix-failing-tests
Your branch is up to date with 'josh/fix-failing-tests'.

$ rspec spec/history_spec.rb
...................

Finished in 0.72533 seconds (files took 0.47315 seconds to load)
19 examples, 0 failures
```

On master:

```sh
$ git co master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

$ git log -1 --pretty="%H"
e0e29dd12d0ab2d48059399e3aec5ce0155b4513

$ rspec spec/history_spec.rb
F.F................

Failures:

  1) Pry::History.default_file returns ~/.local/share/pry/pry_history
     Failure/Error: expect(described_class.default_file).to match('/.local/share/pry/pry_history')
       expected "/Users/josh/.pry_history" to match "/.local/share/pry/pry_history"
     # ./spec/history_spec.rb:26:in `block (3 levels) in <top (required)>'

  2) Pry::History.default_file when $XDG_DATA_HOME is defined returns config location relative to $XDG_DATA_HOME
     Failure/Error: expect(described_class.default_file).to eq('/my/path/pry/pry_history')

       expected: "/my/path/pry/pry_history"
            got: "/Users/josh/.pry_history"

       (compared using ==)
     # ./spec/history_spec.rb:46:in `block (4 levels) in <top (required)>'

Finished in 0.7934 seconds (files took 0.48008 seconds to load)
19 examples, 2 failures

Failed examples:

rspec ./spec/history_spec.rb:25 # Pry::History.default_file returns ~/.local/share/pry/pry_history
rspec ./spec/history_spec.rb:45 # Pry::History.default_file when $XDG_DATA_HOME is defined returns config location relative to $XDG_DATA_HOME
```