### PR TITLE
Remove OpenStruct usage from Pry::CommandState

### DIFF
--- a/lib/pry/command.rb
+++ b/lib/pry/command.rb
@@ -200,7 +200,7 @@ class Pry
       end
 
       def state
-        Pry::CommandState.default.state_for(match)
+        Pry::CommandState.default.state_for(self)
       end
     end
 

--- a/lib/pry/command_state.rb
+++ b/lib/pry/command_state.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ostruct'
-
 class Pry
   # CommandState is a data structure to hold per-command state.
   #
@@ -20,12 +18,19 @@ class Pry
       @command_state = {}
     end
 
-    def state_for(command_name)
-      @command_state[command_name] ||= OpenStruct.new
+    def state_for(command_class)
+      @command_state[command_class] ||= command_struct(command_class)
     end
 
-    def reset(command_name)
-      @command_state[command_name] = OpenStruct.new
+    def reset(command_class)
+      @command_state[command_class] = command_struct(command_class)
+    end
+
+    private
+
+    def command_struct(command_class)
+      Struct.new(:command, *command_class.command_options[:state])
+        .new(command: command_class)
     end
   end
 end

--- a/lib/pry/commands/cd.rb
+++ b/lib/pry/commands/cd.rb
@@ -22,6 +22,8 @@ class Pry
         https://github.com/pry/pry/wiki/State-navigation#wiki-Changing_scope
       BANNER
 
+      command_options state: %i[old_stack]
+
       def process
         state.old_stack ||= []
 

--- a/lib/pry/commands/edit.rb
+++ b/lib/pry/commands/edit.rb
@@ -22,6 +22,8 @@ class Pry
         https://github.com/pry/pry/wiki/Editor-integration#wiki-Edit_command
       BANNER
 
+      command_options state: %i[dynamical_ex_file]
+
       def options(opt)
         opt.on :e, :ex, "Open the file that raised the most recent exception " \
                         "(_ex_.file)",

--- a/lib/pry/commands/shell_command.rb
+++ b/lib/pry/commands/shell_command.rb
@@ -7,7 +7,7 @@ class Pry
       group 'Input and Output'
       description "All text following a '.' is forwarded to the shell."
       command_options listing: '.<shell command>', use_prefix: false,
-                      takes_block: true
+                      takes_block: true, state: %i[old_pwd]
 
       banner <<-'BANNER'
         Usage: .COMMAND_NAME

--- a/lib/pry/commands/shell_mode.rb
+++ b/lib/pry/commands/shell_mode.rb
@@ -6,6 +6,7 @@ class Pry
       match 'shell-mode'
       group 'Input and Output'
       description 'Toggle shell mode. Bring in pwd prompt and file completion.'
+      command_options state: %i[disabled prev_prompt]
 
       banner <<-'BANNER'
         Toggle shell mode. Bring in pwd prompt and file completion.

--- a/lib/pry/commands/watch_expression.rb
+++ b/lib/pry/commands/watch_expression.rb
@@ -7,7 +7,7 @@ class Pry
       group 'Context'
       description 'Watch the value of an expression and print a notification ' \
                   'whenever it changes.'
-      command_options use_prefix: false
+      command_options use_prefix: false, state: %i[watch_expressions]
 
       banner <<-'BANNER'
         Usage: watch [EXPRESSION]

--- a/lib/pry/control_d_handler.rb
+++ b/lib/pry/control_d_handler.rb
@@ -19,7 +19,7 @@ class Pry
       else
         # Otherwise, saves current binding stack as old stack and pops last
         # binding out of binding stack (the old stack still has that binding).
-        cd_state = Pry::CommandState.default.state_for('cd')
+        cd_state = Pry::CommandState.default.state_for(Pry::Command::Cd)
         cd_state.old_stack = pry_instance.binding_stack.dup
         pry_instance.binding_stack.pop
       end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -420,7 +420,7 @@ RSpec.describe Pry::Command do
 
   describe ".state" do
     it "returns a command state" do
-      expect(described_class.state).to be_an(OpenStruct)
+      expect(described_class.state).to be_an(Struct)
     end
   end
 
@@ -478,17 +478,10 @@ RSpec.describe Pry::Command do
   end
 
   describe "#state" do
