### PR TITLE
Add basic Reline support by allowing optional arguments to `readline()`

### DIFF
--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -185,7 +185,7 @@ class Pry
           input_readline(current_prompt, false) # false since we'll add it manually
         elsif coolline_available?
           input_readline(current_prompt)
-        elsif input.method(:readline).arity == 1
+        elsif [1,-1,-2].include? input.method(:readline).arity # allow optional extra arguments
           input_readline(current_prompt)
         else
           input_readline


### PR DESCRIPTION
Works towards #2063, but doesn't completely support it.

I was able to get a simple pry prompt working under reline with `Pry.start(Object.new, input: Reline)`