### PR TITLE
remove Bond spec

### DIFF
--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -399,23 +399,4 @@ RSpec.describe Pry::CommandSet do
       end
     end
   end
-
-  # TODO: rewrite this block.
-  if defined?(Bond)
-    describe "#complete" do
-      it "should list all command names" do
-        set.create_command('susan') {}
-        expect(set.complete('sus')).to.include 'susan '
-      end
-
-      it "should delegate to commands" do
-        set.create_command('susan') do
-          def complete(_search)
-            ['--foo']
-          end
-        end
-        expect(set.complete('susan ')).to eq ['--foo']
-      end
-    end
-  end
 end


### PR DESCRIPTION
remove Bond spec because optional dependency on Bond was removed in https://github.com/pry/pry/pull/1166