### PR TITLE
Handle  multiline string prompt #2065

### DIFF
--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -8,7 +8,7 @@ class Pry
   # @example Registering a new Pry prompt
   #   Pry::Prompt.add(
   #     :ipython,
-  #     'IPython-like prompt', [':', '...:', '...\"', '...\' ]
+  #     'IPython-like prompt', [':', '...:', '...\"', '...\'' ]
   #   ) do |_context, _nesting, pry_instance, sep|
   #     sep == ':' ? "In [#{pry_instance.input_ring.count}]: " : '   ...: '
   #   end

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -469,10 +469,7 @@ class Pry
     )
 
     Pry.critical_section do
-      # If input buffer is empty, then use normal prompt. Otherwise use the wait
-      # prompt (indicating multi-line expression).
       if prompt.is_a?(Pry::Prompt)
-        prompt_proc = eval_string.empty? ? prompt.wait_proc : prompt.incomplete_proc
         return prompt_proc.call(c.object, c.nesting_level, c.pry_instance)
       end
 
@@ -484,7 +481,6 @@ class Pry
           "Use Pry::Prompt API instead"
         )
       end
-
       # If input buffer is empty then use normal prompt
       if eval_string.empty?
         generate_prompt(Array(prompt).first, c)
@@ -492,6 +488,24 @@ class Pry
       else
         generate_prompt(Array(prompt).last, c)
       end
+    end
+  end
+
+  # If input buffer is empty, then use normal prompt.
+  # If input buffer starts with a double quoted string,
+  #   then use string_proc.
+  # If input buffer starts with a single quoted string,
+  #   then use single_quote_string_proc.
+  # Otherwise use the wait prompt (indicating multi-line expression).
+  def prompt_proc
+    return prompt.wait_proc if eval_string.empty?
+
+    if eval_string.start_with?('"', "<<", "%Q(")
+      prompt.string_proc
+    elsif eval_string.start_with?("'", "%q(")
+      prompt.single_quote_string_proc
+    else
+      prompt.incomplete_proc
     end
   end
 

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -26,9 +26,9 @@ describe Pry::Prompt do
       expect(described_class[:my_prompt]).to be_a(described_class)
     end
 
-    it "raises error when separators.size != 2" do
-      expect { described_class.add(:my_prompt, '', [1, 2, 3]) }
-        .to raise_error(ArgumentError, /separators size must be 2/)
+    it "raises error when separators.size != 4" do
+      expect { described_class.add(:my_prompt, '', 1..5) }
+        .to raise_error(ArgumentError, /separators size must be 4/)
     end
 
     it "raises error on adding a prompt with the same name" do
@@ -44,21 +44,21 @@ describe Pry::Prompt do
 
   describe "#name" do
     it "returns name" do
-      prompt = described_class.new(:test, '', Array.new(2) { proc { '' } })
+      prompt = described_class.new(:test, '', Array.new(4) { proc { '' } })
       expect(prompt.name).to eq(:test)
     end
   end
 
   describe "#description" do
     it "returns description" do
-      prompt = described_class.new(:test, 'descr', Array.new(2) { proc { '' } })
+      prompt = described_class.new(:test, 'descr', Array.new(4) { proc { '' } })
       expect(prompt.description).to eq('descr')
     end
   end
 
   describe "#prompt_procs" do
     it "returns the proc array" do
-      prompt_procs = [proc { '>' }, proc { '*' }]
+      prompt_procs = [proc { '>' }, proc { '*' }, proc { "'" }, proc { "'" }]
       prompt = described_class.new(:test, 'descr', prompt_procs)
       expect(prompt.prompt_procs).to eq(prompt_procs)
     end
@@ -66,17 +66,33 @@ describe Pry::Prompt do
 
   describe "#wait_proc" do
     it "returns the first proc" do
-      prompt_procs = [proc { '>' }, proc { '*' }]
+      prompt_procs = [proc { '>' }, proc { '*' }, proc { "'" }, proc { "'" }]
       prompt = described_class.new(:test, '', prompt_procs)
-      expect(prompt.wait_proc).to eq(prompt_procs.first)
+      expect(prompt.wait_proc).to eq(prompt_procs[0])
     end
   end
 
   describe "#incomplete_proc" do
     it "returns the second proc" do
-      prompt_procs = [proc { '>' }, proc { '*' }]
+      prompt_procs = [proc { '>' }, proc { '*' }, proc { "'" }, proc { "'" }]
       prompt = described_class.new(:test, '', prompt_procs)
-      expect(prompt.incomplete_proc).to eq(prompt_procs.last)
+      expect(prompt.incomplete_proc).to eq(prompt_procs[1])
+    end
+  end
+
+  describe "#string_proc" do
+    it "returns the second proc" do
+      prompt_procs = [proc { '>' }, proc { '*' }, proc { "'" }, proc { "'" }]
+      prompt = described_class.new(:test, '', prompt_procs)
+      expect(prompt.string_proc).to eq(prompt_procs[2])
+    end
+  end
+
+  describe "#single_quote_string_proc" do
+    it "returns the second proc" do
+      prompt_procs = [proc { '>' }, proc { '*' }, proc { "'" }, proc { "'" }]
+      prompt = described_class.new(:test, '', prompt_procs)
+      expect(prompt.single_quote_string_proc).to eq(prompt_procs[3])
     end
   end
 

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -27,7 +27,7 @@ describe Pry::Prompt do
     end
 
     it "raises error when separators.size != 4" do
