### PR TITLE
gemspec: bump method_source to `~> 1.0`

### DIFF
--- a/pry.gemspec
+++ b/pry.gemspec
@@ -35,7 +35,7 @@ DESC
   s.files         = `git ls-files bin lib *.md LICENSE`.split("\n")
 
   s.add_dependency 'coderay', '~> 1.1'
-  s.add_dependency 'method_source', '~> 0.9.0'
+  s.add_dependency 'method_source', '~> 1.0'
 
   s.metadata['changelog_uri'] = 'https://github.com/pry/pry/blob/master/CHANGELOG.md'
   s.metadata['source_code_uri'] = 'https://github.com/pry/pry'


### PR DESCRIPTION
This should finally fix our build on Ruby 2.7.