### PR TITLE
As readline is being lazy required it throws an error when it gets resolved inside the trap signal

### DIFF
--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -208,6 +208,7 @@ describe Pry do
         end
 
         it "should return with error message" do
+          expect(mock_pry('1 + 1')).to eql("=> 2\n")
           Process.kill("USR1", Process.pid)
           expect(@str_output).to match(/Unable to obtain mutex lock/)
         end


### PR DESCRIPTION
Fixes #2216

Depending on the order the specs are executed `readline` might already be required or not. If readline is not required yet, it throws an error at an unexpected path.

```
$ rspec ./spec/pry_spec.rb:210

 1) Pry open a Pry session on an object rep inside signal handler should return with error message
     Failure/Error: require 'readline'

     ThreadError:
       can't be called from trap context

     ThreadError:
       can't be called from trap context
     # ./lib/pry/config.rb:290:in `require'
     # ./lib/pry/config.rb:290:in `lazy_readline'
     # ./lib/pry/config.rb:156:in `block in initialize'
     # ./lib/pry/config/memoized_value.rb:30:in `call'
     # ./lib/pry/config/value.rb:20:in `call'
     # ./lib/pry/config/attributable.rb:15:in `block in attribute'
     # ./spec/support/mock_pry.rb:20:in `redirect_pry_io'
     # ./spec/support/mock_pry.rb:11:in `mock_pry'
 ``` 

I just made it sure that pry gets executed and readline 'resolved' before trying the 'trap' spec. We might want to solve this in another way, to ensure this path is 'protected'. Maybe something related to https://github.com/pry/pry/issues/781 

