### PR TITLE
Allow negative ranges in hist --show

### DIFF
--- a/lib/pry/commands/hist.rb
+++ b/lib/pry/commands/hist.rb
@@ -52,8 +52,6 @@ class Pry
             @history.take_lines(1, opts[:head] || 10)
           elsif opts.present?(:tail)
             @history.take_lines(-(opts[:tail] || 10), opts[:tail] || 10)
-          elsif opts.present?(:show)
-            @history.between(opts[:show])
           else
             @history
           end

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -132,6 +132,15 @@ describe "hist" do
     expect(out).to match(/b\n\d+:.*c\n\d+:.*d/)
   end
 
+  it 'should show lines between offsets A and B with the --show switch' do
+    ("a".."f").each do |v|
+      @hist.push v
+    end
+
+    out = @t.eval 'hist --show -4..-2'
+    expect(out).to eq "3: c\n4: d\n5: e\n"
+  end
+
   it "should store a call with `--replay` flag" do
     @t.eval ":banzai"
     @t.eval "hist --replay 1"


### PR DESCRIPTION
Remove duplicate `opts[:show]` check in hist.

Back in the day, when 10b223855e2dc073ab9eaa2c728600262c5452fb merged 645821e4d8b70db36406fa2501f57ae84e049ba0, the check for `show` and `grep` options were [moved](https://github.com/pry/pry/commit/10b223855e2dc073ab9eaa2c728600262c5452fb#diff-bfd594524f67aa64a92c2e9b84731c68R35-R37) to be checked first. However, in the original commit, [the `show` check was deleted](https://github.com/pry/pry/commit/645821e4d8b70db36406fa2501f57ae84e049ba0#diff-4a801a57f817d827c6b3449b120733a4L175-L176), while the merge commit [kept it](https://github.com/pry/pry/commit/10b223855e2dc073ab9eaa2c728600262c5452fb#diff-bfd594524f67aa64a92c2e9b84731c68R48-R49).

It seems like the only side effect of this has to do with using ranges with negative indices. For example, if the history has 20 items, `hist --show 0...-5` will show 10 items, because it has been truncated twice. Ranges where the start index was negative - which will also be the maximum size of the resulting slice - would fail unless the ending index was -1, inclusive.