### PR TITLE
do not undef =~ unless defined

### DIFF
--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -339,7 +339,7 @@ class Pry
         super
       end
     end
-    undef =~ if instance_methods.include?(:=~)
+    undef =~ if method_defined?(:=~)
 
     # Check whether String responds to missing methods.
     def respond_to_missing?(method_name, include_private = false)

--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -339,7 +339,7 @@ class Pry
         super
       end
     end
-    undef =~
+    undef =~ if instance_methods.include?(:=~)
 
     # Check whether String responds to missing methods.
     def respond_to_missing?(method_name, include_private = false)


### PR DESCRIPTION
Undefining a nonexistent definition is an error in Ruby.  This has not been a problem because there always was `Object#=~` predefined.  But we are planning to delete that useless method.  This would become an error unless properly guarded.