### PR TITLE
link broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Pry
 
 **Links:**
 
-* https://pry.github.com/
+* https://pry.github.io/
 * [YARD API documentation](https://www.rubydoc.info/gems/pry)
 * [Wiki](https://github.com/pry/pry/wiki)
 


### PR DESCRIPTION
it should be https://pry.github.io/ instead of https://pry.github.com