-    let(:target) { binding }
-
     subject { Class.new(described_class).new(pry_instance: Pry.new) }
 
     it "returns a state object" do
-      expect(subject.state).to be_an(OpenStruct)
-    end
-
-    it "remembers the state" do
-      subject.state.foo = :bar
-      expect(subject.state.foo).to eq(:bar)
+      expect(subject.state).to be_an(Struct)
     end
   end
 

--- a/spec/command_state_spec.rb
+++ b/spec/command_state_spec.rb
@@ -17,33 +17,35 @@ RSpec.describe Pry::CommandState do
 
   describe "#state_for" do
     it "returns a state for the matching command" do
-      subject.state_for('command').foobar = 1
-      expect(subject.state_for('command').foobar).to eq(1)
+      subject.state_for(Pry::Command::Cd).old_stack = 1
+      expect(subject.state_for(Pry::Command::Cd).old_stack).to eq(1)
     end
 
     it "returns new state for new command" do
-      expect(subject.state_for('command'))
-        .not_to equal(subject.state_for('other-command'))
+      expect(subject.state_for(Pry::Command::Cd))
+        .not_to equal(subject.state_for(Pry::Command::Play))
     end
 
     it "memoizes state for the same command" do
-      expect(subject.state_for('command')).to equal(subject.state_for('command'))
+      state_a = subject.state_for(Pry::Command::Cd)
+      state_b = subject.state_for(Pry::Command::Cd)
+      expect(state_a).to equal(state_b)
     end
   end
 
   describe "#reset" do
     it "resets the command state for the given command" do
-      subject.state_for('command').foobar = 1
-      subject.reset('command')
-      expect(subject.state_for('command').foobar).to be_nil
+      subject.state_for(Pry::Command::Cd).old_stack = 1
+      subject.reset(Pry::Command::Cd)
+      expect(subject.state_for(Pry::Command::Cd).old_stack).to be_nil
     end
 
     it "doesn't reset command state for other commands" do
-      subject.state_for('command').foobar = 1
-      subject.state_for('other-command').foobar = 1
-      subject.reset('command')
+      subject.state_for(Pry::Command::Cd).old_stack = 1
+      subject.state_for(Pry::Command::WatchExpression).watch_expressions = 1
+      subject.reset(Pry::Command::Cd)
 
-      expect(subject.state_for('other-command').foobar).to eq(1)
+      expect(subject.state_for(Pry::Command::WatchExpression).watch_expressions).to eq(1)
     end
   end
 end

--- a/spec/commands/cd_spec.rb
+++ b/spec/commands/cd_spec.rb
@@ -27,7 +27,7 @@ describe 'cd' do
     end
   end
 
-  after { Pry::CommandState.default.reset('cd') }
+  after { Pry::CommandState.default.reset(Pry::Command::Cd) }
 
   describe 'old stack toggling with `cd -`' do
     describe 'in fresh pry instance' do

--- a/spec/commands/shell_command_spec.rb
+++ b/spec/commands/shell_command_spec.rb
@@ -7,12 +7,12 @@ describe Pry::Command::ShellCommand do
 
       @t = pry_tester(@o) do
         def command_state
-          Pry::CommandState.default.state_for(Pry::Command::ShellCommand.match)
+          Pry::CommandState.default.state_for(Pry::Command::ShellCommand)
         end
       end
     end
 
-    after { Pry::CommandState.default.reset(Pry::Command::ShellCommand.match) }
+    after { Pry::CommandState.default.reset(Pry::Command::ShellCommand) }
 
     describe ".cd" do
       before do


### PR DESCRIPTION
 This PR works towards removing OpenStruct usage. As ostruct will no longer be part of the default gems after Ruby 3.5. 

I am still on the fence about using command_options state to define the attributes for the Struct for each Command. Or, changing CommandState back to a Hash instead. I've checked a few plugins to see if anyone outside pry is using state directly.. But I couldn't find any.

To reduce the amount of changes and keep compatibility with other Pry Commands on this PR, I've tried to keep changes to a minimum and went with the Struct approach, and may refactor again later on.

ruby-head is still faling, as there are more OpenStruct references on the code.