### PR TITLE
Fix Ruby 2.7 compatibility in Pry::Slop#mehtod_missing

### DIFF
--- a/lib/pry/slop.rb
+++ b/lib/pry/slop.rb
@@ -454,7 +454,7 @@ class Pry
     def method_missing(method, *args, &block)
       meth = method.to_s
       if meth.end_with?('?')
-        meth.chop!
+        meth = meth.chop
         present?(meth) || present?(meth.tr('_', '-'))
       else
         super


### PR DESCRIPTION
Recently an experimental feature has been merged in Ruby's master https://bugs.ruby-lang.org/issues/16150

In short `Symbol#to_s` will return a frozen string, whereas before it would always return a new mutable string.

Because of this `Pry::Slop#method_missing` breaks on `ruby-head`.

The fix is quite straightforward, I simply reworked the code a little bit to avoid mutating the string.