### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -977,7 +977,7 @@ complete CHANGELOG:
 * _pry_ now passed as 3rd parameter to :before_session hook
 * ls colors now configurable via Pry.config.ls.local_var_color = :bright_red etc
 * ls separator configurable via, e.g Pry.config.ls.separator = "  "
-* Pry.view_clip() now only calls inspect on a few immediates, otherwise uses the #<> syntax, which has been truncated further to exclude teh mem address, again related to #245
+* Pry.view_clip() now only calls inspect on a few immediates, otherwise uses the #<> syntax, which has been truncated further to exclude the mem address, again related to #245
 
 ### 0.9.3 (2011/7/27)
 * cat --ex (cats 5 lines above and below line in file where exception was raised)

--- a/lib/pry/class_command.rb
+++ b/lib/pry/class_command.rb
@@ -137,7 +137,7 @@ class Pry
     #     end
     #   end
     #
-    # @example Define the invokation block anywhere you want
+    # @example Define the invocation block anywhere you want
     #   def subcommands(cmd)
     #     cmd.command :download do |opt|
     #       description 'Downloads a content from a server'
@@ -172,7 +172,7 @@ class Pry
 
     # The actual body of your command should go here.
     #
-    # The `opts` mehod can be called to get the options that Pry::Slop has passed,
+    # The `opts` method can be called to get the options that Pry::Slop has passed,
     # and `args` gives the remaining, unparsed arguments.
     #
     # The return value of this method is discarded unless the command was

--- a/lib/pry/code_object.rb
+++ b/lib/pry/code_object.rb
@@ -11,7 +11,7 @@ class Pry
   # object the user wants (applying precedence rules in doing so -- i.e methods
   # get precedence over commands with the same name) and 2. Returning
   # the appropriate object. If the user fails to provide a string
-  # identifer for the object (i.e they pass in `nil` or "") then the
+  # identifier for the object (i.e they pass in `nil` or "") then the
   # object looked up will be the 'current method' or 'current class'
   # associated with the Binding.
   #
@@ -97,7 +97,7 @@ class Pry
       nil
     end
 
-    # when no paramter is given (i.e CodeObject.lookup(nil)), then we
+    # when no parameter is given (i.e CodeObject.lookup(nil)), then we
     # lookup the 'current object' from the binding.
     def empty_lookup
       return nil if str && !str.empty?

--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -145,7 +145,7 @@ class Pry
     # Imports all the commands from one or more sets.
     # @param [Array<CommandSet>] sets Command sets, all of the commands of which
     #   will be imported.
-    # @return [Pry::CommandSet] Returns the reciever (a command set).
+    # @return [Pry::CommandSet] Returns the receiver (a command set).
     def import(*sets)
       sets.each do |set|
         @commands.merge! set.to_hash
@@ -157,7 +157,7 @@ class Pry
     # Imports some commands from a set
     # @param [CommandSet] set Set to import commands from
     # @param [Array<String>] matches Commands to import
-    # @return [Pry::CommandSet] Returns the reciever (a command set).
+    # @return [Pry::CommandSet] Returns the receiver (a command set).
     def import_from(set, *matches)
       helper_module.send :include, set.helper_module
       matches.each do |match|

--- a/lib/pry/commands/amend_line.rb
+++ b/lib/pry/commands/amend_line.rb
@@ -76,7 +76,7 @@ class Pry
 
       # Takes two numbers that are 1-indexed, and returns a range (or
       # number) that is 0-indexed. 1-indexed means the first element is
-      # indentified by 1 rather than by 0 (as is the case for Ruby arrays).
+      # identified by 1 rather than by 0 (as is the case for Ruby arrays).
       # @param [Fixnum] start_line_number One-indexed number.
       # @param [Fixnum] end_line_number One-indexed number.
       # @return [Range] The zero-indexed range.

--- a/lib/pry/commands/raise_up.rb
+++ b/lib/pry/commands/raise_up.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Pry
-  # N.B. using a regular expresion here so that "raise-up 'foo'" does the right thing.
+  # N.B. using a regular expression here so that "raise-up 'foo'" does the right thing.
   class Command
     class RaiseUp < Pry::ClassCommand
       match(/raise-up(!?\b.*)/)

--- a/lib/pry/commands/ri.rb
+++ b/lib/pry/commands/ri.rb
@@ -57,7 +57,7 @@ class Pry
           RDoc::RI.const_set :PryDriver, subclass # hook it up!
         end
 
