### PR TITLE
Fix Windows encoding problems

### DIFF
--- a/lib/pry/code/code_file.rb
+++ b/lib/pry/code/code_file.rb
@@ -31,7 +31,7 @@ class Pry
 
     # Store the current working directory. This allows show-source etc. to work if
     # your process has changed directory since boot. [Issue #675]
-    INITIAL_PWD = Dir.pwd
+    INITIAL_PWD = Dir.pwd.encode('UTF-8')
 
     # @return [Symbol] The type of code stored in this wrapper.
     attr_reader :code_type
@@ -98,7 +98,7 @@ class Pry
 
     # @return [String]
     def from_pwd
-      File.expand_path(@filename, Dir.pwd)
+      File.expand_path(@filename, Dir.pwd.encode('UTF-8'))
     end
 
     # @return [String]

--- a/lib/pry/commands/shell_command.rb
+++ b/lib/pry/commands/shell_command.rb
@@ -41,7 +41,7 @@ class Pry
       end
 
       def process_cd(dest)
-        state.old_pwd = Dir.pwd
+        state.old_pwd = Dir.pwd.encode('UTF-8')
         Dir.chdir(File.expand_path(path_from_cd_path(dest) || dest))
       rescue Errno::ENOENT
         raise CommandError, "No such directory: #{dest}"

--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -86,7 +86,7 @@ class Pry
       end
 
       def location
-        "#{@file}:#{@line} #{@method && @method.name_with_owner}"
+        "#{@file.encode('UTF-8')}:#{@line} #{@method && @method.name_with_owner}"
       end
 
       def process

--- a/lib/pry/prompt.rb
+++ b/lib/pry/prompt.rb
@@ -200,7 +200,7 @@ class Pry
         "%<name>s %<context>s:%<pwd>s %<separator>s ",
         name: pry_instance.config.prompt_name,
         context: Pry.view_clip(context),
-        pwd: Dir.pwd,
+        pwd: Dir.pwd.encode('UTF-8'),
         separator: sep
       )
     end


### PR DESCRIPTION
Hi! Thanks for the greatest project!! I just realized there are some bugs with filesystem encoding on Windows. `Dir.pwd` gives me string in Windows-1251 encoding on my machine, so Pry starting process is broken with incompatibility exception. Also `whereami` command is broken too. So I think it's safe to perform `encode('UTF-8')` on some strings from filesystem to ensure they are compatible with other. Everything works as expected on my machine after fixes.

I'm using Pry 0.13.1 on Ruby 2.7.0 on Windows 10.