### PR TITLE
add option to display less on alternate screen

### DIFF
--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -67,6 +67,9 @@ class Pry
     # @return [Boolean]
     attribute :pager
 
+    # @return [Boolean]
+    attribute :less_alt_screen
+
     # @return [Boolean] whether the global ~/.pryrc should be loaded
     attribute :should_load_rc
 

--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -131,8 +131,15 @@ class Pry
         pager = Pry::Env['PAGER'] || ''
 
         # Default to less, and make sure less is being passed the correct
-        # options
-        pager = "less -R -F -X" if pager.strip.empty? || pager =~ /^less\b/
+        # options. By default, -X is passed. Do not pass -X if
+        # `Pry.config.less_alt_screen` is set to true.
+        if pager.strip.empty? || pager =~ /^less\b/
+          if Pry.config.less_alt_screen
+            pager = "less -R -F"
+          else
+            pager = "less -R -F -X"
+          end
+        end
 
         pager
       end


### PR DESCRIPTION
Currently, Pry passes the `-X` option to `less` in the class `SystemPager`, which _'Disables sending the termcap initialization and deinitialization strings to the terminal'_. This means that paging happens on the main screen and its contents will stay there after quitting `less`.

For me, having `less` displayed on the alternate screen of the terminal is very useful, because it de-clutters my main screen. For example, if I look at an API response in a Pry session, I often page through a lot of data and then return to the REPL, but whatever I was looking at before is now overwritten by the contents of the API response. By displaying `less` on the alternate screen, I can quickly return to the previous context.

However, I don't want to change any existing behaviour or already established workflows, so this PR adds a config option.
This way, one can just set `Pry.config.less_alt_screen = true` in .pryrc and `less` will be displayed on the alternate screen.