### PR TITLE
Attempt to allow pasting multiple lines with leading dots

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -166,7 +166,7 @@ class Pry
         prefix = convert_to_regex(Pry.config.command_prefix)
         prefix = "(?:#{prefix})?" unless options[:use_prefix]
 
-        /^#{prefix}#{convert_to_regex(match)}(?!\S)/
+        /\A#{prefix}#{convert_to_regex(match)}(?!\S)/
       end
 
       def convert_to_regex(obj)

--- a/lib/pry/testable/pry_tester.rb
+++ b/lib/pry/testable/pry_tester.rb
@@ -29,7 +29,15 @@ class Pry
             if @pry.process_command(str)
               last_command_result_or_output
             else
-              @pry.evaluate_ruby(str)
+              # Check if this is a multiline paste.
+              begin
+                complete_expr = Pry::Code.complete_expression?(str)
+              rescue SyntaxError => exception
+                @pry.output.puts(
+                  "SyntaxError: #{exception.message.sub(/.*syntax error, */m, '')}"
+                )
+              end
+              @pry.evaluate_ruby(str) if complete_expr
             end
         end
 

--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -456,7 +456,7 @@ describe "commands" do
       end
     end
 
-    expect(pry_tester(commands: klass).eval("def yo\nhello\n")).to eq 7
+    expect(pry_tester(commands: klass).eval("def yo", "hello")).to eq 7
   end
 
   it(
@@ -469,7 +469,7 @@ describe "commands" do
       end
     end
 
-    expect(pry_tester(commands: klass).eval("def yo\nhello\n")).to eq 5
+    expect(pry_tester(commands: klass).eval("def yo", "hello\n")).to eq 5
   end
 
   it 'should set the commands default, and the default should be overridable' do

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe Pry::Command do
       before { subject.command_options(use_prefix: true) }
 
       it "returns a Regexp without a prefix" do
-        expect(subject.command_regex).to eq(/^test\-command(?!\S)/)
+        expect(subject.command_regex).to eq(/\Atest\-command(?!\S)/)
       end
     end
 
@@ -350,7 +350,7 @@ RSpec.describe Pry::Command do
       before { subject.command_options(use_prefix: false) }
 
       it "returns a Regexp with a prefix" do
-        expect(subject.command_regex).to eq(/^(?:)?test\-command(?!\S)/)
+        expect(subject.command_regex).to eq(/\A(?:)?test\-command(?!\S)/)
       end
     end
   end


### PR DESCRIPTION
Two tests are breaking, and I kind of understand why (the `pry_tester` command tries to evaluate them), but I'm not sure what to do about it. Figured I should commit and send a PR in hopes of another brain being able to help me out :)

It seems to behave correctly in practice, eg:

![image](https://user-images.githubusercontent.com/77495/59195926-e958c980-8b52-11e9-8a09-c3d99b250ac2.png)