### PR TITLE
Fixes File.expand_path argument error when HOME env is absent

### DIFF
--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -306,11 +306,11 @@ class Pry
       elsif (xdg_home = Pry::Env['XDG_CONFIG_HOME'])
         # See XDG Base Directory Specification at
         # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
-        xdg_home + '/pry/pryrc'
-      elsif File.exist?(File.join(home_path, '.pryrc'))
-        '~/.pryrc'
+        File.join(xdg_home, 'pry', 'pryrc')
+      elsif File.exist?(path = File.join(home_path, '.pryrc'))
+        path
       else
-        '~/.config/pry/pryrc'
+        File.join(home_path, '.config', 'pry', 'pryrc')
       end
     end
 

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -307,21 +307,19 @@ class Pry
         # See XDG Base Directory Specification at
         # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
         xdg_home + '/pry/pryrc'
-      elsif File.exist?(File.join(get_home_path, '.pryrc'))
+      elsif File.exist?(File.join(home_path, '.pryrc'))
         '~/.pryrc'
       else
         '~/.config/pry/pryrc'
       end
     end
 
-    def get_home_path
-      begin
-        Dir.home
-      rescue ArgumentError, NoMethodError
-        # $HOME is not set in systemd service File.expand_path('~') will not work here
-        require 'etc' unless defined?(Etc)
-        Etc.getpwuid(Process.uid).dir
-      end
+    def home_path
+      Dir.home
+    rescue ArgumentError, NoMethodError
+      # $HOME is not set in systemd service File.expand_path('~') will not work here
+      require 'etc' unless defined?(Etc)
+      Etc.getpwuid(Process.uid).dir
     end
   end
 end

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -307,10 +307,20 @@ class Pry
         # See XDG Base Directory Specification at
         # https://standards.freedesktop.org/basedir-spec/basedir-spec-0.8.html
         xdg_home + '/pry/pryrc'
-      elsif File.exist?(File.expand_path('~/.pryrc'))
+      elsif File.exist?(File.join(get_home_path, '.pryrc'))
         '~/.pryrc'
       else
         '~/.config/pry/pryrc'
+      end
+    end
+
+    def get_home_path
+      begin
+        Dir.home
+      rescue ArgumentError, NoMethodError
+        # $HOME is not set in systemd service File.expand_path('~') will not work here
+        require 'etc' unless defined?(Etc)
+        Etc.getpwuid(Process.uid).dir
       end
     end
   end

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -319,7 +319,7 @@ class Pry
     rescue ArgumentError, NoMethodError
       # $HOME is not set in systemd service File.expand_path('~') will not work here
       require 'etc' unless defined?(Etc)
-      Etc.getpwuid(Process.uid).dir
+      Etc.getpwuid.dir
     end
   end
 end

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -148,7 +148,7 @@ class Pry
       line.include?("\0")
     end
 
-    def home_path
+    def self.home_path
       Dir.home
     rescue ArgumentError, NoMethodError
       # $HOME is not set in systemd service File.expand_path('~') will not work here

--- a/lib/pry/history.rb
+++ b/lib/pry/history.rb
@@ -153,7 +153,7 @@ class Pry
     rescue ArgumentError, NoMethodError
       # $HOME is not set in systemd service File.expand_path('~') will not work here
       require 'etc' unless defined?(Etc)
-      Etc.getpwuid(Process.uid).dir
+      Etc.getpwuid.dir
     end
   end
 end


### PR DESCRIPTION
Similar Fixed: https://github.com/pry/pry/pull/2015 
Fixes: https://github.com/pry/pry/issues/2139

$HOME env path is not set if the task running using Systemd service. that cause the expand_path raises Argument error.

Scenario:
```
unset HOME && ruby -e "File.expand_path('~')"
Traceback (most recent call last):
	1: from -e:1:in `<main>'
-e:1:in `expand_path': couldn't find login name -- expanding `~' (ArgumentError)
```  

Ref issue https://github.com/chef/chef/issues/10565:
```
2020-10-14T20:48:40.999279+00:00 chef-client[7187]: Running handlers:
2020-10-14T20:48:41.377744+00:00 chef-client[7187]: [2020-10-14T20:48:41+00:00] ERROR: Report handler Chef::Handler::AuditReport raised #<ArgumentError: couldn't find login name -- expanding `~'>
2020-10-14T20:48:41.378000+00:00 chef-client[7187]: [2020-10-14T20:48:41+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/pry-0.13.1/lib/pry/config.rb:314:in `expand_path'
2020-10-14T20:48:41.378129+00:00 chef-client[7187]: [2020-10-14T20:48:41+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/pry-0.13.1/lib/pry/config.rb:314:in `default_rc_file'
2020-10-14T20:48:41.378249+00:00 chef-client[7187]: [2020-10-14T20:48:41+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/pry-0.13.1/lib/pry/config.rb:187:in `initialize'
2020-10-14T20:48:41.378366+00:00 chef-client[7187]: [2020-10-14T20:48:41+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/pry-0.13.1/lib/pry/pry_class.rb:327:in `new'
2020-10-14T20:48:41.378482+00:00 chef-client[7187]: [2020-10-14T20:48:41+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/pry-0.13.1/lib/pry/pry_class.rb:327:in `reset_defaults'
2020-10-14T20:48:41.378607+00:00 chef-client[7187]: [2020-10-14T20:48:41+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/pry-0.13.1/lib/pry/pry_class.rb:337:in `init'
2020-10-14T20:48:41.378725+00:00 chef-client[7187]: [2020-10-14T20:48:41+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/pry-0.13.1/lib/pry/pry_class.rb:388:in `<top (required)>'
2020-10-14T20:48:41.378851+00:00 chef-client[7187]: [2020-10-14T20:48:41+00:00] ERROR: /opt/chef/embedded/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
2020-10-14T20:48:41.378965+00:00 chef-client[7187]: [2020-10-14T20:48:41+00:00] ERROR: /opt/chef/embedded/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
2020-10-14T20:48:41.379078+00:00 chef-client[7187]: [2020-10-14T20:48:41+00:00] ERROR: /opt/chef/embedded/lib/ruby/gems/2.7.0/gems/pry-0.13.1/lib/pry.rb:61:in `<top (required)>'
```