### PR TITLE
Improve appearance of help command listing

### DIFF
--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -193,7 +193,7 @@ class Pry
 
       options = original_options.merge!(
         desc: "Alias for `#{action}`",
-        listing: match
+        listing: match.is_a?(String) ? match : match.inspect
       ).merge!(options)
 
       # ensure default description is used if desc is nil

--- a/lib/pry/commands/bang.rb
+++ b/lib/pry/commands/bang.rb
@@ -6,7 +6,7 @@ class Pry
       match(/^\s*!\s*$/)
       group 'Editing'
       description 'Clear the input buffer.'
-      command_options use_prefix: false
+      command_options use_prefix: false, listing: '!'
 
       banner <<-'BANNER'
         Clear the input buffer. Useful if the parsing process goes wrong and you get

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -185,9 +185,14 @@ RSpec.describe Pry::CommandSet do
       expect(new_command.description).to eq('Alias for `test`')
     end
 
-    it "sets aliased command's listing" do
+    it "sets aliased command's listing for string alias" do
       new_command = subject.alias_command('new-test', 'test')
       expect(new_command.options).to include(listing: 'new-test')
+    end
+
+    it "sets aliased command's listing for regex alias" do
+      new_command = subject.alias_command(/test[!?]+/, 'test')
+      expect(new_command.options[:listing].to_s).to eq('/test[!?]+/')
     end
 
     it "sets group for the aliased command automatically" do


### PR DESCRIPTION
This PR improves the appearance of some of the commands in the help listing.

Previously:
```
Editing
  /^\s*!\s*$/        Clear the input buffer.
Aliases
  (?-mix:whereami[!?]+) Alias for `whereami`
```
Now:
```
Editing
  !                  Clear the input buffer.
Aliases
  /whereami[!?]+/    Alias for `whereami`
```