### PR TITLE
Short circuit eval regexes in finding module definition

### DIFF
--- a/lib/pry/wrapped_module/candidate.rb
+++ b/lib/pry/wrapped_module/candidate.rb
@@ -98,14 +98,15 @@ class Pry
       #   line number is one-indexed.
       def first_line_of_module_definition(file, line)
         searchable_lines = lines_for_file(file)[0..(line - 2)]
-        searchable_lines.rindex { |v| class_regexes.any? { |r| r =~ v } } + 1
+        searchable_lines.rindex { |v| module_definition_first_line?(v) } + 1
       end
 
-      def class_regexes
+      def module_definition_first_line?(line)
         mod_type_string = wrapped.class.to_s.downcase
-        [/(^|=)\s*#{mod_type_string}\s+(?:(?:\w*)::)*?#{wrapped.name.split(/::/).last}/,
-         /^\s*(::)?#{wrapped.name.split(/::/).last}\s*?=\s*?#{wrapped.class}/,
-         /^\s*(::)?#{wrapped.name.split(/::/).last}\.(class|instance)_eval/]
+        wrapped_name_last = wrapped.name.split(/::/).last
+        /(^|=)\s*#{mod_type_string}\s+(?:(?:\w*)::)*?#{wrapped_name_last}/ =~ line ||
+          /^\s*(::)?#{wrapped_name_last}\s*?=\s*?#{wrapped.class}/ =~ line ||
+          /^\s*(::)?#{wrapped_name_last}\.(class|instance)_eval/ =~ line
       end
 
       # This method is used by `Candidate#source_location` as a


### PR DESCRIPTION
I was profiling gem RBI generation for [Tapioca](https://github.com/Shopify/tapioca#generating-rbi-files-for-gems) and found that it was spending half its time in `Pry::WrappedModule::Candidate#class_regexes`. I noticed that method evaluates three regexes on every invocation since [this](https://github.com/pry/pry/commit/b313a03c8f31914e510504a0f1c31df9be5ed313#diff-30f9ac3a77ff5d511bb5f9ef36e5346d34066ac7ca444f585caada0f5fec71c8R209-R211) change, and have reverted it to the prior short-circuit implementation. I've verified that tests pass locally and that the output of Tapioca RBI generation is unchanged (while running 8% faster). Tapioca has since [removed](https://github.com/Shopify/tapioca/pull/1102) the dependency on this Pry code, but I thought you might find this patch useful regardless.

Note that i think there could be a few more possible optimizations here:
- The start-of-string anchor (`\A`) should probably be preferred over the start-of-line anchor (`^`) in each regex
- `.match?` should be preferred over `=~` once the minimum supported ruby is 2.4
- I think that the various invocations of `#name` are susceptible to the [this](https://bugs.ruby-lang.org/issues/15625) performance bug, and should be cached in an ivar. I've reduced the invocations by two, but not taken on a larger refactor of `WrappedModule`.
