### PR TITLE
Restore `--no-history` CLI flag functionality

### DIFF
--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -138,7 +138,7 @@ Pry::CLI.add_options do
   end
 
   on "no-history", "Disable history loading" do
-    Pry.config.history.should_load = false
+    Pry.config.history_load = false
   end
 
   on "no-color", "Disable syntax highlighting for session" do


### PR DESCRIPTION
The `--no-history` option was almost ten years ago, in db649858a, when the object at `Pry.config.history` was still an `OpenStruct` (added in e1d9763c2, just over ten years ago!). The contract on the configuration history object changed in e5556a2be. This commit brings the `--no-history` option up to date with that refactor.

This is essentially a duplicate of #2143, but that appears to be abandoned.