### PR TITLE
#2141 fix Kernel.system() exit status

### DIFF
--- a/lib/pry/pager.rb
+++ b/lib/pry/pager.rb
@@ -137,32 +137,27 @@ class Pry
         pager
       end
 
-      @system_pager = nil
-
       def self.available?
-        if @system_pager.nil?
-          @system_pager =
-            begin
-              pager_executable = default_pager.split(' ').first
-              if Helpers::Platform.windows? || Helpers::Platform.windows_ansi?
-                `where /Q #{pager_executable}`
-              else
-                `which #{pager_executable}`
-              end
-              $CHILD_STATUS.success?
-            rescue StandardError
-              false
-            end
-        else
-          @system_pager
-        end
+        @system_pager
       end
 
       def initialize(*)
         super
-        @tracker = PageTracker.new(height, width)
-        @buffer  = ""
-        @pager   = nil
+        @tracker      = PageTracker.new(height, width)
+        @buffer       = ""
+        @pager        = nil
+        @system_pager =
+          begin
+            pager_executable = default_pager.split(' ').first
+            if Helpers::Platform.windows? || Helpers::Platform.windows_ansi?
+              `where /Q #{pager_executable}`
+            else
+              `which #{pager_executable}`
+            end
+            $CHILD_STATUS.success?
+          rescue StandardError
+            false
+          end
       end
 
       def write(str)


### PR DESCRIPTION
This PR fixes #2141

The child process was different because `which # {pager_executable}` was execute on the first run.

### Before
```
⋊> ~/g/g/h/pry on master ◦ bundle exec pry
[1] pry(main)> $?
=> #<Process::Status: pid 24738 exit 0>
[2] pry(main)> $?
=> #<Process::Status: pid 24778 exit 0>
[3] pry(main)> $?
=> #<Process::Status: pid 24778 exit 0>
```

I thought it would be better to execute `which # {pager_executable}` at the time of initialize.
 
### After
```
⋊> ~/g/g/h/pry on fix_child_process  bundle exec pry
[1] pry(main)> $?
=> #<Process::Status: pid 24214 exit 0>
[2] pry(main)> $?
=> #<Process::Status: pid 24214 exit 0>
[3] pry(main)> $?
=> #<Process::Status: pid 24214 exit 0>
[4] pry(main)>
```