### PR TITLE
Directly delegate internally-used Method methods

### DIFF
--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -18,6 +18,7 @@ class Pry
   # This class wraps the normal `Method` and `UnboundMethod` classes
   # to provide extra functionality useful to Pry.
   class Method # rubocop:disable Metrics/ClassLength
+    extend Forwardable
     extend Helpers::BaseHelpers
     include Helpers::BaseHelpers
     include Helpers::DocumentationHelpers
@@ -260,6 +261,8 @@ class Pry
       @visibility = known_info[:visibility]
     end
 
+    def_delegators :@method, :owner, :parameters, :receiver
+
     # Get the name of the method as a String, regardless of the underlying
     # Method#name type.
     #
@@ -303,6 +306,11 @@ class Pry
                   when :ruby
                     ruby_source
                   end
+    end
+
+    # @return [Array<(String, Integer)>] The location of the source code of the method.
+    def source_location
+      @method.__send__(:source_location)
     end
 
     # Update the live copy of the method's source.


### PR DESCRIPTION
Relying on `method_missing` for all delegation to `Method` methods means
that it's easier for the wrong method to be called when gems mess with
`Object` or other such core areas.

See https://github.com/ankane/ownership/pull/3 for an example of this.

By defining explicit delegators, at least for the methods that we use
internally withing Pry, we can eliminate this issue and be more
communicative around the methods on the `Pry::Method` class.

For `source_location`, I went with a direct method definition using
`__send__` due to `Forwardable` complaining that it was being told to
delegate to a private method. `Method#source_location` isn't private,
but `NilClass#source_location` is, so the direct definition alleviated the
warning message for when `@method` is undefined.