### PR TITLE
Weird method location shouldn't match unknown location

### DIFF
--- a/lib/pry/method/weird_method_locator.rb
+++ b/lib/pry/method/weird_method_locator.rb
@@ -158,7 +158,7 @@ class Pry
 
         alias_name = all_methods_for(target_self).find do |v|
           location = target_self.method(v).source_location
-          expanded_source_location(location) == renamed_method_source_location
+          location && expanded_source_location(location) == renamed_method_source_location
         end
 
         alias_name && Pry::Method(target_self.method(alias_name))

--- a/spec/fixtures/test_task.rb
+++ b/spec/fixtures/test_task.rb
@@ -1,0 +1,3 @@
+task :test_task do
+  binding
+end


### PR DESCRIPTION
Methods that don't have a source location (e.g., C methods, or methods
created via metaprogramming or even `alias_method`) are not reasonable
possible matching methods for a "weird method" we need to locate.

In this case `renamed_method_source_location` can also return `nil` if
the actual code in question is a bare script (i.e., no methods). If that script
is loaded via `eval` then we'll end up in the weird method path in the first
place, but no method matching can be found, and if a no-source-location
method exists, we'll return that.

Down the line that's particularly painful because the source loading thinks
it's a C method, but it can actually be from metaprogramming (and `alias_method`!),
and then `Pry::Method#pry_doc_info` raises an error, and `wherami` breaks even
though we already have valid `__FILE__` and `__LINE__` values.