### PR TITLE
WIP: add a rescue to ArgumentError exception to show a better output

### DIFF
--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -289,6 +289,10 @@ class Pry
 
     result = current_binding.eval(code, Pry.eval_path, Pry.current_line)
     set_last_result(result, code)
+  rescue ArgumentError => e
+    invocation = code.strip
+    output.puts "Method Signature: #{Pry::Method.from_str(invocation).signature}\n"
+    raise e
   ensure
     update_input_history(code)
     exec_hook :after_eval, result, self


### PR DESCRIPTION
This PR solves #2044 . It adds a rescue to an ArgumentError exception and shows the method signature.

Missing specs.

![Screen Shot 2019-08-30 at 15 47 59](https://user-images.githubusercontent.com/27960597/64063593-6f256780-cbcc-11e9-8a3d-1d5adb9a8679.png)
