### PR TITLE
Configure Windows on Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         ruby:
           - 2.0
           - 2.1
@@ -23,8 +23,24 @@ jobs:
           # - head is currently broken due to yard support for 3.2.0-dev
           - jruby
           # - jruby-head
+        exclude:
+          - os: windows-latest
+            ruby: jruby
+          - os: windows-latest
+            ruby: '2.0'
+          - os: windows-latest
+            ruby: '2.1'
+          - os: windows-latest
+            ruby: '2.2'
+          - os: windows-latest
+            ruby: '2.3' # Intermittent failing Expression: RBASIC_CLASS(ret) == rb_cString
+          - os: windows-latest
+            ruby: '3.0'
+          - os: windows-latest
+            ruby: '3.1'
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: true
 
     steps:
     - uses: actions/checkout@v2
@@ -38,12 +54,10 @@ jobs:
     - name: Install dependencies
       run: bundle install
 
+    # Rubocop is not included on the Gemfile for earlier rubies. This can be dropped as soon as the support is dropped.
     - name: Rubocop lint
-      run: |
-        if bundle list | grep rubocop
-        then
-            bundle exec rubocop --parallel
-        fi
+      if: matrix.ruby != '2.0' && matrix.ruby != '2.1' && matrix.ruby != '2.2'
+      run: rubocop --parallel
 
     - name: YARD lint
       run: |

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -2,8 +2,6 @@
 
 describe "hist" do
   before do
-    # different platforms require different types of Readline.
-    # so best not to rely on it for these tests:
     @hist = Pry.history = Pry::History.new
 
     @str_output = StringIO.new

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -2,8 +2,9 @@
 
 describe "hist" do
   before do
-    Pry.history.clear
-    @hist = Pry.history
+    # different platforms require different types of Readline.
+    # so best not to rely on it for these tests:
+    @hist = Pry.history = Pry::History.new
 
     @str_output = StringIO.new
     @t = pry_tester history: @hist do

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -59,6 +59,7 @@ describe Pry::Editor do
       before do
         allow(ENV).to receive(:key?).and_return(false)
         allow(Kernel).to receive(:system)
+        allow(Pry::Helpers::Platform).to receive(:windows?).and_return(false)
       end
 
       %w[editor nano vi].each do |text_editor_name|

--- a/spec/editor_spec.rb
+++ b/spec/editor_spec.rb
@@ -72,7 +72,11 @@ describe Pry::Editor do
     end
   end
 
