### PR TITLE
Update `?` alias to use show-source

### DIFF
--- a/lib/pry/commands/show_doc.rb
+++ b/lib/pry/commands/show_doc.rb
@@ -89,6 +89,5 @@ class Pry
     end
 
     Pry::Commands.add_command(Pry::Command::ShowDoc)
-    Pry::Commands.alias_command '?', 'show-doc'
   end
 end

--- a/lib/pry/commands/show_source.rb
+++ b/lib/pry/commands/show_source.rb
@@ -113,5 +113,6 @@ class Pry
     Pry::Commands.add_command(Pry::Command::ShowSource)
     Pry::Commands.alias_command 'show-method', 'show-source'
     Pry::Commands.alias_command '$', 'show-source'
+    Pry::Commands.alias_command '?', 'show-source -d'
   end
 end


### PR DESCRIPTION
`show-doc` is deprecated in favor of `show-source -d`. Updating the `?` alias accordingly.