### PR TITLE
Fix 'calling clear method' when defined in pry context. 

### DIFF
--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -281,9 +281,7 @@ class Pry
     # @param [String] string The Ruby to lex
     # @return [Array] An Array of pairs of [token_value, token_type]
     def tokenize(string)
-      tokens = SyntaxHighlighter.tokenize(string)
-      tokens = tokens.tokens.each_slice(2) if tokens.respond_to?(:tokens) # Coderay 1.0.0
-      tokens.to_a
+      SyntaxHighlighter.tokenize(string).each_slice(2).to_a
     end
 
     # Update the internal state about what kind of strings are open.

--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -564,8 +564,7 @@ class Pry
     def method_name_from_first_line(first_ln)
       return nil if first_ln.strip !~ /^def /
 
-      tokens = SyntaxHighlighter.tokenize(first_ln)
-      tokens = tokens.tokens.each_slice(2) if tokens.respond_to?(:tokens)
+      tokens = SyntaxHighlighter.tokenize(first_ln).each_slice(2)
       tokens.each_cons(2) do |t1, t2|
         if t2.last == :method || t2.last == :ident && t1 == [".", :operator]
           return t2.first

--- a/lib/pry/syntax_highlighter.rb
+++ b/lib/pry/syntax_highlighter.rb
@@ -11,7 +11,7 @@ class Pry
     end
 
     def self.tokenize(code, language = :ruby)
-      CodeRay.scan(code, language)
+      CodeRay::Scanners[language].new(code).tokens
     end
 
     def self.keyword_token_color


### PR DESCRIPTION
When scanning code for syntax highlighting, a method 'clear' was called if defined on self.

I narrowed down the issue to being related to this part https://github.com/rubychan/coderay/blob/f71b25d3112ac7fcc43ca48055030319ecc7a840/lib/coderay/encoders/encoder.rb#L72

I changed the way we call CodeRay instead. As a part of this change, I also removed pre-coderay 1.0 code. 

Fixes #1610