### PR TITLE
Deprecate the option "--plugins" on CLI

### DIFF
--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -163,11 +163,8 @@ Pry::CLI.add_options do
   end
 
   on "plugins", "List installed plugins." do
-    puts "Installed Plugins:"
-    puts "--"
-    Pry.locate_plugins.each do |plugin|
-      puts plugin.name.to_s.ljust(18) << plugin.spec.summary
-    end
+    warn "The --plugins option is deprecated and has no effect"
+    warn "Try using `gem list pry-`"
     Kernel.exit
   end
 


### PR DESCRIPTION
## Rational

Since changes on https://github.com/pry/pry/pull/2119 were merge we don't have the source needed to load/list plugins anymore. It was described in PR https://github.com/pry/pry/issues/2172.

Note: I also noticed we have this other PR (https://github.com/pry/pry/pull/2177) restoring plugins auto-load capabilities but considering we're waiting on `pry-byebug` to perform some changes and we may not merge that PR I'll keep this one.