### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           # Due to https://github.com/actions/runner/issues/849,
           # we have to use quotes for '3.0'
           - '3.0'
+          - 3.1
           - head
           - jruby
           - jruby-head

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           # we have to use quotes for '3.0'
           - '3.0'
           - 3.1
-          - head
+          # - head is currently broken due to yard support for 3.2.0-dev
           - jruby
           - jruby-head
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           - 3.1
           # - head is currently broken due to yard support for 3.2.0-dev
           - jruby
-          - jruby-head
+          # - jruby-head
 
     runs-on: ${{ matrix.os }}
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
 inherit_from: .rubocop_todo.yml
 
+# Prevents Ruby 3.1 incompatibility error. You can enable this cop when Ruby 2.4 support is dropped.
+# See https://github.com/rubocop/rubocop/issues/10258
+Layout/BlockAlignment:
+  Enabled: false
+
 Style/NumericPredicate:
   Enabled: false
 


### PR DESCRIPTION
Adding RUby 3.1.0 to the list of supported versions on Github Workflows