### PR TITLE
Add CI support for ruby 3 and fix broken spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,15 @@ jobs:
       - <<: *bundle_install
       - <<: *install_ubuntu_nano
       - <<: *unit
+  "ruby-3.0":
+    docker:
+      - image: circleci/ruby:3.0
+    working_directory: ~/pry
+    steps:
+      - <<: *repo_restore_cache
+      - <<: *bundle_install
+      - <<: *install_ubuntu_nano
+      - <<: *unit
   "jruby-9.1-jdk":
     docker:
       - image: circleci/jruby:9.1-jdk
@@ -196,6 +205,10 @@ workflows:
             - rubocop_lint
             - yard_lint
       - "ruby-2.7":
+          requires:
+            - rubocop_lint
+            - yard_lint
+      - "ruby-3.0":
           requires:
             - rubocop_lint
             - yard_lint

--- a/spec/syntax_checking_spec.rb
+++ b/spec/syntax_checking_spec.rb
@@ -36,7 +36,7 @@ describe Pry do
     ["o = Object.new.tap{ def o.render;", "'MEH'", "}"],
 
     # multiple syntax errors reported in one SyntaxException
-    ["puts {'key'=>'val'}.to_json"]
+    ["puts {key: 'val'}.to_json"]
   ].compact.each do |foo|
     it "should raise an error on invalid syntax like #{foo.inspect}" do
       redirect_pry_io(InputTester.new(*foo), @str_output) do


### PR DESCRIPTION
Spec started failing in ruby 3.0 because a statement which we expected to be a
syntax error is now interpreted as a valid pattern-matching statement.
Swapping the hash-rocket for a colon turns this back into a syntax
error in all ruby versions.