### PR TITLE
Fix: Rubocop: Layout/EmptyLineAfterMagicComment

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # (C) John Mair (banisterfiend) 2016
 # MIT License
 


### PR DESCRIPTION
Add an empty line after magic comments.

I wanted to check what causes build break and, when I saw what was it, I had to just simply fix it. :)

The issue happened due to reverting of an older commit. Seems like the code wasn't checked with rubocop before (or build was constantly failing or this rule was disabled) and that frozen string magic comment was added in between comment removal and reverting of that commit that removed the comment.

Either way, one empty line added, should fix the build.