### PR TITLE
Fix breakage in output with colors disabled

### DIFF
--- a/lib/pry/helpers/text.rb
+++ b/lib/pry/helpers/text.rb
@@ -44,7 +44,7 @@ class Pry
       # @param  [String, #to_s] text
       # @return [String] _text_ stripped of any color codes.
       def strip_color(text)
-        text.to_s.gsub(/(\001)?\e\[.*?(\d)+m(\002)?/, '')
+        text.to_s.gsub(/(\001)?(\e\[(\d[;\d]?)*m)(\002)?/, '')
       end
 
       # Returns _text_ as bold text for use on a terminal.

--- a/spec/helpers/text_spec.rb
+++ b/spec/helpers/text_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe Pry::Helpers::Text do
+  describe "#strip_color" do
+    [
+      ["\e[1A\e[0G[2] pry(main)> puts \e[31m\e[1;31m'\e[0m\e[31m"\
+         "hello\e[1;31m'\e[0m\e[31m\e[0m\e[1B\e[0G",
+       "\e[1A\e[0G[2] pry(main)> puts 'hello'\e[1B\e[0G"],
+      ["\e[31m\e[1;31m'\e[0m\e[31mhello\e[1;31m'\e[0m\e[31m\e[0m\e[1B\e[0G",
+       "'hello'\e[1B\e[0G"],
+      %w[string string]
+    ].each do |(text, text_without_color)|
+      it "removes color code from text #{text.inspect}" do
+        expect(subject.strip_color(text)).to eql(text_without_color)
+      end
+    end
+  end
+end

--- a/spec/pry_repl_spec.rb
+++ b/spec/pry_repl_spec.rb
@@ -135,7 +135,7 @@ loop do
 	break #note the tab here
 end
 TAB
-        output("do\n  break #note the tab here\nend\n\e[1B\e[0G=> nil")
+        output("do\n  break #note the tab here\nend\n\e\\[1B\e\\[0G=> nil")
       end
     end
   end


### PR DESCRIPTION
Investigating `Pry::Helpers#strip_color` I've found out that`\e[1A\e[0G` and the prompt was being removed from the text.

When the string was big enough, it wouldn't cause any trouble, as the output would just 'overwrite' it. But for strings such as 'puts "Hello"', or "'hello'.upcase" it would break the output in unexpected ways.

On master:

```
"\e[1A\e[0G[2] pry(main)> puts \e[31m\e[1;31m'\e[0m\e[31mhello\e[1;31m'\e[0m\e[31m\e[0m\e[1B\e[0G"
```

would become:

```
'hello'\e[1B\e[0G
```

With this fix:

```
"\e[1A\e[0G[2] pry(main)> puts 'hello'\e[1B\e[0G"
```

After my fix a spec on `spec/pry_repl_spec.rb:127` started failing with `RegexpError: premature end of char-class`. A simple "string".match("do\n  break #note the tab here\nend\n\e[1B\e[0G=> nil") raises an error. I've fixed that escaping the `[` on 31590ea

It wasn't failing before because those strings were being matched by RSpec's fuzzy matcher and not by the regex itself.

Fixes #2148 