-      expect { described_class.add(:my_prompt, '', 1..5) }
+      expect { described_class.add(:my_prompt, '', (1..5).to_a) }
         .to raise_error(ArgumentError, /separators size must be 4/)
     end
 

--- a/spec/prompt_spec.rb
+++ b/spec/prompt_spec.rb
@@ -58,7 +58,7 @@ describe Pry::Prompt do
 
   describe "#prompt_procs" do
     it "returns the proc array" do
-      prompt_procs = [proc { '>' }, proc { '*' }, proc { "'" }, proc { "'" }]
+      prompt_procs = [proc { '>' }, proc { '*' }, proc { '"' }, proc { "'" }]
       prompt = described_class.new(:test, 'descr', prompt_procs)
       expect(prompt.prompt_procs).to eq(prompt_procs)
     end
@@ -66,7 +66,7 @@ describe Pry::Prompt do
 
   describe "#wait_proc" do
     it "returns the first proc" do
-      prompt_procs = [proc { '>' }, proc { '*' }, proc { "'" }, proc { "'" }]
+      prompt_procs = [proc { '>' }, proc { '*' }, proc { '"' }, proc { "'" }]
       prompt = described_class.new(:test, '', prompt_procs)
       expect(prompt.wait_proc).to eq(prompt_procs[0])
     end
@@ -74,7 +74,7 @@ describe Pry::Prompt do
 
   describe "#incomplete_proc" do
     it "returns the second proc" do
-      prompt_procs = [proc { '>' }, proc { '*' }, proc { "'" }, proc { "'" }]
+      prompt_procs = [proc { '>' }, proc { '*' }, proc { '"' }, proc { "'" }]
       prompt = described_class.new(:test, '', prompt_procs)
       expect(prompt.incomplete_proc).to eq(prompt_procs[1])
     end
@@ -82,7 +82,7 @@ describe Pry::Prompt do
 
   describe "#string_proc" do
     it "returns the second proc" do
-      prompt_procs = [proc { '>' }, proc { '*' }, proc { "'" }, proc { "'" }]
+      prompt_procs = [proc { '>' }, proc { '*' }, proc { '"' }, proc { "'" }]
       prompt = described_class.new(:test, '', prompt_procs)
       expect(prompt.string_proc).to eq(prompt_procs[2])
     end
@@ -90,7 +90,7 @@ describe Pry::Prompt do
 
   describe "#single_quote_string_proc" do
     it "returns the second proc" do
-      prompt_procs = [proc { '>' }, proc { '*' }, proc { "'" }, proc { "'" }]
+      prompt_procs = [proc { '>' }, proc { '*' }, proc { '"' }, proc { "'" }]
       prompt = described_class.new(:test, '', prompt_procs)
       expect(prompt.single_quote_string_proc).to eq(prompt_procs[3])
     end

--- a/spec/pry_repl_spec.rb
+++ b/spec/pry_repl_spec.rb
@@ -97,6 +97,58 @@ describe Pry::REPL do
         prompt(/> $/)
       end
     end
+
+    describe "multiline string handling" do
+      it "should change prompt between double quoted multiline strings" do
+        ReplTester.start do
+          prompt("[1] pry(main)> ")
+          input '"'
+          prompt("[1] pry(main)\" ")
+          input '"'
+          prompt("[2] pry(main)> ")
+        end
+      end
+
+      it "should change prompt between single quoted multiline strings" do
+        ReplTester.start do
+          prompt("[1] pry(main)> ")
+          input "'"
+          prompt("[1] pry(main)\' ")
+          input "'"
+          prompt("[2] pry(main)> ")
+        end
+      end
+
+      it "should change prompt between HEREDOC multiline strings" do
+        ReplTester.start do
+          prompt("[1] pry(main)> ")
+          input '<<FOO'
+          prompt("[1] pry(main)\" ")
+          input 'FOO'
+          prompt("[2] pry(main)> ")
+        end
+      end
+
+      it "should change prompt between interpolated string % notation" do
+        ReplTester.start do
+          prompt("[1] pry(main)> ")
+          input '%q('
+          prompt("[1] pry(main)' ")
+          input ')'
+          prompt("[2] pry(main)> ")
+        end
+      end
+
+      it "should change prompt between string % notation" do
+        ReplTester.start do
+          prompt("[1] pry(main)> ")
+          input '%Q('
+          prompt("[1] pry(main)\" ")
+          input ')'
+          prompt("[2] pry(main)> ")
+        end
+      end
+    end
   end
 
   describe "space prefix" do


### PR DESCRIPTION
This PR tries to solve https://github.com/pry/pry/issues/2065 by adding two new `Prompt` for single and double quoted strings. 

I've added `"` and `'` in separators array on `Prompt.add` which in my humble opinion could be a bit tricky since we are depending on the position of those elements. As far as I understand this is a breaking change of the Prompt API and maybe we can take the chance to change the API to something easier to read, for instance `def add(name, description = '', wait_proc_separator:, incomplete_proc_separator:, string_proc_separator:, single_quote_string_proc_separator:)`.

I'm not sure of the solution but I'm open to change it with your feedback 🙏 

### Pending
- [ ] Update CHANGELOG.md