-        # Spin-up an RI insance.
+        # Spin-up an RI instance.
         ri = RDoc::RI::PryDriver.new(
           pry_instance.pager, use_stdout: true, interactive: false
         )

--- a/lib/pry/commands/watch_expression/expression.rb
+++ b/lib/pry/commands/watch_expression/expression.rb
@@ -23,7 +23,7 @@ class Pry
 
         # Has the value of the expression changed?
         #
-        # We use the pretty-printed string represenation to detect differences
+        # We use the pretty-printed string representation to detect differences
         # as this avoids problems with dup (causes too many differences) and ==
         # (causes too few)
         def changed?

--- a/lib/pry/helpers/command_helpers.rb
+++ b/lib/pry/helpers/command_helpers.rb
@@ -70,7 +70,7 @@ class Pry
 
         # Find the longest common whitespace to all indented lines. Ignore lines
         # containing just -- or ++ as these seem to be used by comment authors
-        # as delimeters.
+        # as delimiters.
         scanned_text = text.scan(/^[ \t]*(?!--\n|\+\+\n)(?=[^ \t\n])/)
         margin = scanned_text.inject do |current_margin, next_indent|
           if next_indent.start_with?(current_margin)

--- a/lib/pry/input_completer.rb
+++ b/lib/pry/input_completer.rb
@@ -234,7 +234,7 @@ class Pry
       end.compact
     end
 
-    # build_path seperates the input into two parts: path and input.
+    # build_path separates the input into two parts: path and input.
     # input is the partial string that should be completed
     # path is a proc that takes an input and builds a full path.
     def build_path(input)

--- a/lib/pry/method/patcher.rb
+++ b/lib/pry/method/patcher.rb
@@ -43,7 +43,7 @@ class Pry
       #
       # When we're redefining aliased methods we will overwrite the method at the
       # unaliased name (so that super continues to work). By wrapping that code in a
-      # transation we make that not happen, which means that alias_method_chains, etc.
+      # translation we make that not happen, which means that alias_method_chains, etc.
       # continue to work.
       #
       def with_method_transaction
@@ -95,7 +95,7 @@ class Pry
       # Update the source code so that when it has the right owner when eval'd.
       #
       # This (combined with definition_for_owner) is backup for the case that
-      # wrap_for_nesting fails, to ensure that the method will stil be defined in
+      # wrap_for_nesting fails, to ensure that the method will still be defined in
       # the correct place.
       #
       # @param [String] source  The source to wrap

--- a/lib/pry/method/weird_method_locator.rb
+++ b/lib/pry/method/weird_method_locator.rb
@@ -123,7 +123,7 @@ class Pry
       # know which __FILE__ and __LINE__ the binding is at, we can hope to
       # disambiguate these cases.
       #
-      # This obviously won't work if the source is unavaiable for some reason,
+      # This obviously won't work if the source is unavailable for some reason,
       # or if both methods have the same __FILE__ and __LINE__.
       #
       # @return [Pry::Method, nil] The Pry::Method representing the

--- a/lib/pry/pry_class.rb
+++ b/lib/pry/pry_class.rb
@@ -215,7 +215,7 @@ you can add "Pry.config.windows_console_warning = false" to your pryrc.
   #   The maximum number of chars before clipping occurs.
   #
   # @option options [Boolean] :id (false)
-  #   Boolean to indicate whether or not a hex reprsentation of the object ID
+  #   Boolean to indicate whether or not a hex representation of the object ID
   #   is attached to the return value when the length of inspect is greater than
   #   value of `:max_length`.
   #

--- a/lib/pry/pry_instance.rb
+++ b/lib/pry/pry_instance.rb
@@ -388,7 +388,7 @@ class Pry
   # @param [*Object] args The arguments to pass to the hook
   # @return [Object, Exception] The return value of the hook or the exception raised
   #
-  # If executing a hook raises an exception, we log that and then continue sucessfully.
+  # If executing a hook raises an exception, we log that and then continue successfully.
   # To debug such errors, use the global variable $pry_hook_error, which is set as a
   # result.
   def exec_hook(name, *args, &block)
@@ -549,7 +549,7 @@ class Pry
   # and a mistake in specifying that exception.
   #
   # (i.e. raise-up RunThymeError.new should not be the same as
-  #  raise-up NameError, "unititialized constant RunThymeError")
+  #  raise-up NameError, "uninitialized constant RunThymeError")
   #
   def raise_up_common(force, *args)
     exception = if args == []

