### PR TITLE
Update actions/checkout@v3 to actions/checkout@v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
     continue-on-error: true
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
Fixes warnings such as:

```[test (ubuntu-20.04, 3.2)](https://github.com/pry/pry/actions/runs/8481826392/job/23239920674)
Node.js 16 actions are deprecated.

Please update the following actions to use Node.js 20: actions/checkout@v3. 

For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.```