### PR TITLE
Fix typo of input config annotation

### DIFF
--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -7,7 +7,7 @@ class Pry
   class Config
     extend Attributable
 
-    # @return [IO, #readline] he object from which Pry retrieves its lines of
+    # @return [IO, #readline] the object from which Pry retrieves its lines of
     #   input
     attribute :input
 


### PR DESCRIPTION
While I was browsing the [Pry config wiki page](https://github.com/pry/pry/wiki/Customization-and-configuration#the-input-object) and the docs, I spotted a little typo, so I fixed it.
Feel free to merge if needed.
