### PR TITLE
Display all syntax error messages when catching SyntaxException

### DIFF
--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -627,7 +627,7 @@ class Pry
     begin
       complete_expr = Pry::Code.complete_expression?(@eval_string)
     rescue SyntaxError => e
-      output.puts "SyntaxError: #{e.message.sub(/.*syntax error, */m, '')}"
+      output.puts e.message.gsub(/^.*syntax error, */, "SyntaxError: ")
       reset_eval_string
     end
 


### PR DESCRIPTION
Previously when catching syntax errors in the REPL, we were only showing
the last syntax error displayed by the ruby output. However, ruby can
generate multiple syntax error messages within a single SyntaxException.
For example, this code generates multiple syntax error messages:
```
$ ruby -e 'puts {"key"=>"val"}.to_json'
-e:1: syntax error, unexpected =>, expecting '}'
puts {"key"=>"val"}.to_json
-e:1: syntax error, unexpected '}', expecting end-of-input
puts {"key"=>"val"}.to_json
```
We can't predict which error message would be most helpful for the
consumer - we should show both of them.

This PR modifies the string replacement we're doing when printing
syntax exceptions so any number of syntax error lines will be shown
correctly.

Previous behavior:
```
[1] pry(main)> puts {"key"=>"val"}.to_json
SyntaxError: unexpected '}', expecting end-of-input
puts {"key"=>"val"}.to_json
                  ^
[1] pry(main)>
 ```

New behavior:
```
[1] pry(main)> puts {"key"=>"val"}.to_json
SyntaxError: unexpected =>, expecting '}'
puts {"key"=>"val"}.to_json
           ^~
SyntaxError: unexpected '}', expecting end-of-input
puts {"key"=>"val"}.to_json
                  ^
[1] pry(main)>
```

Issue: https://github.com/pry/pry/issues/2102
The error message of SyntaxError is different from Ruby's one