### PR TITLE
Reduce ambiguity in error message

### DIFF
--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -530,9 +530,9 @@ class Pry
       else
         fail_msg = "Cannot locate this method: #{name}."
         if Helpers::Platform.mri?
-          fail_msg += " Run 'gem install pry-doc' to install" \
+          fail_msg += " Run `gem install pry-doc` to install" \
                       " Ruby Core documentation," \
-                      " and 'require pry-doc' to load it.\n"
+                      " and `require 'pry-doc'` to load it.\n"
         end
         raise CommandError, fail_msg
       end


### PR DESCRIPTION
Apologies, the line

```ruby
" and 'require pry-doc' to load it.\n"
```

should have been more like 

```ruby
" and require 'pry-doc' to load it.\n"
```

(the difference is the placement of the `'`)

In order to keep the error message formatting consistent and reduce ambiguity, this error message is amended to use backticks. 