### PR TITLE
.github/workflows/test: fix YARD linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       run: which rubocop && bundle exec rubocop || true
 
     - name: YARD lint
-      run: >-
+      run: |
         touch README # Workaround for "incorrect" links in README.md
         bundle exec yardoc --fail-on-warning --no-progress --readme=README
 


### PR DESCRIPTION
Linting wasn't running because of bad YAML.