### PR TITLE
Make method_size_cutoff configurable

### DIFF
--- a/lib/pry/commands/whereami.rb
+++ b/lib/pry/commands/whereami.rb
@@ -11,12 +11,6 @@ class Pry
         @method_code = nil
       end
 
-      class << self
-        attr_accessor :method_size_cutoff
-      end
-
-      @method_size_cutoff = 30
-
       match 'whereami'
       description 'Show code surrounding the current context.'
       group 'Context'
@@ -138,7 +132,11 @@ class Pry
       end
 
       def small_method?
-        @method.source_range.count < self.class.method_size_cutoff
+        @method.source_range.count < cutoff_size
+      end
+
+      def cutoff_size
+        pry_instance.config.method_size_cutoff || 30
       end
 
       def default_code

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -34,6 +34,9 @@ class Pry
     #   exceptions
     attribute :default_window_size
 
+    # @return [Integer] The cutoff size of lines of method to show
+    attribute :method_size_cutoff
+
     # @return [Pry::Hooks]
     attribute :hooks
 
@@ -180,6 +183,7 @@ class Pry
         system: Pry::SystemCommandHandler.method(:default),
         color: Pry::Helpers::BaseHelpers.use_ansi_codes?,
         default_window_size: 5,
+        method_size_cutoff: 30,
         editor: Pry::Editor.default,
         rc_file: default_rc_file,
         should_load_rc: true,

--- a/spec/commands/whereami_spec.rb
+++ b/spec/commands/whereami_spec.rb
@@ -148,8 +148,8 @@ describe "whereami" do
   it 'should show entire method when -m option used' do
     old_size = Pry.config.default_window_size
     Pry.config.default_window_size = 1
-    old_cutoff = Pry::Command::Whereami.method_size_cutoff
-    Pry::Command::Whereami.method_size_cutoff = 1
+    old_cutoff = Pry.config.method_size_cutoff
+    Pry.config.method_size_cutoff = 1
     class Cor
       def blimey!
         @foo = 1
@@ -157,8 +157,8 @@ describe "whereami" do
         pry_eval(binding, 'whereami -m')
       end
     end
-    Pry::Command::Whereami.method_size_cutoff = old_cutoff
     Pry.config.default_window_size = old_size
+    Pry.config.method_size_cutoff = old_cutoff
     result = Cor.new.blimey!
     Object.remove_const(:Cor)
     expect(result).to match(/def blimey/)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Pry::Config do
   specify { expect(subject.system).to be_a(Method) }
   specify { expect(subject.color).to be(true).or be(false) }
   specify { expect(subject.default_window_size).to be_a(Numeric) }
+  specify { expect(subject.method_size_cutoff).to be_a(Numeric) }
   specify { expect(subject.editor).to be_a(String) }
   specify { expect(subject.should_load_rc).to be(true).or be(false) }
   specify { expect(subject.should_load_local_rc).to be(true).or be(false) }


### PR DESCRIPTION
## WHAT & WHY
This PR enables `method_size_cutoff` to be configured through `Pry.config.method_size_cutoff`.
I would like to adjust `method_size_cutoff`, and the change seems to have small impact area.

## Checked
1. `pry_instance.config.method_size_cutoff` is configured by adding `Pry.config.method_size_cutoff = {integer}` to `.pryrc`, and whereami works as expected.

2. Usage of `method_size_cutoff` is limited in pry/pry repository among pry/* repositories. 
The variable can be accessed from outside of the class by `Pry::Command::Whereami.method_size_cutoff`, but that does not happen in at least 16 repositories of pry organization.