### PR TITLE
Fix Ruby 2.0 and Ruby 2.2 builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ['ubuntu-20.04', windows-latest]
         ruby:
           - 2.0
           - 2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: ['ubuntu-20.04', windows-latest]
         ruby:
-          - 2.0
+          - '2.0'
           - 2.1
           - 2.2
           - 2.3

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -194,10 +194,6 @@ describe Pry do
             skip "jruby allows mutex usage in signal handlers"
           end
 
-          if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.0.0")
-            skip "pre-2.0 mri allows mutex usage in signal handlers"
-          end
-
           trap("USR1") { @str_output = mock_pry }
         end
 

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -210,6 +210,9 @@ describe Pry do
         it "should return with error message" do
           expect(mock_pry('1 + 1')).to eql("=> 2\n")
           Process.kill("USR1", Process.pid)
+
+          sleep 0.01 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
+
           expect(@str_output).to match(/Unable to obtain mutex lock/)
         end
       end


### PR DESCRIPTION
Changed from ubuntu-latest to ubuntu-20. When running the 2.2 build with ubuntu 22. Bundler was not installing properly. The same does not happen with ubuntu 20. 

Ruby 2.0 tests were not running at all. It's the same issue with '3.0'. We need to add quotes to install the correct version. I also fixed a test on Ruby related to pry being called inside trap signals on Ruby 2.0. 

ruby-head is still failing. I'm take a look into that later.  