### PR TITLE
Add Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@ Pry
 * [YARD API documentation](http://www.rubydoc.info/gems/pry)
 * [Wiki](https://github.com/pry/pry/wiki)
 
+Table of Contents
+=================
+
+* [Introduction](#introduction)
+* [Key features](#key-features)
+* [Installation](#installation)
+* [Overview](#overview)
+   * [Commands](#commands)
+   * [Navigating around state](#navigating-around-state)
+   * [Runtime invocation](#runtime-invocation)
+   * [Command Shell Integration](#command-shell-integration)
+   * [Code Browsing](#code-browsing)
+   * [Documentation Browsing](#documentation-browsing)
+   * [Gist integration](#gist-integration)
+   * [Edit methods](#edit-methods)
+   * [Live Help System](#live-help-system)
+   * [Use Pry as your Rails Console](#use-pry-as-your-rails-console)
+   * [Syntax Highlighting](#syntax-highlighting)
+* [Supported Rubies](#supported-rubies)
+* [Contact](#contact)
+* [License](#license)
+* [Contributors](#contributors)
+
 Introduction
 ------------
 


### PR DESCRIPTION
I found it a little bit hard to navigate the README.md so in case you want to merge this, I've added a Table of Contents.

The ToC was generated using: https://github.com/ekalinin/github-markdown-toc
(I've additionally modified the ToC output)

It was inspired by these two READMEs (first two I found:
https://github.com/webpack/webpack

https://github.com/ekalinin/envirius/blob/24ea3be0d3cc03f4235fa4879bb33dc122d0ae29/README.md

