### PR TITLE
Remove all remaining `.should`s from the tests

### DIFF
--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -592,10 +592,7 @@ describe "edit" do
 
         it "should successfully replace a class method" do
           pry_eval 'edit -p X.x'
-
-          class << X
-            X.method(:x).owner.should == self
-          end
+          expect(X.method(:x).owner).to eq class << X; self end
           expect(X.method(:x).receiver).to eq X
           expect(X.x).to eq :maybe
         end

--- a/spec/commands/show_doc_spec.rb
+++ b/spec/commands/show_doc_spec.rb
@@ -54,9 +54,9 @@ describe "show-doc" do
   ) do
     # sample comment
     def @o.sample
-      pry_eval(binding, 'show-doc').should =~ /sample comment/
+      pry_eval(binding, 'show-doc')
     end
-    @o.sample
+    expect(@o.sample).to match(/sample comment/)
   end
 
   describe "finding find super method docs with help of `--super` switch" do

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -8,7 +8,6 @@ describe "show-source" do
     def @o.sample_method
       :sample
     end
-
     Object.remove_const :Test if Object.const_defined? :Test
     Object.const_set(:Test, Module.new)
   end
@@ -37,16 +36,18 @@ describe "show-source" do
 
   it "should output a method's source if inside method and no name given" do
     def @o.sample
-      pry_eval(binding, 'show-source').should =~ /def @o.sample/
+      pry_eval(binding, 'show-source')
     end
-    @o.sample
+    docs = @o.sample
+    expect(docs).to match(/def @o.sample/)
   end
 
   it "should output a method's source inside method using the -l switch" do
     def @o.sample
-      pry_eval(binding, 'show-source -l').should =~ /def @o.sample/
+      pry_eval(binding, 'show-source -l')
     end
-    @o.sample
+    docs = @o.sample
+    expect(docs).to match(/def @o.sample/)
   end
 
   it "should find methods even if there are spaces in the arguments" do
@@ -339,9 +340,7 @@ describe "show-source" do
         SHADOWED_VAR
       end
 
-      after do
-        Object.remove_const(:TestHost)
-      end
+      after { Object.remove_const(:TestHost) }
 
       it "source of variable takes precedence over method that is being shadowed" do
         source = @t.eval('show-source hello')
@@ -365,9 +364,7 @@ describe "show-source" do
       end
     end
 
-    after do
-      Object.remove_const(:TestHost)
-    end
+    after { Object.remove_const(:TestHost) }
 
     it "outputs source of its class if variable doesn't respond to source_location" do
       _test_host = TestHost.new

--- a/spec/commands/whereami_spec.rb
+++ b/spec/commands/whereami_spec.rb
@@ -22,14 +22,14 @@ describe "whereami" do
   it 'should work in objects with no method methods' do
     class Cor
       def blimey!
-        pry_eval(binding, 'whereami').should =~ /Cor[#]blimey!/
+        pry_eval(binding, 'whereami')
       end
 
       def method
         "moo"
       end
     end
-    Cor.new.blimey!
+    expect(Cor.new.blimey!).to match(/Cor[#]blimey!/)
     Object.remove_const(:Cor)
   end
 
@@ -37,11 +37,10 @@ describe "whereami" do
     class Cor
       def blimey!
         pry_eval(binding, 'whereami', '_file_')
-          .should == File.expand_path(__FILE__)
       end
     end
 
-    Cor.new.blimey!
+    expect(Cor.new.blimey!).to eq File.expand_path(__FILE__)
     Object.remove_const(:Cor)
   end
 
@@ -55,11 +54,11 @@ describe "whereami" do
       class Cor
         prepend Cor2
         def blimey!
-          pry_eval(binding, 'whereami').should =~ /Cor2[#]blimey!/
+          pry_eval(binding, 'whereami')
         end
       end
 
-      Cor.new.blimey!
+      expect(Cor.new.blimey!).to match(/Cor2[#]blimey!/)
 
       Object.remove_const(:Cor)
       Object.remove_const(:Cor2)
@@ -139,10 +138,10 @@ describe "whereami" do
   it 'should show code window (not just method source) if parameter passed to whereami' do
     class Cor
       def blimey!
-        pry_eval(binding, 'whereami 3').should =~ /class Cor/
+        pry_eval(binding, 'whereami 3')
       end
     end
-    Cor.new.blimey!
+    expect(Cor.new.blimey!).to match(/class Cor/)
     Object.remove_const(:Cor)
   end
 
@@ -211,11 +210,11 @@ describe "whereami" do
 
     it 'should show class when -c option used, and binding is outside a method' do
       class Cor
+        extend RSpec::Matchers
         def blimey; end
-
         out = pry_eval(binding, 'whereami -c')
-        out.should =~ /class Cor/
-        out.should =~ /blimey/
+        expect(out).to match(/class Cor/)
+        expect(out).to match(/blimey/)
       end
       Object.remove_const(:Cor)
     end
@@ -224,12 +223,12 @@ describe "whereami" do
   it 'should not show line numbers or marker when -n switch is used' do
     class Cor
       def blimey!
-        out = pry_eval(binding, 'whereami -n')
-        out.should =~ /^\s*def/
-        out.should_not =~ /\=\>/
+        pry_eval(binding, 'whereami -n')
       end
     end
-    Cor.new.blimey!
+    out = Cor.new.blimey!
+    expect(out).to match(/^\s*def/)
+    expect(out).to_not match(/\=\>/)
     Object.remove_const(:Cor)
   end
 

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -19,7 +19,7 @@ describe Pry do
     # regression test for exotic object support
     it "Should not error when return value is a BasicObject instance" do
       ReplTester.start do
-        input('BasicObject.new').should =~ /^=> #<BasicObject:/
+        expect(input('BasicObject.new')).to match(/^=> #<BasicObject:/)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,10 +37,6 @@ if ENV["SET_TRACE_FUNC"]
 end
 
 RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = [:should, :expect]
-  end
-
   config.before(:each) do
     Pry::Testable.set_testenv_variables
   end

--- a/spec/support/repl_tester.rb
+++ b/spec/support/repl_tester.rb
@@ -40,6 +40,8 @@ class ReplTester
     instance.thread.kill if instance && instance.thread && instance.thread.alive?
   end
 
+  include RSpec::Matchers
+
   attr_accessor :thread, :mailbox, :last_prompt
 
   def initialize(options = {})
@@ -71,14 +73,14 @@ class ReplTester
   end
 
   # Assert that the current prompt matches the given string or regex.
-  def prompt(match)
-    match.should === last_prompt # rubocop:disable Style/CaseEquality
+  def prompt(pattern)
+    expect(last_prompt).to match pattern
   end
 
   # Assert that the most recent output (since the last time input was called)
   # matches the given string or regex.
-  def output(match)
-    match.should === @pry.output.string.chomp # rubocop:disable Style/CaseEquality
+  def output(pattern)
+    expect(@pry.output.string.chomp).to match pattern
   end
 
   # Assert that the Pry session ended naturally after the last input.


### PR DESCRIPTION
The tests had mostly moved from `.should` to `expect(...).to eq`, but there were a few places that remained. This PR moves them over to the `expect` syntax and removes the configuration to enable the old `.should` syntax.

Rubocop did yell at me for one of the blocks being too long, so there's a few other changes in there that just turn `after do\n ... \nend` into `after { ... }` in order to shave off a few lines to appease the robot :shrug:

One that that was not obvious to me was that RSpec's `.to match whatevz` is used for both `=~` and `===` (or at least that was my conclusion, and it holds up to my experimentation, but I didn't chase it all the way down in their source, so I'm only 90% confident this is the correct way to translate these)