### PR TITLE
Complete rubocop todos

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,10 +51,6 @@ Style/SingleLineMethods:
 Style/StringLiterals:
   Enabled: false
 
-# TODO: delete this rule when we drop Ruby 1.9.3 support.
-Style/SymbolArray:
-  EnforcedStyle: brackets
-
 Metrics/LineLength:
   Max: 90
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,12 +33,6 @@ Style/ClassAndModuleChildren:
   Exclude:
     - 'spec/fixtures/example_nesting.rb'
 
-# TODO: delete exclusions when we drop Ruby 1.9.3 support.
-Style/ExpandPathArguments:
-  Exclude:
-    - 'lib/pry/commands.rb'
-    - 'pry.gemspec'
-
 Style/Semicolon:
   Exclude:
     - 'spec/method_spec.rb'

--- a/lib/pry/basic_object.rb
+++ b/lib/pry/basic_object.rb
@@ -2,7 +2,7 @@
 
 class Pry
   class BasicObject < BasicObject
-    [:Kernel, :File, :Dir, :LoadError, :ENV, :Pry].each do |constant|
+    %i[Kernel File Dir LoadError ENV Pry].each do |constant|
       const_set constant, ::Object.const_get(constant)
     end
     include Kernel

--- a/lib/pry/commands/ls/constants.rb
+++ b/lib/pry/commands/ls/constants.rb
@@ -4,8 +4,8 @@ class Pry
   class Command
     class Ls < Pry::ClassCommand
       class Constants < Pry::Command::Ls::Formatter
