### PR TITLE
Gemfile: run Rubocop only on Ruby 2.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
 
     - name: Rubocop lint
       run: |

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem 'yard'
 gem 'rspec'
 
 # Rubocop supports only >=2.2.0
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
+if Gem::Version.new(RUBY_VERSION) == Gem::Version.new('2.2.0')
   gem 'rubocop', '= 0.66.0', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem 'yard'
 gem 'rspec'
 
 # Rubocop supports only >=2.2.0
-if Gem::Version.new(RUBY_VERSION) == Gem::Version.new('2.2.0')
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
   gem 'rubocop', '= 0.66.0', require: false
 end


### PR DESCRIPTION
In https://github.com/pry/pry/pull/2212 I thought the build was fixed however
after mergin that PR with `master` showed that it wasn't the case.

Now I want to lock the Rubocop dependency to be installed only on Ruby 2.2.0 in
the hope that its dependencies doesn't clash with other gems. Still not sure
exactly what the problem is.