### PR TITLE
Add initial support for Reline on Ruby 3.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 #### Features
 
+* Added support for Reline
+  ([#2298](https://github.com/pry/pry/pull/2298))
 * Added support for Ruby 3.3
   ([#2295](https://github.com/pry/pry/pull/2295)
 * Added Pry::Input::SimpleStdio for dumb terminals when Reline is in use

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ end
 
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3.0')
   gem 'reline'
+  gem 'prism', '>= 0.25.0'
 end
 
 # Rubocop supports only >=2.2.0

--- a/lib/pry/indent.rb
+++ b/lib/pry/indent.rb
@@ -17,6 +17,9 @@ class Pry
     # @return [String] String containing the spaces to be inserted before the next line.
     attr_reader :indent_level
 
+    # @return [String] String containing the spaces for the current line.
+    attr_reader :last_indent_level
+
     # @return [Array<String>] The stack of open tokens.
     attr_reader :stack
 
@@ -110,6 +113,7 @@ class Pry
     def reset
       @stack = []
       @indent_level = String.new # rubocop:disable Style/EmptyLiteral
+      @last_indent_level = @indent_level
       @heredoc_queue = []
       @close_heredocs = {}
       @string_start = nil
@@ -164,11 +168,11 @@ class Pry
 
         output += line
 
+        @last_indent_level = prefix
         prefix = new_prefix
       end
 
       @indent_level = prefix
-
       output
     end
 

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -205,6 +205,12 @@ class Pry
         end
       end
 
+      Reline.auto_indent_proc = lambda do |lines, line_index, byte_pointer, is_newline|
+        pry_indentation = Pry::Indent.new
+        pry_indentation.indent(lines.join("\n"))
+        pry_indentation.last_indent_level.length
+      end
+
       Pry::InputLock.for(:all).interruptible_region do
         input.readmultiline(*args) do |multiline_input|
           Pry.commands.find_command(multiline_input) ||

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -205,10 +205,12 @@ class Pry
         end
       end
 
-      Reline.auto_indent_proc = lambda do |lines, line_index, byte_pointer, is_newline|
-        pry_indentation = Pry::Indent.new
-        pry_indentation.indent(lines.join("\n"))
-        pry_indentation.last_indent_level.length
+      if pry.config.auto_indent
+        Reline.auto_indent_proc = lambda do |lines, line_index, byte_pointer, is_newline|
+          pry_indentation = Pry::Indent.new
+          pry_indentation.indent(lines.join("\n"))
+          pry_indentation.last_indent_level.length
+        end
       end
 
       Pry::InputLock.for(:all).interruptible_region do

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -195,8 +195,6 @@ class Pry
     end
 
     def input_reline(*args)
-      require 'prism'
-
       Reline.output_modifier_proc = lambda do |text, _|
         if pry.color
           SyntaxHighlighter.highlight(text)
@@ -232,7 +230,7 @@ class Pry
     end
 
     def reline_available?
-      defined?(Reline) && input == Reline
+      defined?(Reline) && input == Reline && prism_available?
     end
 
     def readline_available?
@@ -241,6 +239,13 @@ class Pry
 
     def coolline_available?
       defined?(Coolline) && input.is_a?(Coolline)
+    end
+
+    def prism_available?
+      require 'prism'
+
+      @prism_available ||= defined?(Prism) &&
+                           Gem::Version.new(Prism::VERSION) >= Gem::Version.new('0.25.0')
     end
 
     # If `$stdout` is not a tty, it's probably a pipe.

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -197,6 +197,14 @@ class Pry
     def input_reline(*args)
       require 'prism'
 
+      Reline.output_modifier_proc = lambda do |text, _|
+        if pry.color
+          SyntaxHighlighter.highlight(text)
+        else
+          text
+        end
+      end
+
       Pry::InputLock.for(:all).interruptible_region do
         input.readmultiline(*args) do |multiline_input|
           Pry.commands.find_command(multiline_input) ||

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -206,7 +206,7 @@ class Pry
       end
 
       if pry.config.auto_indent
-        Reline.auto_indent_proc = lambda do |lines, line_index, byte_pointer, is_newline|
+        Reline.auto_indent_proc = lambda do |lines, _line_index, _byte_pointer, _newline|
           pry_indentation = Pry::Indent.new
           pry_indentation.indent(lines.join("\n"))
           pry_indentation.last_indent_level.length

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -206,10 +206,14 @@ class Pry
       end
 
       if pry.config.auto_indent
-        Reline.auto_indent_proc = lambda do |lines, _line_index, _byte_pointer, _newline|
-          pry_indentation = Pry::Indent.new
-          pry_indentation.indent(lines.join("\n"))
-          pry_indentation.last_indent_level.length
+        Reline.auto_indent_proc = lambda do |lines, line_index, _byte_pointer, _newline|
+          if line_index == 0
+            0
+          else
+            pry_indentation = Pry::Indent.new
+            pry_indentation.indent(lines.join("\n"))
+            pry_indentation.last_indent_level.length
+          end
         end
       end
 

--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -100,7 +100,7 @@ class Pry
       # Return nil for EOF, :no_more_input for error, or :control_c for <Ctrl-C>
       return val unless val.is_a?(String)
 
-      if pry.config.auto_indent
+      if pry.config.auto_indent && !reline_available?
         original_val = "#{indentation}#{val}"
         indented_val = @indent.indent(val)
 


### PR DESCRIPTION
On Ruby 3.3 Readline was finally replaced by reline. 

Currently pry kinda works, but has some edge cases like #2297 that were working on previous versions with Readline.

We can go back to older readline via installing `readline-ext'. [ref](https://github.com/ruby/readline-ext) As the default that come with ruby is Reline, we need some kind of support here. 

This PR attempts to add reline support, multiline editing, and so on. Making Pry compatible.

Fixes: #2063 #1524 #2297 #2302 #1740 #1765 #1514 #2023