### PR TITLE
Escape non-printing characters

### DIFF
--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -21,20 +21,20 @@ class Pry
 
       COLORS.each_pair do |color, value|
         define_method color do |text|
-          "\033[0;#{30 + value}m#{text}\033[0m"
+          "\001\033[0;#{30 + value}m\002#{text}\001\033[0m\002"
         end
 
         define_method "bright_#{color}" do |text|
-          "\033[1;#{30 + value}m#{text}\033[0m"
+          "\001\033[1;#{30 + value}m\002#{text}\001\033[0m\002"
         end
 
         COLORS.each_pair do |bg_color, bg_value|
           define_method "#{color}_on_#{bg_color}" do |text|
-            "\033[0;#{30 + value};#{40 + bg_value}m#{text}\033[0m"
+            "\001\033[0;#{30 + value};#{40 + bg_value}m\002#{text}\001\033[0m\002"
           end
 
           define_method "bright_#{color}_on_#{bg_color}" do |text|
-            "\033[1;#{30 + value};#{40 + bg_value}m#{text}\033[0m"
+            "\001\033[1;#{30 + value};#{40 + bg_value}m\002#{text}\001\033[0m\002"
           end
         end
       end
@@ -52,7 +52,7 @@ class Pry
       # @param [String, #to_s] text
       # @return [String] _text_
       def bold(text)
-        "\e[1m#{text}\e[0m"
+        "\001\e[1m\002#{text}\001\e[0m\002"
       end
 
       # Returns `text` in the default foreground colour.

