### PR TITLE
Allow subclasses of ClassCommand to pass options onto Pry::Slop.

### DIFF
--- a/lib/pry/class_command.rb
+++ b/lib/pry/class_command.rb
@@ -20,6 +20,7 @@ class Pry
         klass.match match
         klass.description description
         klass.command_options options
+        klass.slop_options slop_options
       end
 
       def source
@@ -91,7 +92,7 @@ class Pry
     # Return an instance of Pry::Slop that can parse either subcommands or the
     # options that this command accepts.
     def slop
-      Pry::Slop.new do |opt|
+      Pry::Slop.new(self.class.slop_options) do |opt|
         opt.banner(unindent(self.class.banner))
         subcommands(opt)
         options(opt)

--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -57,6 +57,12 @@ class Pry
       alias options command_options
       alias options= command_options=
 
+      # Options passed onto `Pry::Slop#initialize`.
+      def slop_options(options = nil)
+        @options = options if options
+        @options || {}
+      end
+
       # Define or get the command's banner
       def banner(arg = nil)
         @banner = arg if arg

--- a/spec/class_command_spec.rb
+++ b/spec/class_command_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe Pry::ClassCommand do
           .to match(hash_including(listing: 'listing'))
       end
     end
+
+    context "when slop_options is defined" do
+      subject do
+        Class.new(described_class) do
+          slop_options strict: true
+        end
+      end
+
+      it 'sets slop_options on the subclass' do
+        expect(subject.slop_options).to eq(strict: true)
+      end
+    end
   end
 
   describe ".source" do
@@ -233,6 +245,18 @@ RSpec.describe Pry::ClassCommand do
 
       it "adds subcommands to Slop" do
         expect(subject.slop.fetch_option(:test)).not_to be_nil
+      end
+    end
+
+    context "when there are slop options" do
+      subject do
+        Class.new(described_class) do
+          slop_options strict: true
+        end.new
+      end
+
+      it 'enables strict option parsing' do
+        expect(subject.slop).to be_strict
       end
     end
   end


### PR DESCRIPTION
This commit allows us to forward options onto `Pry::Slop#initialize`, which in
turn lets us enable strict option parsing:

```
class FooCommand < Pry::ClassCommand
  match 'foo'
  slop_options strict: true
  banner 'foo [OPTIONS]'

  def process
  end
end
Pry.commands.add_command FooCommand

[1] pry(main)> foo --typo-1 --typo-2
Error: Unknown options --typo-1, --typo-2
```

There are other Slop options, but I didn't investigate them much.
Strict option parsing is the feature I'm most interested in. 