### PR TITLE
Make find-method compatible with BasicObject instances.

### DIFF
--- a/lib/pry/commands/find_method.rb
+++ b/lib/pry/commands/find_method.rb
@@ -128,7 +128,7 @@ class Pry
           next if klass.autoload?(name)
 
           begin
-            const = klass.const_get(name)
+            const = Pry::Method.singleton_class_of(klass.const_get(name))
           rescue RescuableException # rubocop:disable Lint/HandleExceptions
             # constant loading is an inexact science at the best of times,
             # this often happens when a constant was .autoload? but someone

--- a/spec/commands/find_method_spec.rb
+++ b/spec/commands/find_method_spec.rb
@@ -48,7 +48,9 @@ describe "find-method" do
   end
 
   it "should work with badly behaved constants" do
+    MyKlass::Z = BasicObject.new
     MyKlass::X = Object.new
+
     def (MyKlass::X).hash
       raise "mooo"
     end


### PR DESCRIPTION
While traversing objects and classes we may hit special objects inside constants. i.e: BasicObject.

As BasicObject does not has defined methods such as `is_a?`. We need to handle this on alternatives ways, such as Pry::Method.singleton_class_of. 

Fixes #2277