### PR TITLE
config: return `nil` on unknown option instead of raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 * Fixed bug where on invalid input only the last syntax error is displayed
   (instead of all of them) ([#2117](https://github.com/pry/pry/pull/2117))
 
+#### API changes
+
+* `Pry::Config` returns `nil` on undefined option instead of raising
+  `NoMethodError` (usually invoked via `Pry.config.foo_option` calls)
+  ([#2126](https://github.com/pry/pry/pull/2126))
+
 ### [v0.13.0][v0.13.0] (March 21, 2020)
 
 #### Features

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -239,17 +239,17 @@ class Pry
       @custom_attrs[attr.to_s].call
     end
 
-    def method_missing(method_name, *args, &block)
+    # rubocop:disable Style/MethodMissingSuper
+    def method_missing(method_name, *args, &_block)
       name = method_name.to_s
 
       if name.end_with?('=')
         self[name[0..-2]] = args.first
       elsif @custom_attrs.key?(name)
         self[name]
-      else
-        super
       end
     end
+    # rubocop:enable Style/MethodMissingSuper
 
     def respond_to_missing?(method_name, include_all = false)
       @custom_attrs.key?(method_name.to_s.tr('=', '')) || super

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -150,8 +150,8 @@ RSpec.describe Pry::Config do
     end
 
     context "when invoked method is not an option" do
-      it "raises NoMethodError" do
-        expect { subject.foo }.to raise_error(NoMethodError)
+      it "returns nil" do
+        expect(subject.foo).to be_nil
       end
     end
 


### PR DESCRIPTION
Returning `nil` on unknown option was default behaviour for Pry v0.12.x. In
e5556a2be8627ec3fe594c738f10422d5a1f5d43 I changed that but I am not sure if it
was intentional. This breaks plugins such as
pry-theme (https://github.com/kyrylo/pry-theme/issues/59).

Returning `nil` makes more sense, because we can write code like this:

```
Pry.config.foo ||= 123
```

...whereas as of now this is no longer possible and you would need to use
`respond_to?` to achieve the same effect.