### PR TITLE
Close #2054 - prefer XDG_* paths (if set)

### DIFF
--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -307,12 +307,12 @@ class Pry
     def default_rc_file
       if ENV.key?('PRYRC')
         ENV['PRYRC']
-      elsif File.exist?(File.expand_path('~/.pryrc'))
-        '~/.pryrc'
       elsif ENV.key?('XDG_CONFIG_HOME') && ENV['XDG_CONFIG_HOME'] != ''
         # See XDG Base Directory Specification at
         # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
         ENV['XDG_CONFIG_HOME'] + '/pry/pryrc'
+      elsif File.exist?(File.expand_path('~/.pryrc'))
+        '~/.pryrc'
       else
         '~/.config/pry/pryrc'
       end

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -6,12 +6,12 @@ class Pry
   class History
     def self.default_file
       history_file =
-        if File.exist?(File.expand_path('~/.pry_history'))
-          '~/.pry_history'
-        elsif ENV.key?('XDG_DATA_HOME') && ENV['XDG_DATA_HOME'] != ''
+        if ENV.key?('XDG_DATA_HOME') && ENV['XDG_DATA_HOME'] != ''
           # See XDG Base Directory Specification at
           # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
           ENV['XDG_DATA_HOME'] + '/pry/pry_history'
+        elsif File.exist?(File.expand_path('~/.pry_history'))
+          '~/.pry_history'
         else
           '~/.local/share/pry/pry_history'
         end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -67,18 +67,31 @@ RSpec.describe Pry::Config do
     end
 
     context "when $XDG_CONFIG_HOME is defined" do
-      before do
-        allow(File).to receive(:exist?)
-        expect(File).to receive(:exist?)
-          .with(File.expand_path('~/.pryrc')).and_return(false)
-
-        ENV['XDG_CONFIG_HOME'] = '/xdg_home'
-      end
-
+      before { ENV['XDG_CONFIG_HOME'] = '/xdg_home' }
       after { ENV.delete('XDG_CONFIG_HOME') }
 
-      it "defaults $XDG_CONFIG_HOME/pry/pryrc" do
-        expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+      context "when ~/.pryrc exists" do
+        before do
+          allow(File).to receive(:exist?)
+          expect(File).to receive(:exist?)
+            .with(File.expand_path('~/.pryrc')).and_return(true)
+        end
+
+        it "defaults $XDG_CONFIG_HOME/pry/pryrc" do
+          expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+        end
+      end
+
+      context "when ~/.pryrc doesn't exist" do
+        before do
+          allow(File).to receive(:exist?)
+          expect(File).to receive(:exist?)
+            .with(File.expand_path('~/.pryrc')).and_return(false)
+        end
+
+        it "defaults $XDG_CONFIG_HOME/pry/pryrc" do
+          expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+        end
       end
     end
   end

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -53,6 +53,11 @@ RSpec.describe Pry::History do
         stub_hist has_default: false, xdg_home: '/my/path'
         expect(described_class.default_file).to eq('/my/path/pry/pry_history')
       end
+
+      it "returns config location relative to $XDG_DATA_HOME when ~/.pryrc exists" do
+        stub_hist has_default: true, xdg_home: '/my/path'
+        expect(described_class.default_file).to eq('/my/path/pry/pry_history')
+      end
     end
   end
 


### PR DESCRIPTION
References #2054

Using XDG_* paths (if set) with preference higher than the
home dir, for pry config and history files.

Testing: ran `bundle exec rspec`, observed the tests pass.