### PR TITLE
README: Removed method is used in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,23 +267,23 @@ syntax and also simply the name of a method that's in scope. You can optionally
 pass the `-l` option to `show-source` to include line numbers in the output.
 
 In the following example we will enter the `Pry` class, list the instance
-methods beginning with 're' and display the source code for the `rep` method:
+methods beginning with 're' and display the source code for the `repl` method:
 
 ```ruby
 pry(main)> cd Pry
 pry(Pry):1> ls -M --grep re
-Pry#methods: re  readline  refresh  rep  repl  repl_epilogue  repl_prologue  retrieve_line
-pry(Pry):1> show-source rep -l
+Pry#methods: current_binding  current_context  last_result  last_result=  last_result_is_exception?  repl  reset_eval_string  set_last_result  show_result  suppress_output  suppress_output=
+pry(Pry):1> show-source repl -l
 
-From: /home/john/ruby/projects/pry/lib/pry/pry_instance.rb:143
-Number of lines: 6
+From: /home/john/ruby/projects/pry/lib/pry/pry_instance.rb:279:
+Owner: Pry
+Visibility: public
+Signature: repl(target=?)
+Number of lines: 3
 
-143: def rep(target=TOPLEVEL_BINDING)
-144:   target = Pry.binding_for(target)
-145:   result = re(target)
-146:
-147:   show_result(result) if should_print?
-148: end
+279: def repl(target = nil)
+280:   Pry::REPL.new(self, target: target).start
+281: end
 ```
 
 Note that we can also view C methods (from Ruby Core) using the

--- a/README.md
+++ b/README.md
@@ -267,23 +267,26 @@ syntax and also simply the name of a method that's in scope. You can optionally
 pass the `-l` option to `show-source` to include line numbers in the output.
 
 In the following example we will enter the `Pry` class, list the instance
-methods beginning with 're' and display the source code for the `repl` method:
+methods beginning with 'se' and display the source code for the `set_last_result` method:
 
 ```ruby
 pry(main)> cd Pry
-pry(Pry):1> ls -M --grep re
-Pry#methods: current_binding  current_context  last_result  last_result=  last_result_is_exception?  repl  reset_eval_string  set_last_result  show_result  suppress_output  suppress_output=
-pry(Pry):1> show-source repl -l
+pry(Pry):1> ls -M --grep se
+Pry#methods: raise_up  raise_up!  raise_up_common  reset_eval_string  select_prompt  set_last_result
+pry(Pry):1> show-source set_last_result -l
 
-From: /home/john/ruby/projects/pry/lib/pry/pry_instance.rb:279:
+From: /home/john/ruby/projects/pry/lib/pry/pry_instance.rb:405:
 Owner: Pry
 Visibility: public
-Signature: repl(target=?)
-Number of lines: 3
+Signature: set_last_result(result, code=?)
+Number of lines: 6
 
-279: def repl(target = nil)
-280:   Pry::REPL.new(self, target: target).start
-281: end
+405: def set_last_result(result, code = "")
+406:   @last_result_is_exception = false
+407:   @output_ring << result
+408:
+409:   self.last_result = result unless code =~ /\A\s*\z/
+410: end
 ```
 
 Note that we can also view C methods (from Ruby Core) using the


### PR DESCRIPTION
`Pry#rep` has already been removed. What about a example that uses `Pry#repl` instead?

https://github.com/pry/pry/blob/5590e095ae97bfed0374ee0e1f58a78dae855d8f/README.md#L273-L286