### PR TITLE
Backport "Ruby 2.6 warning for Binding#source_location" to v0.12.x

### DIFF
--- a/lib/pry/commands/edit/file_and_line_locator.rb
+++ b/lib/pry/commands/edit/file_and_line_locator.rb
@@ -3,7 +3,11 @@ class Pry
     module FileAndLineLocator
       class << self
         def from_binding(target)
-          [target.eval("__FILE__"), target.eval("__LINE__")]
+          if target.respond_to?(:source_location)
+            target.source_location
+          else
+            [target.eval("__FILE__"), target.eval("__LINE__")]
+          end
         end
 
         def from_code_object(code_object, filename_argument)

--- a/lib/pry/commands/play.rb
+++ b/lib/pry/commands/play.rb
@@ -86,7 +86,13 @@ class Pry
     # The file to play from when no code object is specified.
     # e.g `play --lines 4..10`
     def default_file
-      target.eval("__FILE__") && File.expand_path(target.eval("__FILE__"))
+      file =
+        if target.respond_to?(:source_location)
+          target.source_location.first
+        else
+          target.eval("__FILE__")
+        end
+      file && File.expand_path(file)
     end
 
     def file_content

--- a/lib/pry/commands/reload_code.rb
+++ b/lib/pry/commands/reload_code.rb
@@ -27,7 +27,13 @@ class Pry
     private
 
     def current_file
-      File.expand_path target.eval("__FILE__")
+      file =
+        if target.respond_to?(:source_location)
+          target.source_location.first
+        else
+          target.eval("__FILE__")
+        end
+      File.expand_path file
     end
 
     def reload_current_file

--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -37,8 +37,13 @@ class Pry
     BANNER
 
     def setup
-      @file = expand_path(target.eval('__FILE__'))
-      @line = target.eval('__LINE__')
+      if target.respond_to?(:source_location)
+        file, @line = target.source_location
+        @file = expand_path(file)
+      else
+        @file = expand_path(target.eval('__FILE__'))
+        @line = target.eval('__LINE__')
+      end
       @method = Pry::Method.from_binding(target)
     end
 

--- a/lib/pry/method/weird_method_locator.rb
+++ b/lib/pry/method/weird_method_locator.rb
@@ -25,8 +25,12 @@ class Pry
         # @return [Boolean]
         def normal_method?(method, b)
           if method and method.source_file and method.source_range
-            binding_file, binding_line = b.eval('__FILE__'), b.eval('__LINE__')
-            File.expand_path(method.source_file) == File.expand_path(binding_file) and
+            if b.respond_to?(:source_location)
+              binding_file, binding_line = b.source_location
+            else
+              binding_file, binding_line = b.eval('__FILE__'), b.eval('__LINE__')
+            end
+            (File.expand_path(method.source_file) == File.expand_path(binding_file)) and
             method.source_range.include?(binding_line)
           end
         rescue
@@ -77,15 +81,31 @@ class Pry
       end
 
       def target_file
-        pry_file? ? target.eval('__FILE__') : File.expand_path(target.eval('__FILE__'))
+        file =
+          if target.respond_to?(:source_location)
+            target.source_location.first
+          else
+            target.eval('__FILE__')
+          end
+        pry_file? ? file : File.expand_path(file)
       end
 
       def target_line
-        target.eval('__LINE__')
+        if target.respond_to?(:source_location)
+          target.source_location.last
+        else
+          target.eval('__LINE__')
+        end
       end
 
       def pry_file?
-        Pry.eval_path == target.eval('__FILE__')
+        file =
+          if target.respond_to?(:source_location)
+            target.source_location.first
+          else
+            target.eval('__FILE__')
+          end
+        Pry.eval_path == file
       end
 
       # it's possible in some cases that the method we find by this approach is a sub-method of


### PR DESCRIPTION
I have cherry-picked the commit from https://github.com/pry/pry/pull/1904 into the v0.12.x code. The one change I made along the way was to conform to the pre-existing syntax (`and` instead of `&&`) in the v0.12.x version of `WeirdMethodLocator#normal_method?`

This is in hopes of getting a v0.12.3 release, as discussed in https://github.com/pry/pry/issues/2096, to fix warnings in the current version of Ruby. I have left out the multi-line paste changes discussed in the issue, as I can imagine it surprising those who are used to / assume the previous behavior.

Thanks for `pry`, it is awesome and I use it nearly every day.