### PR TITLE
Configure `code` as a supported editor on Pry::Editor

### DIFF
--- a/lib/pry/editor.rb
+++ b/lib/pry/editor.rb
@@ -105,7 +105,7 @@ class Pry
         '--nofork' if blocking
       when /^jedit/
         '-wait' if blocking
-      when /^mate/, /^subl/, /^redcar/
+      when /^mate/, /^subl/, /^redcar/, /^code/
         '-w' if blocking
       end
     end
@@ -121,6 +121,8 @@ class Pry
         "+#{line_number} #{file_name}"
       when /^mate/, /^geany/
         "-l #{line_number} #{file_name}"
+      when /^code/
+        "-g #{file_name}:#{line_number}"
       when /^subl/
         "#{file_name}:#{line_number}"
       when /^uedit32/


### PR DESCRIPTION
```
» code --help
Visual Studio Code 1.65.0

Usage: code [options][paths...]

....
  -g --goto <file:line[:character]> Open a file at the path on the specified line and character position.
  -w --wait                         Wait for the files to be closed before returning.
...
```