### PR TITLE
Allow loading pryrc in other location even if XDG env is set

### DIFF
--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -80,25 +80,61 @@ RSpec.describe Pry::Config do
         allow(File).to receive(:exist?)
       end
 
-      context "and when ~/.pryrc exists" do
+      context "and when $XDG_CONFIG_HOME/pry/pryrc exists" do
         before do
-          allow(File).to receive(:exist?)
-            .with(File.expand_path('~/.pryrc')).and_return(true)
+          allow(File).to receive(:exist?).and_return(true)
         end
 
-        it "defaults to $XDG_CONFIG_HOME/pry/pryrc" do
-          expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+        context "and when ~/.pryrc exists" do
+          before do
+            allow(File).to receive(:exist?)
+              .with(File.expand_path('~/.pryrc')).and_return(true)
+          end
+
+          it "defaults to $XDG_CONFIG_HOME/pry/pryrc" do
+            expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+          end
+        end
+
+        context "and when ~/.pryrc doesn't exist" do
+          before do
+            allow(File).to receive(:exist?)
+              .with(File.expand_path('~/.pryrc')).and_return(false)
+          end
+
+          it "defaults to $XDG_CONFIG_HOME/pry/pryrc" do
+            expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+          end
         end
       end
 
-      context "and when ~/.pryrc doesn't exist" do
+      context "and when $XDG_CONFIG_HOME/pry/pryrc doesn't exist" do
         before do
           allow(File).to receive(:exist?)
-            .with(File.expand_path('~/.pryrc')).and_return(false)
+            .with(File.expand_path('/xdg_home/pry/pryrc'))
+            .and_return(false)
         end
 
-        it "defaults to $XDG_CONFIG_HOME/pry/pryrc" do
-          expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+        context "and when ~/.pryrc exists" do
+          before do
+            allow(File).to receive(:exist?)
+              .with(File.expand_path('~/.pryrc')).and_return(true)
+          end
+
+          it "defaults to $XDG_CONFIG_HOME/pry/pryrc" do
+            expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+          end
+        end
+
+        context "and when ~/.pryrc doesn't exist" do
+          before do
+            allow(File).to receive(:exist?)
+              .with(File.expand_path('~/.pryrc')).and_return(false)
+          end
+
+          it "defaults to $XDG_CONFIG_HOME/pry/pryrc" do
+            expect(subject.rc_file).to eq('/xdg_home/pry/pryrc')
+          end
         end
       end
     end


### PR DESCRIPTION
Purpose of this PR is to allow loading pryrc in ~/.pryrc even if XDG_CONFIG_HOME is set.

On Linux environment, when loading graphically, XDG environment is set.
On the same Linux environment when loading through ssh, XDG environment is not set.

So since pry is not a graphical tool, make it dependent to X environment may be a bit restrictive ?

This change a little bit the behavior for default rc,
so when XDG environment is set (for X environment),
but the X "standard" path are not used for pry which is not a graphical tool (for the moment ?),
it allows a fallback to ~/.pryrc.