### PR TITLE
Remove OpenStruct usage from Pry::Command::Ls

### DIFF
--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -34,6 +34,7 @@ require 'pry/env'
 
 Pry::Commands = Pry::CommandSet.new unless defined?(Pry::Commands)
 
+require 'pry/commands/ls/config'
 require 'pry/commands/ls/jruby_hacks'
 require 'pry/commands/ls/methods_helper'
 require 'pry/commands/ls/interrogatable'

--- a/lib/pry/commands/ls.rb
+++ b/lib/pry/commands/ls.rb
@@ -3,27 +3,6 @@
 class Pry
   class Command
     class Ls < Pry::ClassCommand
-      DEFAULT_OPTIONS = {
-        heading_color: :bright_blue,
-        public_method_color: :default,
-        private_method_color: :blue,
-        protected_method_color: :blue,
-        method_missing_color: :bright_red,
-        local_var_color: :yellow,
-        pry_var_color: :default, # e.g. _, pry_instance, _file_
-        instance_var_color: :blue, # e.g. @foo
-        class_var_color: :bright_blue, # e.g. @@foo
-        global_var_color: :default, # e.g. $CODERAY_DEBUG, $eventmachine_library
-        builtin_global_color: :cyan, # e.g. $stdin, $-w, $PID
-        pseudo_global_color: :cyan, # e.g. $~, $1..$9, $LAST_MATCH_INFO
-        constant_color: :default, # e.g. VERSION, ARGF
-        class_constant_color: :blue, # e.g. Object, Kernel
-        exception_constant_color: :magenta, # e.g. Exception, RuntimeError
-        unloaded_constant_color: :yellow, # Any constant that is still in .autoload? state
-        separator: "  ",
-        ceiling: [Object, Module, Class]
-      }.freeze
-
       match 'ls'
       group 'Context'
       description 'Show the list of vars and methods in the current scope.'

--- a/lib/pry/commands/ls/config.rb
+++ b/lib/pry/commands/ls/config.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class Pry
+  class Command
+    class Ls < Pry::ClassCommand
+      class Config
+        attr_accessor :heading_color,
+                      :public_method_color,
+                      :private_method_color,
+                      :protected_method_color,
+                      :method_missing_color,
+                      :local_var_color,
+                      :pry_var_color,            # e.g. _, pry_instance, _file_
+                      :instance_var_color,       # e.g. @foo
+                      :class_var_color,          # e.g. @@foo
+                      :global_var_color,         # e.g. $CODERAY_DEBUG, $foo
+                      :builtin_global_color,     # e.g. $stdin, $-w, $PID
+                      :pseudo_global_color,      # e.g. $~, $1..$9, $LAST_MATCH_INFO
+                      :constant_color,           # e.g. VERSION, ARGF
+                      :class_constant_color,     # e.g. Object, Kernel
+                      :exception_constant_color, # e.g. Exception, RuntimeError
+                      :unloaded_constant_color,  # Constant that is still in .autoload?
+                      :separator,
+                      :ceiling
+
+        def self.default
+          config = new
+          config.heading_color = :bright_blue
+          config.public_method_color = :default
+          config.private_method_color = :blue
+          config.protected_method_color = :blue
+          config.method_missing_color = :bright_red
+          config.local_var_color = :yellow
+          config.pry_var_color = :default
+          config.instance_var_color = :blue
+          config.class_var_color = :bright_blue
+          config.global_var_color = :default
+          config.builtin_global_color = :cyan
+          config.pseudo_global_color = :cyan
+          config.constant_color = :default
+          config.class_constant_color = :blue
+          config.exception_constant_color = :magenta
+          config.unloaded_constant_color = :yellow
+          config.separator = "  "
+          config.ceiling = [Object, Module, Class]
+          config
+        end
+      end
+    end
+  end
+end

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'ostruct'
-
 class Pry
   # @api private
   class Config
@@ -199,7 +197,7 @@ class Pry
         extra_sticky_locals: {},
         command_completions: proc { commands.keys },
         file_completions: proc { Dir['.'] },
-        ls: OpenStruct.new(Pry::Command::Ls::DEFAULT_OPTIONS),
+        ls: Pry::Command::Ls::Config.default,
         completer: Pry::InputCompleter,
         history_save: true,
         history_load: true,

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Pry::Config do
   specify { expect(subject.extra_sticky_locals).to be_a(Hash) }
   specify { expect(subject.command_completions).to be_a(Proc) }
   specify { expect(subject.file_completions).to be_a(Proc) }
-  specify { expect(subject.ls).to be_an(OpenStruct) }
+  specify { expect(subject.ls).to be_an(Pry::Command::Ls::Config) }
   specify { expect(subject.completer).to eq(Pry::InputCompleter) }
   specify { expect(subject.history).to be_a(Pry::History) }
   specify { expect(subject.history_save).to eq(true).or be(false) }


### PR DESCRIPTION
In order to remove OpenStruct usage, I moved Ls::DEFAULT_OPTIONS on its own config class.

At first, I've tried to use a simple Struct instead, but having it be compatible between ruby versions was kinda hard and the result was not great, especially < 2.5. 
