### PR TITLE
Remove deprecated Prompt proc configuration.

### DIFF
--- a/spec/pry_defaults_spec.rb
+++ b/spec/pry_defaults_spec.rb
@@ -28,7 +28,7 @@ describe "test Pry defaults" do
     end
 
     it 'should pass in the prompt if readline arity is 1' do
-      Pry.prompt = proc { "A" }
+      Pry.prompt = Pry::Prompt[:simple]
 
       arity_one_input = Class.new do
         attr_accessor :prompt
@@ -39,11 +39,11 @@ describe "test Pry defaults" do
       end.new
 
       Pry.start(self, input: arity_one_input, output: StringIO.new)
-      expect(arity_one_input.prompt).to eq Pry.prompt.call
+      expect(arity_one_input.prompt).to eq Pry.prompt.wait_proc.call
     end
 
     it 'should not pass in the prompt if the arity is 0' do
-      Pry.prompt = proc { "A" }
+      Pry.prompt = Pry::Prompt[:simple]
 
       arity_zero_input = Class.new do
         def readline
@@ -56,7 +56,7 @@ describe "test Pry defaults" do
     end
 
     it 'should not pass in the prompt if the arity is -1' do
-      Pry.prompt = proc { "A" }
+      Pry.prompt = Pry::Prompt[:simple]
 
       arity_multi_input = Class.new do
         attr_accessor :prompt


### PR DESCRIPTION
The proc/prompt was deprecated on v0.13.0 long time ago..  on https://github.com/pry/pry/pull/1877 We should move towards using the Pry::Prompt API instead. It's also nice to remove some older code in here. 

Some projects already made their move to remove the older prompt warnings. So I think this won't be an issue. 

This also removes one type of usage do OpenStruct, which will not be loaded by Ruby 3.5.0. 