### PR TITLE
Clean up MRI 1.9 code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN wget --no-check-certificate -O ruby-install-0.4.3.tar.gz https://github.com/
 RUN tar -xzvf ruby-install-0.4.3.tar.gz
 RUN cd ruby-install-0.4.3 && make install
 
-RUN ruby-install ruby 1.9.3
 RUN ruby-install ruby 2.1.1
 RUN ruby-install ruby 2.1.2
 

--- a/lib/pry/helpers/platform.rb
+++ b/lib/pry/helpers/platform.rb
@@ -47,11 +47,6 @@ class Pry
       end
 
       # @return [Boolean]
-      def self.mri_19?
-        mri? && RUBY_VERSION.start_with?('1.9')
-      end
-
-      # @return [Boolean]
       def self.mri_2?
         mri? && RUBY_VERSION.start_with?('2')
       end

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -140,12 +140,6 @@ class Pry
         should_retry = false
         retry
 
-      # Handle <Ctrl+C> like Bash: empty the current input buffer, but don't
-      # quit.  This is only for MRI 1.9; other versions of Ruby don't let you
-      # send Interrupt from within Readline.
-      rescue Interrupt
-        return :control_c
-
       # If we get a random error when trying to read a line we don't want to
       # automatically retry, as the user will see a lot of error messages
       # scroll past and be unable to do anything about it.

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -140,6 +140,11 @@ class Pry
         should_retry = false
         retry
 
+      # Handle <Ctrl+C> like Bash: empty the current input buffer, but don't
+      # quit.
+      rescue Interrupt
+        return :control_c
+
       # If we get a random error when trying to read a line we don't want to
       # automatically retry, as the user will see a lot of error messages
       # scroll past and be unable to do anything about it.


### PR DESCRIPTION
As a follow-up to https://github.com/pry/pry/pull/2256 this cleans up more Ruby 1.9 code 