-        DEPRECATED_CONSTANTS = [
-          :Data, :Fixnum, :Bignum, :TimeoutError, :NIL, :FALSE, :TRUE
+        DEPRECATED_CONSTANTS = %i[
+          Data Fixnum Bignum TimeoutError NIL FALSE TRUE
         ].tap do |constants|
           constants << :JavaPackageModuleTemplate if Helpers::Platform.jruby?
         end

--- a/lib/pry/commands/watch_expression.rb
+++ b/lib/pry/commands/watch_expression.rb
@@ -96,7 +96,7 @@ class Pry
       end
 
       def add_hook
-        hook = [:after_eval, :watch_expression]
+        hook = %i[after_eval watch_expression]
         return if pry_instance.hooks.hook_exists?(*hook)
 
         pry_instance.hooks.add_hook(*hook) do |_, pry_instance|

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -57,8 +57,8 @@ class Pry
     #
     # :pre_constant and :preserved_constant are the CodeRay 0.9.8 and 1.0.0
     # classifications of "true", "false", and "nil".
-    IGNORE_TOKENS = [:space, :content, :string, :method, :ident,
-                     :constant, :pre_constant, :predefined_constant].freeze
+    IGNORE_TOKENS = %i[space content string method ident
+                       constant pre_constant predefined_constant].freeze
 
     # Tokens that indicate the end of a statement (i.e. that, if they appear
     # directly before an "if" indicates that that if applies to the same line,
@@ -66,10 +66,10 @@ class Pry
     #
     # :reserved and :keywords are the CodeRay 0.9.8 and 1.0.0 respectively
     # classifications of "super", "next", "return", etc.
-    STATEMENT_END_TOKENS = IGNORE_TOKENS + [:regexp, :integer, :float,
-                                            :keyword, :delimiter, :reserved,
-                                            :instance_variable,
-                                            :class_variable, :global_variable]
+    STATEMENT_END_TOKENS = IGNORE_TOKENS + %i[regexp integer float
+                                              keyword delimiter reserved
+                                              instance_variable
+                                              class_variable global_variable]
 
     # Collection of tokens that should appear dedented even though they
     # don't affect the surrounding code.

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -270,7 +270,7 @@ class Pry
       end
 
       # FIXME: Add Pry here as well?
-      [:IRB, :SLex, :RubyLex, :RubyToken].each do |module_name|
+      %i[IRB SLex RubyLex RubyToken].each do |module_name|
         next unless Object.const_defined?(module_name)
 
         scanner.call(Object.const_get(module_name))

--- a/lib/pry/wrapped_module/candidate.rb
+++ b/lib/pry/wrapped_module/candidate.rb
@@ -20,9 +20,9 @@ class Pry
 
       # Methods to delegate to associated `Pry::WrappedModule
       # instance`.
-      private_delegates = [:lines_for_file, :method_candidates, :yard_docs?, :name]
-      public_delegates = [:wrapped, :module?, :class?, :nonblank_name,
-                          :number_of_candidates]
+      private_delegates = %i[lines_for_file method_candidates yard_docs? name]
+      public_delegates = %i[wrapped module? class? nonblank_name
+                            number_of_candidates]
 
       def_delegators :@wrapper, *public_delegates
       def_private_delegators :@wrapper, *private_delegates

--- a/pry.gemspec
+++ b/pry.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../lib/pry/version', __FILE__)
+require File.expand_path('lib/pry/version', __dir__)
 
 Gem::Specification.new do |s|
   s.name    = "pry"

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -1151,7 +1151,7 @@ describe "show-source" do # rubocop:disable Metrics/BlockLength
       end
 
       after do
-        [:BetaClass, :AlphaClass].each { |name| Object.remove_const(name) }
+        %i[BetaClass AlphaClass].each { |name| Object.remove_const(name) }
       end
 
       it "shows docs for the nested classes" do
@@ -1176,7 +1176,7 @@ describe "show-source" do # rubocop:disable Metrics/BlockLength
       end
 
       after do
-        [:BetaClass, :AlphaClass].each { |name| Object.remove_const(name) }
+        %i[BetaClass AlphaClass].each { |name| Object.remove_const(name) }
       end
 
       it "shows docs for the nested classes" do
@@ -1386,7 +1386,7 @@ describe "show-source" do # rubocop:disable Metrics/BlockLength
       end
 
       after do
-        [:Child, :Parent].each { |name| Object.remove_const(name) }
+        %i[Child Parent].each { |name| Object.remove_const(name) }
       end
 
       it "shows the docs of the superclass" do
@@ -1412,7 +1412,7 @@ describe "show-source" do # rubocop:disable Metrics/BlockLength
       end
 
       after do
-        [:Grandparent, :Child, :Parent].each { |name| Object.remove_const(name) }
+        %i[Grandparent Child Parent].each { |name| Object.remove_const(name) }
       end
 
       it "shows the docs of the superclass" do
@@ -1437,7 +1437,7 @@ describe "show-source" do # rubocop:disable Metrics/BlockLength
       end
 
       after do
-        [:Child, :Parent].each { |name| Object.remove_const(name) }
+        %i[Child Parent].each { |name| Object.remove_const(name) }
       end
 
       it "raises Pry::CommandError" do
@@ -1459,7 +1459,7 @@ describe "show-source" do # rubocop:disable Metrics/BlockLength
       end
 
       after do
-        [:Beta, :Alpha].each { |name| Object.remove_const(name) }
+        %i[Beta Alpha].each { |name| Object.remove_const(name) }
       end
 
       it "shows the included module's doc" do
@@ -1486,7 +1486,7 @@ describe "show-source" do # rubocop:disable Metrics/BlockLength
       end
 
       after do
-        [:Beta, :Alpha].each { |name| Object.remove_const(name) }
+        %i[Beta Alpha].each { |name| Object.remove_const(name) }
       end
 
       it "raises Pry::CommandError" do
@@ -1512,7 +1512,7 @@ describe "show-source" do # rubocop:disable Metrics/BlockLength
       end
 
       after do
-        [:Gamma, :Beta, :Alpha].each { |name| Object.remove_const(name) }
+        %i[Gamma Beta Alpha].each { |name| Object.remove_const(name) }
       end
 
       it "shows nth level included module doc" do
@@ -1550,7 +1550,7 @@ describe "show-source" do # rubocop:disable Metrics/BlockLength
       end
 
       after do
-        [:Grandparent, :Parent, :Child].each { |name| Object.remove_const(name) }
+        %i[Grandparent Parent Child].each { |name| Object.remove_const(name) }
       end
 
       context "and when it's passed once" do

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'The bin/pry CLI' do
                       pry_dir,
                       'bin/pry',
                       *args,
-                      err: [:child, :out]], &:read)
+                      err: %i[child out]], &:read)
       status = $CHILD_STATUS
 
       # Pry will emit silent garbage because of our auto indent feature.


### PR DESCRIPTION
Complete rubocop todos, now that ruby 1.9.3 is no longer supported.