### PR TITLE
Make ruby-head build green again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,3 +85,5 @@ jobs:
       env:
         # Make sure TERM is set so Pry can indent correctly inside tests.
         TERM: screen-256color
+        ROWS: 40
+        COLUMNS: 160

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'rake'
 gem 'yard'
 gem 'rspec'
 
+gem "psych", '<= 5.1.0'
+
 # Rubocop supports only >=2.2.0
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
   gem 'rubocop', '= 0.66.0', require: false


### PR DESCRIPTION
- Had to downgrade psych to 5.1.0. Seems like 5.1.1 is broken on jruby.
- Had to configure terminal size on Github Actions for indentation specs.