--- a/spec/commands/wtf_spec.rb
+++ b/spec/commands/wtf_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Pry::Command::Wtf do
       it "prints only a part of the exception backtrace" do
         subject.process
         expect(subject.output.string).to eq(
-          "\e[1mException:\e[0m RuntimeError: oops\n" \
+          "\001\e[1m\002Exception:\001\e[0m\002 RuntimeError: oops\n" \
           "--\n" \
           "0: /bin/pry:23:in `<main>'\n" \
           "1: /bin/pry:23:in `<main>'\n" \
@@ -55,7 +55,7 @@ RSpec.describe Pry::Command::Wtf do
       it "prints full exception backtrace" do
         subject.process
         expect(subject.output.string).to eq(
-          "\e[1mException:\e[0m RuntimeError: oops\n" \
+          "\001\e[1m\002Exception:\001\e[0m\002 RuntimeError: oops\n" \
           "--\n" \
           "0: /bin/pry:23:in `<main>'\n" \
           "1: /bin/pry:23:in `<main>'\n" \
@@ -73,7 +73,7 @@ RSpec.describe Pry::Command::Wtf do
       it "prints more of backtrace" do
         subject.process
         expect(subject.output.string).to eq(
-          "\e[1mException:\e[0m RuntimeError: oops\n" \
+          "\001\e[1m\002Exception:\001\e[0m\002 RuntimeError: oops\n" \
           "--\n" \
           "0: /bin/pry:23:in `<main>'\n" \
           "1: /bin/pry:23:in `<main>'\n" \
@@ -116,14 +116,14 @@ RSpec.describe Pry::Command::Wtf do
         it "prints parts of both original and nested exception backtrace" do
           subject.process
           expect(subject.output.string).to eq(
-            "\e[1mException:\e[0m RuntimeError: outer\n" \
+            "\001\e[1m\002Exception:\001\e[0m\002 RuntimeError: outer\n" \
             "--\n" \
             "0: /bin/pry:23:in `<main>'\n" \
             "1: /bin/pry:23:in `<main>'\n" \
             "2: /bin/pry:23:in `<main>'\n" \
             "3: /bin/pry:23:in `<main>'\n" \
             "4: /bin/pry:23:in `<main>'\n" \
-            "\e[1mCaused by:\e[0m RuntimeError: inner\n" \
+            "\001\e[1m\002Caused by:\001\e[0m\002 RuntimeError: inner\n" \
             "--\n" \
             "0: /bin/pry:23:in `<main>'\n" \
             "1: /bin/pry:23:in `<main>'\n" \
@@ -140,7 +140,7 @@ RSpec.describe Pry::Command::Wtf do
         it "prints both original and nested exception backtrace" do
           subject.process
           expect(subject.output.string).to eq(
-            "\e[1mException:\e[0m RuntimeError: outer\n" \
+            "\001\e[1m\002Exception:\001\e[0m\002 RuntimeError: outer\n" \
             "--\n" \
             "0: /bin/pry:23:in `<main>'\n" \
             "1: /bin/pry:23:in `<main>'\n" \
@@ -148,7 +148,7 @@ RSpec.describe Pry::Command::Wtf do
             "3: /bin/pry:23:in `<main>'\n" \
             "4: /bin/pry:23:in `<main>'\n" \
             "5: /bin/pry:23:in `<main>'\n" \
-            "\e[1mCaused by:\e[0m RuntimeError: inner\n" \
+            "\001\e[1m\002Caused by:\001\e[0m\002 RuntimeError: inner\n" \
             "--\n" \
             "0: /bin/pry:23:in `<main>'\n" \
             "1: /bin/pry:23:in `<main>'\n" \
@@ -177,17 +177,17 @@ RSpec.describe Pry::Command::Wtf do
       it "prints lines of code that exception frame references" do
         subject.process
         expect(subject.output.string).to eq(
-          "\e[1mException:\e[0m RuntimeError: oops\n" \
+          "\001\e[1m\002Exception:\001\e[0m\002 RuntimeError: oops\n" \
           "--\n" \
-          "0: \e[1m#{__FILE__}:168:in `<main>'\e[0m\n" \
+          "0: \001\e[1m\002#{__FILE__}:168:in `<main>'\001\e[0m\002\n" \
           "             Array.new(6) { \"\#{__FILE__}:\#{__LINE__}:in `<main>'\" }\n" \
-          "1: \e[1m#{__FILE__}:168:in `<main>'\e[0m\n" \
+          "1: \001\e[1m\002#{__FILE__}:168:in `<main>'\001\e[0m\002\n" \
           "             Array.new(6) { \"\#{__FILE__}:\#{__LINE__}:in `<main>'\" }\n" \
-          "2: \e[1m#{__FILE__}:168:in `<main>'\e[0m\n" \
+          "2: \001\e[1m\002#{__FILE__}:168:in `<main>'\001\e[0m\002\n" \
           "             Array.new(6) { \"\#{__FILE__}:\#{__LINE__}:in `<main>'\" }\n" \
-          "3: \e[1m#{__FILE__}:168:in `<main>'\e[0m\n" \
+          "3: \001\e[1m\002#{__FILE__}:168:in `<main>'\001\e[0m\002\n" \
           "             Array.new(6) { \"\#{__FILE__}:\#{__LINE__}:in `<main>'\" }\n" \
-          "4: \e[1m#{__FILE__}:168:in `<main>'\e[0m\n" \
+          "4: \001\e[1m\002#{__FILE__}:168:in `<main>'\001\e[0m\002\n" \
           "             Array.new(6) { \"\#{__FILE__}:\#{__LINE__}:in `<main>'\" }\n"
         )
       end
@@ -200,13 +200,13 @@ RSpec.describe Pry::Command::Wtf do
         it "skips code and prints only the backtrace frame" do
           subject.process
           expect(subject.output.string).to eq(
-            "\e[1mException:\e[0m RuntimeError: oops\n" \
+            "\001\e[1m\002Exception:\001\e[0m\002 RuntimeError: oops\n" \
             "--\n" \
-            "0: \e[1m#{__FILE__}:168:in `<main>'\e[0m\n" \
-            "1: \e[1m#{__FILE__}:168:in `<main>'\e[0m\n" \
-            "2: \e[1m#{__FILE__}:168:in `<main>'\e[0m\n" \
-            "3: \e[1m#{__FILE__}:168:in `<main>'\e[0m\n" \
-            "4: \e[1m#{__FILE__}:168:in `<main>'\e[0m\n"
+            "0: \001\e[1m\002#{__FILE__}:168:in `<main>'\001\e[0m\002\n" \
+            "1: \001\e[1m\002#{__FILE__}:168:in `<main>'\001\e[0m\002\n" \
+            "2: \001\e[1m\002#{__FILE__}:168:in `<main>'\001\e[0m\002\n" \
+            "3: \001\e[1m\002#{__FILE__}:168:in `<main>'\001\e[0m\002\n" \
+            "4: \001\e[1m\002#{__FILE__}:168:in `<main>'\001\e[0m\002\n"
           )
         end
       end


### PR DESCRIPTION
Escape non-printing characters to avoid weird behavior when colors are used.

According to https://superuser.com/questions/301353/escape-non-printing-characters-in-a-function-for-a-bash-prompt

From lib/readline/display.c:243 in bash source code:

```C
243 /* Current implementation:
244         \001 (^A) start non-visible characters
245         \002 (^B) end non-visible characters
246    all characters except \001 and \002 (following a \001) are copied to
247    the returned string; all characters except those between \001 and
248    \002 are assumed to be `visible'. */
``` 

Closes https://github.com/pry/pry/issues/493