### PR TITLE
removed gist section - Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,24 +345,6 @@ pry(main) ri Array#each
         a -- b -- c --
 ```
 
-### Gist integration
-
-If the `gist` gem is installed then method source or documentation can be gisted
-to GitHub with the `gist` command.  The `gist` command is capable of gisting
-[almost any REPL content](https://gist.github.com/cae143e4533416529726),
-including methods, documentation, input expressions, command source, and so
-on. In the example below we will gist the C source code for the `Symbol#to_proc`
-method to GitHub:
-
-```ruby
-pry(main)> gist -m Symbol#to_proc
-Gist created at https://gist.github.com/5332c38afc46d902ce46 and added to clipboard.
-pry(main)>
-```
-
-You can see the actual gist generated here:
-[https://gist.github.com/5332c38afc46d902ce46](https://gist.github.com/5332c38afc46d902ce46)
-
 ### Edit methods
 
 You can use `edit Class#method` or `edit my_method` (if the method is in scope)


### PR DESCRIPTION
Since Github no longer supports anonymous gists it would be good to either 

(the examples will fail with 
`RuntimeError: Got Net::HTTPUnauthorized from gist: {"message":"Requires authentication","documentation_url":"https://developer.github.com/v3/gists/#create-a-gist"}`)

a) delete this section (like proposed in this pull request) or
b) change it with code working 