### PR TITLE
Use actions/checkout@v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,11 @@ jobs:
           - '3.0'
           - 3.1
           # - head is currently broken due to yard support for 3.2.0-dev
-          - jruby
+          - jruby-9.3.3.0
           # - jruby-head
         exclude:
           - os: windows-latest
-            ruby: jruby
+            ruby: jruby-9.3.3.0
           - os: windows-latest
             ruby: '2.0'
           - os: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     continue-on-error: true
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Updates actions/checkout to v3

pinned the jruby build 9.3.3.0. On 9.3.4.0 there's [a spec failing](https://github.com/pry/pry/blob/master/spec/commands/whereami_spec.rb#L95-L112). Which is related to https://github.com/jruby/jruby/pull/7145 . I'll dig into that into another PR. 


```
  1) whereami shows description and corrects code when @method.source_location would raise an error
     Failure/Error:
       expect { Cor.instance_method(:blimey!).source }
         .to raise_error MethodSource::SourceNotFoundError

       expected MethodSource::SourceNotFoundError, got #<RuntimeError: circular causes> with backtrace:
         # ./spec/commands/whereami_spec.rb:108:in `block in <main>'
         # ./spec/commands/whereami_spec.rb:109:in `block in <main>'
```