### PR TITLE
validates file presence in Config#default_rc_file

### DIFF
--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -305,17 +305,14 @@ class Pry
     end
 
     def default_rc_file
-      if (pryrc = Pry::Env['PRYRC'])
-        pryrc
-      elsif (xdg_home = Pry::Env['XDG_CONFIG_HOME'])
-        # See XDG Base Directory Specification at
-        # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
-        xdg_home + '/pry/pryrc'
-      elsif File.exist?(File.expand_path('~/.pryrc'))
-        '~/.pryrc'
-      else
-        '~/.config/pry/pryrc'
-      end
+      [Pry::Env['PRYRC'],
+       # See XDG Base Directory Specification at
+       # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
+       "#{Pry::Env['XDG_CONFIG_HOME']}/pry/pryrc",
+       File.expand_path('~/.pryrc'),
+       '~/.config/pry/pryrc']
+        .compact
+        .find { |file| File.exist?(file) }
     end
   end
 end

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -307,10 +307,10 @@ class Pry
     def default_rc_file
       [Pry::Env['PRYRC'],
        # See XDG Base Directory Specification at
-       # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
+       # https://specifications.freedesktop.org/basedir-spec/latest/
        "#{Pry::Env['XDG_CONFIG_HOME']}/pry/pryrc",
        File.expand_path('~/.pryrc'),
-       '~/.config/pry/pryrc']
+       File.expand_path('~/.config/pry/pryrc')]
         .compact
         .find { |file| File.exist?(file) }
     end

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -87,7 +87,7 @@ class Pry
   # Load the local RC file (./.pryrc)
   def self.rc_files_to_load
     files = []
-    files << Pry.config.rc_file if Pry.config.should_load_rc
+    files << Pry.config.rc_file if Pry.config.rc_file && Pry.config.should_load_rc
     files << LOCAL_RC_FILE if Pry.config.should_load_local_rc
     files.map { |file| real_path_to(file) }.compact.uniq
   end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -105,17 +105,17 @@ RSpec.describe Pry::Config do
           expect(subject.rc_file).to eq(File.expand_path('~/.pryrc'))
         end
 
-      context "and when ~/.config/pry/pryrc exists" do
-        before do
-          allow(File).to receive(:exist?)
-          allow(File).to receive(:exist?)
-            .with(File.expand_path('~/.config/pry/pryrc')).and_return(true)
-        end
+        context "and when ~/.config/pry/pryrc exists" do
+          before do
+            allow(File).to receive(:exist?)
+            allow(File).to receive(:exist?)
+              .with(File.expand_path('~/.config/pry/pryrc')).and_return(true)
+          end
 
-        it "defaults to ~/.config/pry/pryrc" do
-          expect(subject.rc_file).to eq(File.expand_path('~/.config/pry/pryrc'))
+          it "defaults to ~/.config/pry/pryrc" do
+            expect(subject.rc_file).to eq(File.expand_path('~/.config/pry/pryrc'))
+          end
         end
-      end
       end
 
       context "and when no default rc file exists" do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Pry::Config do
   specify { expect(subject.history_load).to eq(true).or be(false) }
   specify { expect(subject.history_file).to be_a(String) }
   specify { expect(subject.exec_string).to be_a(String) }
-  specify { expect(subject.rc_file).to be_a(String) }
+  specify { expect(subject.rc_file).to be_a(String).or be(nil) }
 
   describe "#rc_file" do
     context "when $PRYRC env variable is set" do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe Pry::Config do
   describe "#rc_file" do
     context "when $PRYRC env variable is set" do
       before do
+        allow(File).to receive(:exist?)
+        allow(File).to receive(:exist?)
+          .with('/foo/pryrc').and_return(true)
         allow(Pry::Env).to receive(:[])
         allow(Pry::Env).to receive(:[]).with('PRYRC').and_return('/foo/pryrc')
       end
@@ -68,7 +71,7 @@ RSpec.describe Pry::Config do
       end
 
       it "defaults to ~/.pryrc" do
-        expect(subject.rc_file).to eq('~/.pryrc')
+        expect(subject.rc_file).to eq(File.expand_path('~/.pryrc'))
       end
     end
 
@@ -79,6 +82,8 @@ RSpec.describe Pry::Config do
           .with('XDG_CONFIG_HOME').and_return('/xdg_home')
 
         allow(File).to receive(:exist?)
+        allow(File).to receive(:exist?)
+          .with('/xdg_home/pry/pryrc').and_return(true)
       end
 
       context "and when ~/.pryrc exists" do

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -80,31 +80,58 @@ RSpec.describe Pry::Config do
         allow(Pry::Env).to receive(:[])
         allow(Pry::Env).to receive(:[])
           .with('XDG_CONFIG_HOME').and_return('/xdg_home')
+      end
 
-        allow(File).to receive(:exist?)
-        allow(File).to receive(:exist?)
-          .with('/xdg_home/pry/pryrc').and_return(true)
+      context "and when '/xdg_home/pry/pryrc' exists" do
+        before do
+          allow(File).to receive(:exist?)
+          allow(File).to receive(:exist?)
+            .with('/xdg_home/pry/pryrc').and_return(true)
+        end
+
+        it "defaults to $XDG_CONFIG_HOME/pry/pryrc" do
+          expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+        end
       end
 
       context "and when ~/.pryrc exists" do
         before do
           allow(File).to receive(:exist?)
+          allow(File).to receive(:exist?)
             .with(File.expand_path('~/.pryrc')).and_return(true)
         end
 
-        it "defaults to $XDG_CONFIG_HOME/pry/pryrc" do
-          expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+        it "defaults to ~/.pryrc" do
+          expect(subject.rc_file).to eq(File.expand_path('~/.pryrc'))
         end
-      end
 
-      context "and when ~/.pryrc doesn't exist" do
+      context "and when ~/.config/pry/pryrc exists" do
         before do
           allow(File).to receive(:exist?)
-            .with(File.expand_path('~/.pryrc')).and_return(false)
+          allow(File).to receive(:exist?)
+            .with(File.expand_path('~/.config/pry/pryrc')).and_return(true)
         end
 
-        it "defaults to $XDG_CONFIG_HOME/pry/pryrc" do
-          expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+        it "defaults to ~/.config/pry/pryrc" do
+          expect(subject.rc_file).to eq(File.expand_path('~/.config/pry/pryrc'))
+        end
+      end
+      end
+
+      context "and when no default rc file exists" do
+        before do
+          allow(File).to receive(:exist?)
+          allow(Pry::Env).to receive(:[]).with('PRYRC').and_return(nil)
+          allow(File).to receive(:exist?)
+            .with('/xdg_home/pry/pryrc').and_return(false)
+          allow(File).to receive(:exist?)
+            .with(File.expand_path('~/.pryrc')).and_return(false)
+          allow(File).to receive(:exist?)
+            .with(File.expand_path('~/.config/pry/pryrc')).and_return(false)
+        end
+
+        it "should return nil" do
+          expect(subject.rc_file).to eq(nil)
         end
       end
     end


### PR DESCRIPTION
Return `nil` if no default rc file is present in the filesystem.
This fixes the behavior if $XDG_CONFIG_HOME is set, but no rc file at
the path `$XDG_CONFIG_HOME/pry/pryrc` (while it may be at `~/.pryrc`).