### PR TITLE
helpers/documentation: don't colorize twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### master
 
+#### Bug fixes
+
+* Fixed bad coloring of some RDoc-style docs
+  (([#2182](https://github.com/pry/pry/pull/2182))
+
 ### [v0.14.0][v0.14.0] (February 8, 2021)
 
 #### Features

--- a/lib/pry/helpers/documentation_helpers.rb
+++ b/lib/pry/helpers/documentation_helpers.rb
@@ -17,12 +17,13 @@ class Pry
         last_match_ruby = proc do
           SyntaxHighlighter.highlight(Regexp.last_match(1))
         end
+
         comment.gsub(%r{<code>(?:\s*\n)?(.*?)\s*</code>}m, &last_match_ruby)
           .gsub(%r{<em>(?:\s*\n)?(.*?)\s*</em>}m) { "\e[1m#{Regexp.last_match(1)}\e[0m" }
           .gsub(%r{<i>(?:\s*\n)?(.*?)\s*</i>}m) { "\e[1m#{Regexp.last_match(1)}\e[0m" }
           .gsub(%r{<tt>(?:\s*\n)?(.*?)\s*</tt>}m, &last_match_ruby)
           .gsub(/\B\+(\w+?)\+\B/) { "\e[32m#{Regexp.last_match(1)}\e[0m" }
-          .gsub(/((?:^[ \t]+.+(?:\n+|\Z))+)/, &last_match_ruby)
+          .gsub(/((?:^[ \t]+(?:(?!.+\e\[)).+(?:\n+|\Z))+)/, &last_match_ruby)
           .gsub(/`(?:\s*\n)?([^\e]*?)\s*`/) { "`#{last_match_ruby.call}`" }
       end
 

--- a/spec/documentation_helper_spec.rb
+++ b/spec/documentation_helper_spec.rb
@@ -72,5 +72,9 @@ describe Pry::Helpers::DocumentationHelpers do
     it "should not remove ++" do
       expect(@helper.process_rdoc("--\n  comment in a bubble\n++")).to match(/\+\+/)
     end
+
+    it "should not syntax highlight already highlighted code" do
+      expect(@helper.process_rdoc("  \e\[31mFOO\e\[0m")).to match(/  \e\[31mFOO\e\[0m/)
+    end
   end
 end


### PR DESCRIPTION
Fixes #2181 (Bad formatting)

One of the regexps matches against string that were already colored. To prevent
that I used a negative look-ahead and rejected color sequences.