### PR TITLE
Fix failing build on Ruby 2.4 & 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,21 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', head, jruby, jruby-head]
+        ruby:
+          - 2.0
+          - 2.1
+          - 2.2
+          - 2.3
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+          # Due to https://github.com/actions/runner/issues/849,
+          # we have to use quotes for '3.0'
+          - '3.0'
+          - head
+          - jruby
+          - jruby-head
 
     runs-on: ${{ matrix.os }}
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 gem 'rake'
 gem 'yard'
 gem 'rspec'
-gem 'simplecov', '~> 0.16', require: false
 
 # Rubocop supports only >=2.2.0
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-if ENV['COVERAGE']
-  require 'simplecov'
-  SimpleCov.start
-end
-
 require 'pry'
 require 'rspec'
 


### PR DESCRIPTION
Example failure: https://github.com/pry/pry/runs/3010680604

```
ArgumentError: wrong number of arguments (given 4, expected 1)
    /home/runner/work/pry/pry/vendor/bundle/ruby/2.4.0/gems/psych-4.0.1/lib/psych.rb:323:in `safe_load'
```

I am not sure what exactly causes the failure but deleting simplecov dependency
fixes (I guess?) this problem.