### PR TITLE
Fix ruby 1.9 build

### DIFF
--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -230,7 +230,7 @@ describe Pry::Method do
         end
 
         def load_task
-          path = File.expand_path("fixtures/test_task.rb", __dir__)
+          path = File.expand_path("spec/fixtures/test_task.rb")
           instance_eval File.read(path), path
         end
       end


### PR DESCRIPTION
__dir__ was introduced on Ruby 2.0