### PR TITLE
spec/integration/bundler: fix the "no dependencies" warning

### DIFF
--- a/spec/integration/bundler_spec.rb
+++ b/spec/integration/bundler_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe 'Bundler' do
       code = <<-RUBY
       require "pry"
       require "bundler/inline"
+
+      # Silence the "The Gemfile specifies no dependencies" warning
+      class Bundler::UI::Shell
+        def warn(*args, &block); end
+      end
+
       gemfile(true) do
         source "https://rubygems.org"
       end


### PR DESCRIPTION
Fixes the following warning:

```
The Gemfile specifies no dependencies
```