### PR TITLE
Fix whereami -c bug when class definition is not beginning of line

### DIFF
--- a/lib/pry/wrapped_module/candidate.rb
+++ b/lib/pry/wrapped_module/candidate.rb
@@ -103,7 +103,7 @@ class Pry
 
       def class_regexes
         mod_type_string = wrapped.class.to_s.downcase
-        [/^\s*#{mod_type_string}\s+(?:(?:\w*)::)*?#{wrapped.name.split(/::/).last}/,
+        [/(^|=)\s*#{mod_type_string}\s+(?:(?:\w*)::)*?#{wrapped.name.split(/::/).last}/,
          /^\s*(::)?#{wrapped.name.split(/::/).last}\s*?=\s*?#{wrapped.class}/,
          /^\s*(::)?#{wrapped.name.split(/::/).last}\.(class|instance)_eval/]
       end

--- a/spec/commands/whereami_spec.rb
+++ b/spec/commands/whereami_spec.rb
@@ -218,6 +218,17 @@ describe "whereami" do
       end
       Object.remove_const(:Cor)
     end
+
+    it 'should show class when -c option used, and beginning of the class is on the' \
+       'same line as another expression' do
+      out = class Cor
+              def blimey; end
+              pry_eval(binding, 'whereami -c')
+            end
+      expect(out).to match(/class Cor/)
+      expect(out).to match(/blimey/)
+      Object.remove_const(:Cor)
+    end
   end
 
   it 'should not show line numbers or marker when -n switch is used' do


### PR DESCRIPTION
This PR fixes the bug reported in #2052 