### PR TITLE
Fix: Convert HTTP links to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Pry
 
 [![Circle Build Status](https://circleci.com/gh/pry/pry.svg?style=shield)](https://circleci.com/gh/pry/pry)
 [![Code Climate](https://codeclimate.com/github/pry/pry.svg)](https://codeclimate.com/github/pry/pry)
-[![Gem Version](https://badge.fury.io/rb/pry.svg)](http://badge.fury.io/rb/pry)
-[![Documentation Status](http://inch-ci.org/github/pry/pry.svg?branch=master)](http://inch-ci.org/github/pry/pry)
+[![Gem Version](https://badge.fury.io/rb/pry.svg)](https://badge.fury.io/rb/pry)
+[![Documentation Status](https://inch-ci.org/github/pry/pry.svg?branch=master)](https://inch-ci.org/github/pry/pry)
 [![Downloads](https://img.shields.io/gem/dt/pry.svg?style=flat)](https://rubygems.org/gems/pry)
 
 ![Pry logo](https://www.dropbox.com/s/zp8o63kquby2rln/pry_logo_350.png?raw=1)
@@ -21,8 +21,8 @@ Pry
 
 **Links:**
 
-* http://pryrepl.org/
-* [YARD API documentation](http://www.rubydoc.info/gems/pry)
+* https://pryrepl.org/
+* [YARD API documentation](https://www.rubydoc.info/gems/pry)
 * [Wiki](https://github.com/pry/pry/wiki)
 
 Introduction


### PR DESCRIPTION
I just noticed that none of HTTP links in the README worked.
I've updated them to their HTTPS equivalents.

It could be that my computer some issues loading HTTP pages, but still, I believe HTTPS should be preferred when avaialable.