### PR TITLE
README: Execution result of pry is one wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ hello world!
 pry(main)> def a.goodbye
 pry(main)*   puts "goodbye cruel world!"
 pry(main)* end
-=> nil
+=> :goodbye
 pry(main)> a.goodbye
 goodbye cruel world!
 => nil


### PR DESCRIPTION
The return value of `define_method` is symbol, so the return value of `def a.goodbye ... end` is `:goodbye` instead of `nil`.

https://github.com/pry/pry/blob/5590e095ae97bfed0374ee0e1f58a78dae855d8f/README.md#L209-L212