### PR TITLE
REPL prints to the configured output, not directly to $stdout

### DIFF
--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -50,7 +50,7 @@ class Pry
       return unless pry.config.correct_indent
 
       # Clear the line before starting Pry. This fixes issue #566.
-      Kernel.print(Helpers::Platform.windows_ansi? ? "\e[0F" : "\e[0G")
+      output.print(Helpers::Platform.windows_ansi? ? "\e[0F" : "\e[0G")
     end
 
     # The actual read-eval-print loop.


### PR DESCRIPTION
![rspec-clobbering-itself](https://user-images.githubusercontent.com/77495/58601905-709f6680-8250-11e9-8c1c-72a993aa8f11.gif)
