### PR TITLE
Reflect latest version (0.13.1) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Installation
 ### Bundler
 
 ```ruby
-gem 'pry', '~> 0.12.2'
+gem 'pry', '~> 0.13.1'
 ```
 
 ### Manual


### PR DESCRIPTION
I hope all of you who maintain this gem are doing well.

I noticed that the Readme is not reporting the latest version.

This PR aims to update this information.