--- a/lib/pry/ring.rb
+++ b/lib/pry/ring.rb
@@ -3,7 +3,7 @@
 class Pry
   # A ring is a thread-safe fixed-capacity array to which you can only add
   # elements. Older entries are overwritten as you add new elements, so that the
-  # ring can never contain more than `max_size` elemens.
+  # ring can never contain more than `max_size` elements.
   #
   # @example
   #   ring = Pry::Ring.new(3)

--- a/lib/pry/slop.rb
+++ b/lib/pry/slop.rb
@@ -73,7 +73,7 @@ class Pry
       # Build a Slop object from a option specification.
       #
       # This allows you to design your options via a simple String rather
-      # than programatically. Do note though that with this method, you're
+      # than programmatically. Do note though that with this method, you're
       # unable to pass any advanced options to the on() method when creating
       # options.
       #

--- a/lib/pry/wrapped_module.rb
+++ b/lib/pry/wrapped_module.rb
@@ -286,7 +286,7 @@ class Pry
     #   highest rank, that is the 'monkey patch' of this module with the
     #   highest number of methods, which contains a source code line that
     #   defines the module. It is considered the 'canonical' definition
-    #   for the module. In the absense of a suitable candidate, the
+    #   for the module. In the absence of a suitable candidate, the
     #   candidate of rank 0 will be returned, or a CommandError raised if
     #   there are no candidates at all.
     def primary_candidate

--- a/spec/class_command_spec.rb
+++ b/spec/class_command_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Pry::ClassCommand do
       end
     end
 
-    context "when help is not invloved" do
+    context "when help is not involved" do
       context "when #process accepts no arguments" do
         subject do
           command = Class.new(described_class) do

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe Pry::Code do
     end
 
     context "when start_line is a Range" do
-      it "returns a range fo lines corresponding to the given Range" do
+      it "returns a range of lines corresponding to the given Range" do
         expect(subject.between(2..3).lines).to eq(%W[2\n 3\n])
       end
     end
@@ -434,7 +434,7 @@ RSpec.describe Pry::Code do
   describe "#expression_at" do
     subject { described_class.new(['def foo', '  :test', 'end']) }
 
-    it "returns a multiline expressiong starting on the given line number" do
+    it "returns a multiline expression starting on the given line number" do
       expect(subject.expression_at(1)).to eq("def foo\n  :test\nend\n")
     end
   end

--- a/spec/command_set_spec.rb
+++ b/spec/command_set_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Pry::CommandSet do
       expect(subject.count).to eq(1)
     end
 
-    it "assings default description" do
+    it "assigns default description" do
       command = subject.block_command('test')
       expect(command.description).to eq('No description.')
     end
@@ -59,7 +59,7 @@ RSpec.describe Pry::CommandSet do
       expect(subject.count).to eq(1)
     end
 
-    it "assings default description" do
+    it "assigns default description" do
       command = subject.create_command('test') {}
       expect(command.description).to eq('No description.')
     end
@@ -225,7 +225,7 @@ RSpec.describe Pry::CommandSet do
   describe "#rename_command" do
     before { subject.command('test') }
 
-    it "renames a comamnd" do
+    it "renames a command" do
       subject.rename_command('new-name', 'test')
       expect(subject['test']).to be_nil
       expect(subject['new-name']).not_to be_nil

--- a/spec/commands/exit_all_spec.rb
+++ b/spec/commands/exit_all_spec.rb
@@ -8,7 +8,7 @@ describe "exit-all" do
     expect(@pry.exit_value).to equal nil
   end
 
-  it "should break out of the repl wth a user specified value" do
+  it "should break out of the repl with a user specified value" do
     expect(@pry.eval("exit-all 'message'")).to equal false
     expect(@pry.exit_value).to eq("message")
   end

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -202,7 +202,7 @@ describe "hist" do
       expect(@t.eval('hist')).to match(/1:\shello\n2:\sworld/)
     end
 
-    it "displays all history (including the current sesion) with `--all` switch" do
+    it "displays all history (including the current session) with `--all` switch" do
       @hist.push('goodbye')
       @hist.push('world')
 

--- a/spec/commands/raise_up_spec.rb
+++ b/spec/commands/raise_up_spec.rb
@@ -17,7 +17,7 @@ describe "raise-up" do
     end
   end
 
