### PR TITLE
ring: change guard priority so that the value at index can be read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### master
 
+#### Bug fixes
+
+* Fixed bug where reading from the `_out_` sticky local variable could return
+  wrong results ([#2201](https://github.com/pry/pry/pull/2201))
+
 ### [v0.14.1][v0.14.1] (April 12, 2021)
 
 #### Bug fixes

--- a/lib/pry/ring.rb
+++ b/lib/pry/ring.rb
@@ -56,8 +56,8 @@ class Pry
     #   exist
     def [](index)
       @mutex.synchronize do
-        return @buffer[(count + index) % max_size] if index.is_a?(Integer)
         return @buffer[index] if count <= max_size
+        return @buffer[(count + index) % max_size] if index.is_a?(Integer)
 
         transpose_buffer_tail[index]
       end

--- a/spec/ring_spec.rb
+++ b/spec/ring_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Pry::Ring do
-  let(:ring) { described_class.new(3) }
+  subject(:ring) { described_class.new(3) }
 
   describe "#<<" do
     it "adds elements as is when the ring is not full" do
@@ -28,6 +28,8 @@ describe Pry::Ring do
     end
 
     context "when the ring is not full" do
+      subject(:ring) { described_class.new(100) }
+
       before { ring << 1 << 2 << 3 }
 
       it "reads elements" do


### PR DESCRIPTION
Fixes #2199 (`_out_` Ring is ill-addressible)