### PR TITLE
Make sure method_source stays at 1.0.0 for RUBY < 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ gem 'rspec'
 
 gem "psych", '<= 5.1.0'
 
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
+  gem 'method_source', '= 1.0.0'
+end
+
 # Rubocop supports only >=2.2.0
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
   gem 'rubocop', '= 0.66.0', require: false


### PR DESCRIPTION
On https://github.com/banister/method_source/pull/80 a change was made that making <2.2 break with method_source v1.1.0.

In order to keep pry specs running, I'm pinning method_source on those builds to v1.0.0. cc @kyrylo 👀 

<img width="810" alt="image" src="https://github.com/pry/pry/assets/16997/129830ca-7b58-465e-85cb-5f0ca2687b30">

Few examples of that ^ 

Ruby 2.2 EOL 2018-03-31. Maybe we can consider dropping it too in the future. 