### PR TITLE
repl: clear line after indenting when Vi mode is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@
   ([#2098](https://github.com/pry/pry/pull/2098))
 * Fixed bug when `Object#owner` is defined, which results into somewhat broken
   method introspection ([#2113](https://github.com/pry/pry/pull/2113))
+* Fixed bug when indentation leaves parts of input after pressing enter when
+  Readline is enabled with mode indicators for vi mode. This was supposed to be
+  fixed in v0.12.2 but it regressed
+  ([#2114](https://github.com/pry/pry/pull/2114))
 
 ### [v0.12.2][v0.12.2] (November 12, 2018)
 

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -243,7 +243,7 @@ class Pry
           # rb-readline doesn't support this method:
           # https://github.com/ConnorAtherton/rb-readline/issues/152
           if Readline.vi_editing_mode?
-            overhang += current_prompt.length - indented_val.length
+            overhang = output.width - current_prompt.size - indented_val.size
           end
         rescue NotImplementedError
           # VI editing mode is unsupported on JRuby.


### PR DESCRIPTION
Fixes #1859 (Pry still leaves duplicated characters on long enough input)