### PR TITLE
Fix bundler_spec test

### DIFF
--- a/spec/integration/bundler_spec.rb
+++ b/spec/integration/bundler_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe 'Bundler' do
   context "when Pry requires Gemfile, which doesn't specify Pry as a dependency" do
     it "loads auto-completion correctly" do
       code = <<-RUBY
-      require "pry"
+      require "bundler"
       require "bundler/inline"
+      require "pry"
 
       # Silence the "The Gemfile specifies no dependencies" warning
       class Bundler::UI::Shell


### PR DESCRIPTION
Thanks for your awesome work on maintaining pry, @kyrylo! :heart: 

However, whilst maintaining pry in Debian, I noticed that there was a test failure:
```
➜  pry git:(master) rspec spec/integration/bundler_spec.rb

Randomized with seed 32029
Traceback (most recent call last):
-e:5:in `<main>': uninitialized constant Bundler (NameError)
F

Failures:

  1) Bundler when Pry requires Gemfile, which doesn't specify Pry as a dependency loads auto-completion correctly
     Failure/Error: expect($CHILD_STATUS.exitstatus).to eq(42)
     
       expected: 42
            got: 1
     
       (compared using ==)
     # ./spec/integration/bundler_spec.rb:26:in `block (3 levels) in <top (required)>'

Finished in 0.54534 seconds (files took 0.58163 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/integration/bundler_spec.rb:10 # Bundler when Pry requires Gemfile, which doesn't specify Pry as a dependency loads auto-completion correctly
```

This PR fixes the same and also arranges those requires in alphabetical order :smile: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>