### PR TITLE
In Ruby 3.4 error messages are not including backticks

### DIFF
--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -512,7 +512,7 @@ RSpec.describe Pry::Code do
     context "when a String does not respond to the given method" do
       it "raises NoMethodError" do
         expect { subject.abcdefg }
-          .to raise_error(NoMethodError, /undefined method `abcdefg'/)
+          .to raise_error(NoMethodError, /undefined method (`|')abcdefg'/)
       end
     end
   end


### PR DESCRIPTION
ref: https://bugs.ruby-lang.org/issues/16495

