### PR TITLE
pry-backtrace frozen bug

### DIFF
--- a/lib/pry/commands/pry_backtrace.rb
+++ b/lib/pry/commands/pry_backtrace.rb
@@ -20,9 +20,7 @@ class Pry
       BANNER
 
       def process
-        text = bold('Backtrace:')
-        text << "\n--\n"
-        text << pry_instance.backtrace.join("\n")
+        text = "#{bold('Backtrace:')}\n--\n#{pry_instance.backtrace.join("\n")}"
         pry_instance.pager.page(text)
       end
     end

--- a/spec/commands/pry_backtrace_spec.rb
+++ b/spec/commands/pry_backtrace_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+describe "pry_backtrace" do
+  before do
+    @t = pry_tester
+  end
+
+  it 'should print a backtrace' do
+    @t.process_command 'pry-backtrace'
+    expect(@t.last_output).to start_with('Backtrace:')
+  end
+end


### PR DESCRIPTION
fixes
```
pry-backtrace
RuntimeError: can't modify frozen String
from /pry-0.13.0/lib/pry/commands/pry_backtrace.rb:24:in `process'
```