### PR TITLE
Return with an error message if pry is started inside signal handler

### DIFF
--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -168,6 +168,12 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
       return
     end
 
+    unless mutex_available?
+      output.puts "ERROR: Unable to obtain mutex lock."
+      output.puts "This can happen if binding.pry is called from a signal handler"
+      return
+    end
+
     options[:target] = Pry.binding_for(target || toplevel_binding)
     initial_session_setup
     final_session_setup
@@ -378,6 +384,13 @@ Readline version #{Readline::VERSION} detected - will not auto_resize! correctly
   ensure
     Thread.current[:pry_critical_section] -= 1
   end
+
+  def self.mutex_available?
+    Mutex.new.synchronize { true }
+  rescue ThreadError
+    false
+  end
+  private_class_method :mutex_available?
 end
 
 Pry.init

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -184,6 +184,21 @@ describe Pry do
           .to raise_error SignalException
       end
 
+      it "should return if started inside signal handler" do
+        if Pry::Helpers::Platform.jruby?
+          skip "jruby allows mutex usage in signal handlers"
+        end
+
+        if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.0.0")
+          skip "pre-2.0 mri allows mutex usage in signal handlers"
+        end
+
+        output = nil
+        trap("USR1") { output = mock_pry }
+        Process.kill("USR1", Process.pid)
+        expect(output).to match(/Unable to obtain mutex lock/)
+      end
+
       describe "multi-line input" do
         it "works" do
           expect(mock_pry('x = ', '1 + 4')).to match(/5/)


### PR DESCRIPTION
`Mutex#synchronize` will raise an exception if called from code passed to
`Signal.trap`. This makes it impossible to start a working Pry session
inside a signal handler.

Currently, calling `binding.pry` inside signal handling code raises an
exception because Pry uses mutexes to solve various thread-safety
issues.

This commit updates `Pry.start` to detect whether we'll have the ability
to use `Mutex#synchronize`. If not, we'll print an error message and
return instead of raising an error.

Resolves #2191