### PR TITLE
method: delegate internally-used methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@
 * Fixed bug when `whereami -c` cannot show beginning of the class, which is on
   the same line as another expression
   ([#2098](https://github.com/pry/pry/pull/2098))
+* Fixed bug when `Object#owner` is defined, which results into somewhat broken
+  method introspection ([#2113](https://github.com/pry/pry/pull/2113))
 
 ### [v0.12.2][v0.12.2] (November 12, 2018)
 

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -19,6 +19,8 @@ class Pry
   # to provide extra functionality useful to Pry.
   class Method # rubocop:disable Metrics/ClassLength
     extend Helpers::BaseHelpers
+    extend Forwardable
+
     include Helpers::BaseHelpers
     include Helpers::DocumentationHelpers
     include CodeObject::Helpers
@@ -248,6 +250,9 @@ class Pry
         obj.class
       end
     end
+
+    # Workaround for https://github.com/pry/pry/pull/2086
+    def_delegators :@method, :owner, :parameters, :receiver
 
     # A new instance of `Pry::Method` wrapping the given `::Method`,
     # `UnboundMethod`, or `Proc`.

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -658,4 +658,67 @@ describe Pry::Method do
       end
     end
   end
+
+  describe "#owner" do
+    context "when it is overriden in Object" do
+      before do
+        module OwnerMod
+          def owner
+            :fail
+          end
+        end
+
+        Object.__send__(:include, OwnerMod)
+      end
+
+      after { Object.remove_const(:OwnerMod) }
+
+      it "correctly reports the owner" do
+        method = described_class.new(method(:puts))
+        expect(method.owner).not_to eq(:fail)
+      end
+    end
+  end
+
+  describe "#parameters" do
+    context "when it is overriden in Object" do
+      before do
+        module ParametersMod
+          def parameters
+            :fail
+          end
+        end
+
+        Object.__send__(:include, ParametersMod)
+      end
+
+      after { Object.remove_const(:ParametersMod) }
+
+      it "correctly reports the parameters" do
+        method = described_class.new(method(:puts))
+        expect(method.parameters).not_to eq(:fail)
+      end
+    end
+  end
+
+  describe "#receiver" do
+    context "when it is overriden in Object" do
+      before do
+        module ReceiverMod
+          def receiver
+            :fail
+          end
+        end
+
+        Object.__send__(:include, ReceiverMod)
+      end
+
+      after { Object.remove_const(:ReceiverMod) }
+
+      it "correctly reports the receiver" do
+        method = described_class.new(method(:puts))
+        expect(method.receiver).not_to eq(:fail)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Improves on #2086 (Directly delegate internally-used Method methods)
(we add tests here)

Description by @michaelherold

> Relying on `method_missing` for all delegation to `Method` methods means
> that it's easier for the wrong method to be called when gems mess with
> `Object` or other such core areas.

> See https://github.com/ankane/ownership/pull/3 for an example of this.

> By defining explicit delegators, at least for the methods that we use
> internally withing Pry, we can eliminate this issue and be more
> communicative around the methods on the `Pry::Method` class.

I omitted the `source_location` changes because they need some clarification.