-  describe "build_editor_invocation_string", skip: !Pry::Helpers::Platform.windows? do
+  describe "build_editor_invocation_string" do
+    before do
+      allow(Pry::Helpers::Platform).to receive(:windows?).and_return(false)
+    end
+
     it 'should shell-escape files' do
       invocation_str = @editor.build_editor_invocation_string(@tf_path, 5, true)
       expect(invocation_str).to match(/#{@tf_dir}.+hello\\ world\.rb/)

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -49,14 +49,16 @@ RSpec.describe Pry::History do
     end
 
     context "when $XDG_DATA_HOME is defined" do
+      let(:expected_file_path) { File.expand_path('/my/path/pry/pry_history') }
+
       it "returns config location relative to $XDG_DATA_HOME" do
         stub_hist has_default: false, xdg_home: '/my/path'
-        expect(described_class.default_file).to eq('/my/path/pry/pry_history')
+        expect(described_class.default_file).to eq(expected_file_path)
       end
 
       it "returns config location relative to $XDG_DATA_HOME when ~/.pryrc exists" do
         stub_hist has_default: true, xdg_home: '/my/path'
-        expect(described_class.default_file).to eq('/my/path/pry/pry_history')
+        expect(described_class.default_file).to eq(expected_file_path)
       end
     end
   end
@@ -189,8 +191,9 @@ RSpec.describe Pry::History do
       history = Pry::History.new(file_path: '~/test_history')
       error = Class.new(RuntimeError)
 
+      expected_path = File.expand_path(File.join(ENV['HOME'].to_s, "/test_history"))
       expect(File).to receive(:open)
-        .with(File.join(ENV['HOME'].to_s, "/test_history"), 'a', 0o600)
+        .with(expected_path, 'a', 0o600)
         .and_raise(error)
 
       expect { history.push 'a line' }.to raise_error error

--- a/spec/history_spec.rb
+++ b/spec/history_spec.rb
@@ -4,8 +4,6 @@ require 'tempfile'
 require 'rbconfig'
 
 RSpec.describe Pry::History do
-  # different platforms require different types of Readline.
-  # so best not to rely on it for these tests:
   let(:history) { Pry::History.new }
 
   before do

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -3,38 +3,51 @@
 require 'rbconfig'
 
 RSpec.describe 'The bin/pry CLI' do
-  let(:ruby) { RbConfig.ruby.shellescape }
-  let(:pry_dir) { File.expand_path(File.join(__FILE__, '../../../lib')).shellescape }
-  let(:clean_output) do
-    # Pry will emit silent garbage because of our auto indent feature.
-    # This lambda cleans the output of that garbage.
-    ->(out) { out.strip.sub("\e[0G", "") }
+  let(:call_pry) do
+    lambda { |*args|
+      pry_dir = File.expand_path(File.join(__FILE__, '../../../lib'))
+
+      # the :err option is equivalent to 2>&1
+      out = IO.popen([RbConfig.ruby,
+                      "-I",
+                      pry_dir,
+                      'bin/pry',
+                      *args,
+                      err: [:child, :out]], &:read)
+      status = $CHILD_STATUS
+
+      # Pry will emit silent garbage because of our auto indent feature.
+      # This lambda cleans the output of that garbage.
+      out = out.strip.sub(/^\e\[0[FG]/, "")
+
+      [out, status]
+    }
   end
 
   context "ARGV forwarding" do
-    let(:code) { "p(ARGV) and exit".shellescape }
+    let(:code) { "p(ARGV) and exit" }
 
     it "forwards ARGV as an empty array when - is passed without following arguments" do
-      out = clean_output.call(`#{ruby} -I#{pry_dir} bin/pry -e #{code} -`)
+      out, status = call_pry.call('-e', code, '-')
+      expect(status).to be_success
       expect(out).to eq([].inspect)
     end
 
     it "forwards ARGV as an empty array when -- is passed without following arguments" do
-      out = clean_output.call(`#{ruby} -I#{pry_dir} bin/pry -e #{code} --`)
+      out, status = call_pry.call('-e', code, '--')
+      expect(status).to be_success
       expect(out).to eq([].inspect)
     end
 
     it "forwards its remaining arguments as ARGV when - is passed" do
-      out = clean_output.call(
-        `#{ruby} -I#{pry_dir} bin/pry -e #{code} - 1 -foo --bar --baz daz`
-      )
+      out, status = call_pry.call('-e', code, '-', '1', '-foo', '--bar', '--baz', 'daz')
+      expect(status).to be_success
       expect(out).to eq(%w[1 -foo --bar --baz daz].inspect)
     end
 
     it "forwards its remaining arguments as ARGV when -- is passed" do
-      out = clean_output.call(
-        `#{ruby} -I#{pry_dir} bin/pry -e #{code} -- 1 -foo --bar --baz daz`
-      )
+      out, status = call_pry.call('-e', code, '--', '1', '-foo', '--bar', '--baz', 'daz')
+      expect(status).to be_success
       expect(out).to eq(%w[1 -foo --bar --baz daz].inspect)
     end
   end
@@ -42,19 +55,17 @@ RSpec.describe 'The bin/pry CLI' do
   context '-I path' do
     it 'adds an additional path to $LOAD_PATH' do
       code = 'p($LOAD_PATH) and exit'
-      out = clean_output.call(
-        `#{ruby} -I#{pry_dir} bin/pry -I /added/at/cli -e '#{code}'`
-      )
+      out, status = call_pry.call('-I', '/added/at/cli', '-e', code)
+      expect(status).to be_success
       expect(out).to include('/added/at/cli')
     end
 
     it 'adds multiple additional paths to $LOAD_PATH' do
       code = 'p($LOAD_PATH) and exit'
-      out = clean_output.call(
-        # rubocop:disable Metrics/LineLength
-        `#{ruby} -I#{pry_dir} bin/pry -I /added-1/at/cli -I /added/at/cli/also -e '#{code}'`
-        # rubocop:enable Metrics/LineLength
-      )
+      out, status = call_pry.call('-I', '/added-1/at/cli',
+                                  '-I', '/added/at/cli/also',
+                                  '-e', code)
+      expect(status).to be_success
       expect(out).to include('/added-1/at/cli')
       expect(out).to include('/added/at/cli/also')
     end

--- a/spec/pry_repl_spec.rb
+++ b/spec/pry_repl_spec.rb
@@ -125,6 +125,7 @@ describe Pry::REPL do
 
   describe "autoindent" do
     it "should raise no exception when indented with a tab" do
+      skip if Pry::Helpers::Platform.windows?
       ReplTester.start(correct_indent: true, auto_indent: true) do
         output = @pry.config.output
         def output.tty?

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -186,7 +186,7 @@ describe Pry do
 
       describe "inside signal handler" do
         before do
-          unless Signal.list.has_key?('USR1')
+          unless Signal.list.key?('USR1')
             skip "Host OS #{RbConfig::CONFIG['host_os']} doesn't support signal USR1"
           end
 

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -186,6 +186,10 @@ describe Pry do
 
       describe "inside signal handler" do
         before do
+          unless Signal.list.has_key?('USR1')
+            skip "Host OS #{RbConfig::CONFIG['host_os']} doesn't support signal USR1"
+          end
+
           if Pry::Helpers::Platform.jruby?
             skip "jruby allows mutex usage in signal handlers"
           end


### PR DESCRIPTION
Add partial support for testing from Ruby 2.4~2.7 on windows.

Ruby 3.0 and 3.1 should be fixed when #2209 gets merged.

This PR also aims to break down the changes on #2209 and merge it on smallers subsets. :)
