### PR TITLE
spec/config: fix flaky test

### DIFF
--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -56,14 +56,18 @@ RSpec.describe Pry::Config do
       end
     end
 
-    context "when ~/.pryrc exists" do
+    context "when ~/.pryrc exists and $XDG_CONFIG_HOME is undefined" do
       before do
         allow(File).to receive(:exist?)
         expect(File).to receive(:exist?)
           .with(File.expand_path('~/.pryrc')).and_return(true)
+
+        allow(Pry::Env).to receive(:[])
+        allow(Pry::Env).to receive(:[])
+          .with('XDG_CONFIG_HOME').and_return(nil)
       end
 
-      it "defaults ~/.pryrc" do
+      it "defaults to ~/.pryrc" do
         expect(subject.rc_file).to eq('~/.pryrc')
       end
     end


### PR DESCRIPTION
This spec was failing for me locally (but worked well on Circle). The reason
is that `XDG_CONFIG_HOME` is set for me and takes precedence. Therefore, the fix
would be to unset it for the test.