### PR TITLE
Fix completion_spec on MRI 2.7.0

### DIFF
--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -239,7 +239,7 @@ describe Pry::InputCompleter do
   unless Pry::Helpers::Platform.jruby?
     # Classes that override .hash are still hashable in JRuby, for some reason.
     it 'ignores methods from modules that override Object#hash incompatibly' do
-      # skip unless Pry::Helpers::Platform.jruby?
+      require 'irb'
 
       m = Module.new do
         def self.hash; end


### PR DESCRIPTION
Ref: https://github.com/pry/pry/pull/2087

The spec was failing because on 2.7 hash directly return nil without
hashing the key if they are empty:

```ruby
m = Module.new do
  def self.hash; end
end

h = {}
h[m] # => nil
h[1] = 2
h[m] # => ArgumentError
```

So we need to require IRB so that the to_ignore set isn't empty.

@kyrylo 