### PR TITLE
Enable whereami to receive two arguments

### DIFF
--- a/lib/pry/code.rb
+++ b/lib/pry/code.rb
@@ -173,17 +173,20 @@ class Pry
       end
     end
 
-    # Remove all lines except for the +lines+ on either side of and including
-    # +lineno+.
+    # Remove all lines except for the +before_lines+ before and +after_lines+ after
+    # and including +lineno+.
     #
     # @param [Integer] lineno
-    # @param [Integer] lines
+    # @param [Integer] before_lines
+    # @param [Integer] after_lines
     # @return [Code]
-    def around(lineno, lines = 1)
+    def around(lineno, before_lines = 1, after_lines = nil)
       return self unless lineno
 
+      after_lines ||= before_lines
+
       select do |loc|
-        loc.lineno >= lineno - lines && loc.lineno <= lineno + lines
+        loc.lineno >= lineno - before_lines && loc.lineno <= lineno + after_lines
       end
     end
 

--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -150,7 +150,8 @@ class Pry
       end
 
       def code_window
-        Pry::Code.from_file(@file).around(@line, window_size)
+        before_lines, after_lines = window_size
+        Pry::Code.from_file(@file).around(@line, before_lines, after_lines)
       end
 
       def method_code
@@ -193,7 +194,7 @@ class Pry
         if args.empty?
           pry_instance.config.default_window_size
         else
-          args.first.to_i
+          args.slice(0, 2).map(&:to_i)
         end
       end
     end

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -305,9 +305,15 @@ RSpec.describe Pry::Code do
         expect(subject.around(2).lines).to eql(%W[1\n 2\n 3\n])
       end
 
-      context "and we specify how many lines to select" do
+      context "and we specify how many lines to select by an integer" do
         it "selects more than 1 line around" do
           expect(subject.around(4, 2).lines).to eql(%W[2\n 3\n 4\n 5\n 6\n])
+        end
+      end
+
+      context "and we specify how many lines to select by two integers" do
+        it "selects before and after lines around independently" do
+          expect(subject.around(4, 2, 3).lines).to eql(%W[2\n 3\n 4\n 5\n 6\n 7\n])
         end
       end
     end


### PR DESCRIPTION
Details are described in #2219.

I changed whereami to receive two arguments.
The first and second arguments specify the number of lines to show before and after lineno.
