### PR TITLE
fix pry indent frozen error

### DIFF
--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -109,7 +109,7 @@ class Pry
     # reset internal state
     def reset
       @stack = []
-      @indent_level = ''
+      @indent_level = ''.dup
       @heredoc_queue = []
       @close_heredocs = {}
       @string_start = nil

--- a/spec/indent_spec.rb
+++ b/spec/indent_spec.rb
@@ -305,6 +305,14 @@ OUTPUT
     expect(@indent.indent(input)).to eq output
   end
 
+  it "should not raise error, if MIDWAY_TOKENS are used without indentation" do
+    expect { @indent.indent("when") }.not_to raise_error
+    expect { @indent.reset.indent("else") }.not_to raise_error
+    expect { @indent.reset.indent("elsif") }.not_to raise_error
+    expect { @indent.reset.indent("ensure") }.not_to raise_error
+    expect { @indent.reset.indent("rescue") }.not_to raise_error
+  end
+
   describe "nesting" do
     test = File.read("spec/fixtures/example_nesting.rb")
 


### PR DESCRIPTION
Fixes https://github.com/pry/pry/issues/2135

I think there are two ways to solve this error.

a. use `sub` instead of `sub!`
b. don't use frozen string for `sub!`

In this pull request, I chose the latter.

If this fix is not better than the former or there is a better way, please point out.