### PR TITLE
I fix `warning: deprecated Object#=~ is called on Proc; it always returns nil` in Ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'rake', '~> 10.0'
+gem 'rake'
 gem 'yard'
 gem 'rspec', '~> 3.8.0'
 


### PR DESCRIPTION
## Description

I fix belog warning in Ruby 2.7

```ruby
pry/vendor/bundle/ruby/2.7.0/gems/rake-10.5.0/lib/rake/application.rb:381: warning: deprecated Object#=~ is called on Proc; it always returns nil
```

## See Also

- https://github.com/ruby/rake/pull/297