-  it "should raise an unamed exception with raise-up" do
+  it "should raise an unnamed exception with raise-up" do
     redirect_pry_io(InputTester.new("raise 'stop'", "raise-up 'noreally'")) do
       expect { Object.new.pry }.to raise_error(RuntimeError, "noreally")
     end

--- a/spec/commands/reload_code_spec.rb
+++ b/spec/commands/reload_code_spec.rb
@@ -19,7 +19,7 @@ describe "reload_code" do
       end.to raise_error(Pry::CommandError)
     end
 
-    it 'reloads pry commmand' do
+    it 'reloads pry command' do
       expect(pry_eval("reload-code reload-code")).to match(/reload-code was reloaded!/)
     end
 

--- a/spec/commands/save_file_spec.rb
+++ b/spec/commands/save_file_spec.rb
@@ -100,7 +100,7 @@ describe "save-file" do
     #       Pry::Method.from_obj(@o, :bang).source
     #   end
 
-    #   it 'should save multiple methods to a file trucated by --lines' do
+    #   it 'should save multiple methods to a file truncated by --lines' do
     #     @t.eval "save-file #{@path} -m baby -m bang --lines 2..-2"
 
     #     # must add 1 as first line of method is 1
@@ -108,7 +108,7 @@ describe "save-file" do
     #       Pry::Method.from_obj(@o, :bang).source).lines.to_a[1..-2].join
     #   end
 
-    #   it 'should save multiple methods to a file trucated by --lines 1 ' \
+    #   it 'should save multiple methods to a file truncated by --lines 1 ' \
     #      '(single parameter, not range)' do
     #     @t.eval "save-file #{@path} -m baby -m bang --lines 1"
 

--- a/spec/commands/watch_expression_spec.rb
+++ b/spec/commands/watch_expression_spec.rb
@@ -64,7 +64,7 @@ describe "watch expression" do
     end
   end
 
-  it "doesn't print when an expresison remains the same" do
+  it "doesn't print when an expression remains the same" do
     ReplTester.start do
       input 'a = 1'
       output '=> 1'

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -469,7 +469,7 @@ describe Pry::Method do
           .to eq(class << @class; self; end)
       end
 
-      it "should attrbute overridden methods to the class not the module" do
+      it "should attribute overridden methods to the class not the module" do
         @class = Class.new do
           class << self
             def meth; 1; end
@@ -698,7 +698,7 @@ describe Pry::Method do
   end
 
   describe "#owner" do
-    context "when it is overriden in Object" do
+    context "when it is overridden in Object" do
       before do
         module OwnerMod
           def owner
@@ -719,7 +719,7 @@ describe Pry::Method do
   end
 
   describe "#parameters" do
-    context "when it is overriden in Object" do
+    context "when it is overridden in Object" do
       before do
         module ParametersMod
           def parameters
@@ -740,7 +740,7 @@ describe Pry::Method do
   end
 
   describe "#receiver" do
-    context "when it is overriden in Object" do
+    context "when it is overridden in Object" do
       before do
         module ReceiverMod
           def receiver

--- a/spec/syntax_checking_spec.rb
+++ b/spec/syntax_checking_spec.rb
@@ -61,7 +61,7 @@ describe Pry do
     end
   end
 
-  it "should not intefere with syntax errors explicitly raised" do
+  it "should not interfere with syntax errors explicitly raised" do
     input_tester = InputTester.new('raise SyntaxError, "unexpected $end"')
     redirect_pry_io(input_tester, @str_output) do
       Pry.start
@@ -91,15 +91,15 @@ describe Pry do
     expect(output).to match(/^RuntimeError.*\nSyntaxError.*\n=> true/m)
   end
 
-  it "should allow whitespace delimeted strings" do
+  it "should allow whitespace delimited strings" do
     expect(mock_pry('"%s" % % foo ')).to match(/"foo"/)
   end
 
-  it "should allow newline delimeted strings" do
+  it "should allow newline delimited strings" do
     expect(mock_pry('"%s" % %', 'foo')).to match(/"foo"/)
   end
 
-  it "should allow whitespace delimeted strings ending on the first char of a line" do
+  it "should allow whitespace delimited strings ending on the first char of a line" do
     expect(mock_pry('"%s" % % ', ' #done!')).to match(/"\\n"/)
   end
 end


### PR DESCRIPTION
Found via `codespell -L jist,uper,halp,cant,aadd,aas` and `typos --hidden --format brief`