### PR TITLE
Test against MRI 2.7.0-preview1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,15 @@ jobs:
       - <<: *bundle_install
       - <<: *install_ubuntu_nano
       - <<: *unit
+  "ruby-2.7":
+    docker:
+      - image: circleci/ruby:2.7.0-preview1
+    working_directory: ~/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *install_ubuntu_nano
+      - <<: *unit
   "jruby-9.1-jdk":
     docker:
       - image: circleci/jruby:9.1-jdk
@@ -183,6 +192,10 @@ workflows:
             - rubocop_lint
             - yard_lint
       - "ruby-2.6":
+          requires:
+            - rubocop_lint
+            - yard_lint
+      - "ruby-2.7":
           requires:
             - rubocop_lint
             - yard_lint


### PR DESCRIPTION
@kyrylo as discussed in #2084, `preview2` is not yet available, and testing against `ruby-head` is not ideal because CircleCI make it hard to allow failures.

However this PR puts 2.7 testing in place, I'll try to remember to submit a PR to update `preview1` to `preview2` whenever it's available (hopefully soon).