### PR TITLE
exceptions: check if $SAFE is supported by Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
   are set, Pry no longer uses traditional files like `~/.pryrc` &
   `~/.pry_history`. Instead, the env variable paths are loaded first
   ([#2056](https://github.com/pry/pry/pull/2056))
+* Fixed the `$SAFE will become a normal global variable in Ruby 3.0` warning on
+  Ruby 2.7 ([#2107](https://github.com/pry/pry/pull/2107))
 
 ### [v0.12.2][v0.12.2] (November 12, 2018)
 

--- a/lib/pry/exceptions.rb
+++ b/lib/pry/exceptions.rb
@@ -27,7 +27,11 @@ class Pry
   # Catches SecurityErrors if $SAFE is set
   module TooSafeException
     def self.===(exception)
-      $SAFE > 0 && exception.is_a?(SecurityError)
+      if Pry::HAS_SAFE_LEVEL
+        $SAFE > 0 && exception.is_a?(SecurityError)
+      else
+        exception.is_a?(SecurityError)
+      end
     end
   end
 

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -6,6 +6,13 @@ require 'pathname'
 class Pry
   LOCAL_RC_FILE = "./.pryrc".freeze
 
+  # @return [Boolean] true if this Ruby supports safe levels and tainting,
+  #  to guard against using deprecated or unsupported features
+  HAS_SAFE_LEVEL = (
+    RUBY_ENGINE == 'ruby' &&
+    Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7')
+  )
+
   class << self
     extend Pry::Forwardable
     attr_accessor :custom_completions


### PR DESCRIPTION
Fixes #2099 ($SAFE will become a normal global variable in Ruby 3.0)

MRI < 2.7 supports `$SAFE` variable, which is associated with
taint/untaint methods. All of that is deprecated in 2.7 with a lot of
warning messages generated, and no other effect.

None of this is supported on other Ruby platforms.

Related Ruby ticket:
https://bugs.ruby-lang.org/issues/8468