### PR TITLE
Remove OpenStruct usage from specs

### DIFF
--- a/spec/command_integration_spec.rb
+++ b/spec/command_integration_spec.rb
@@ -1,16 +1,22 @@
 # frozen_string_literal: true
 
 describe "commands" do
+  CommandHelper = Struct.new(:bs1, :bs2, :bs3, :self, :bong) do
+    def reset
+      @bs1, @bs2, @bs3, @self, @bong = nil
+    end
+  end.new
+
   before do
     @str_output = StringIO.new
     @o = Object.new
 
     # Shortcuts. They save a lot of typing.
-    @bs1 = "Pad.bs1 = pry_instance.binding_stack.dup"
-    @bs2 = "Pad.bs2 = pry_instance.binding_stack.dup"
-    @bs3 = "Pad.bs3 = pry_instance.binding_stack.dup"
+    @bs1 = "CommandHelper.bs1 = pry_instance.binding_stack.dup"
+    @bs2 = "CommandHelper.bs2 = pry_instance.binding_stack.dup"
+    @bs3 = "CommandHelper.bs3 = pry_instance.binding_stack.dup"
 
-    @self = "Pad.self = self"
+    @self = "CommandHelper.self = self"
 
     @command_tester = Pry::CommandSet.new do
       command "command1", "command 1 test" do
@@ -22,11 +28,11 @@ describe "commands" do
       end
     end
 
-    Pad.bong = "bong"
+    CommandHelper.bong = "bong"
   end
 
   after do
-    Pad.clear
+    CommandHelper.reset
     Pry.reset_defaults
   end
 
@@ -126,9 +132,9 @@ describe "commands" do
         Pry.start(@o, commands: set)
       end
 
-      expect(Pad.bs1.size).to eq 7
-      expect(Pad.self).to eq @o
-      expect(Pad.bs2.size).to eq 1
+      expect(CommandHelper.bs1.size).to eq 7
+      expect(CommandHelper.self).to eq @o
+      expect(CommandHelper.bs2.size).to eq 1
     end
 
     it 'should allow running of cd command when contained in a single string' do
@@ -143,9 +149,9 @@ describe "commands" do
         Pry.start(@o, commands: set)
       end
 
-      expect(Pad.bs1.size).to eq 7
-      expect(Pad.self).to eq @o
-      expect(Pad.bs2.size).to eq 1
+      expect(CommandHelper.bs1.size).to eq 7
+      expect(CommandHelper.self).to eq @o
+      expect(CommandHelper.bs2.size).to eq 1
     end
 
     it 'should allow running of cd command when split into array' do
@@ -160,9 +166,9 @@ describe "commands" do
         Pry.start(@o, commands: set)
       end
 
-      expect(Pad.bs1.size).to eq 7
-      expect(Pad.self).to eq @o
-      expect(Pad.bs2.size).to eq 1
+      expect(CommandHelper.bs1.size).to eq 7
+      expect(CommandHelper.self).to eq @o
+      expect(CommandHelper.bs2.size).to eq 1
     end
 
     it 'should run a command from within a command' do
@@ -239,7 +245,7 @@ describe "commands" do
     end
 
     # rubocop:disable Lint/InterpolationCheck
-    expect(pry_tester(commands: set).eval('hello #{Pad.bong}')).to match(/bong/)
+    expect(pry_tester(commands: set).eval('hello #{CommandHelper.bong}')).to match(/bong/)
     # rubocop:enable Lint/InterpolationCheck
   end
 
@@ -268,8 +274,8 @@ describe "commands" do
     end
 
     # rubocop:disable Lint/InterpolationCheck
-    expect(pry_tester(commands: set).eval('hello #{Pad.bong}'))
-      .to match(/Pad\.bong/)
+    expect(pry_tester(commands: set).eval('hello #{CommandHelper.bong}'))
+      .to match(/CommandHelper\.bong/)
     # rubocop:enable Lint/InterpolationCheck
   end
 

--- a/spec/commands/hist_spec.rb
+++ b/spec/commands/hist_spec.rb
@@ -43,7 +43,7 @@ describe "hist" do
     @hist.push "cd 2"
 
     @t.eval("hist --replay 0..2")
-    stack = @t.eval("Pad.stack = pry_instance.binding_stack.dup")
+    stack = @t.eval("stack = pry_instance.binding_stack.dup")
     expect(stack.map { |b| b.eval("self") }).to eq [TOPLEVEL_BINDING.eval("self"), 1, 2]
   end
 

--- a/spec/commands/raise_up_spec.rb
+++ b/spec/commands/raise_up_spec.rb
@@ -1,14 +1,20 @@
 # frozen_string_literal: true
 
 describe "raise-up" do
+  RaiseHelper = Struct.new(:self, :inner, :outer, :deep) do
+    def reset
+      @self, @inner, @outer, @deep = nil
+    end
+  end.new
+
   before do
-    @self  = "Pad.self = self"
-    @inner = "Pad.inner = self"
-    @outer = "Pad.outer = self"
+    @self  = "RaiseHelper.self = self"
+    @inner = "RaiseHelper.inner = self"
+    @outer = "RaiseHelper.outer = self"
   end
 
   after do
-    Pad.clear
+    RaiseHelper.reset
   end
 
   it "should raise the exception with raise-up" do
@@ -29,8 +35,8 @@ describe "raise-up" do
       Pry.start(:outer)
     end
 
-    expect(Pad.inner).to eq :inner
-    expect(Pad.outer).to eq :outer
+    expect(RaiseHelper.inner).to eq :inner
+    expect(RaiseHelper.outer).to eq :outer
   end
 
   it "should raise the most recently raised exception" do
@@ -40,15 +46,15 @@ describe "raise-up" do
 
   it "should allow you to cd up and (eventually) out" do
     redirect_pry_io(InputTester.new("cd :inner", "raise NoMethodError", @inner,
-                                    "deep = :deep", "cd deep", "Pad.deep = self",
+                                    "deep = :deep", "cd deep", "RaiseHelper.deep = self",
                                     "raise-up NoMethodError", "raise-up", @outer,
                                     "raise-up", "exit-all")) do
       expect { Pry.start(:outer) }.to raise_error NoMethodError
     end
 
-    expect(Pad.deep).to  eq :deep
-    expect(Pad.inner).to eq :inner
-    expect(Pad.outer).to eq :outer
+    expect(RaiseHelper.deep).to  eq :deep
+    expect(RaiseHelper.inner).to eq :inner
+    expect(RaiseHelper.outer).to eq :outer
   end
 
   it "should jump immediately out of nested contexts with !" do

--- a/spec/commands/show_source_spec.rb
+++ b/spec/commands/show_source_spec.rb
@@ -16,10 +16,6 @@ describe "show-source" do # rubocop:disable Metrics/BlockLength
     Object.const_set(:Test, Module.new)
   end
 
-  after do
-    Pad.clear
-  end
-
   it "should output a method's source" do
     expect(pry_eval(binding, 'show-source @o.sample_method')).to match(/def @o.sample/)
   end

--- a/spec/commands/whereami_spec.rb
+++ b/spec/commands/whereami_spec.rb
@@ -4,6 +4,8 @@ require 'method_source'
 
 describe "whereami" do
   it 'should work with methods that have been undefined' do
+    Pad = Struct.new(:binding).new
+
     class Cor
       def blimey!
         Cor.send :undef_method, :blimey!

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -413,8 +413,8 @@ describe Pry::Hooks do
 
     describe "after_session hook" do
       it 'should always run, even if uncaught exception bubbles out of repl' do
-        o = OpenStruct.new
-        o.great_escape = Class.new(StandardError)
+        class MyCustomException < StandardError; end
+        o = double(great_escape: MyCustomException)
 
         old_ew = Pry.config.unrescued_exceptions
         Pry.config.unrescued_exceptions << o.great_escape

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -127,8 +127,9 @@ describe Pry do
       end
 
       it 'should be able to operate inside the BasicObject class' do
-        pry_eval(BasicObject, ":foo", "Pad.obj = _")
-        expect(Pad.obj).to eq :foo
+        ObjectStore = Struct.new(:obj).new
+        pry_eval(BasicObject, ":foo", "ObjectStore.obj = _")
+        expect(ObjectStore.obj).to eq :foo
       end
 
       it 'should set an ivar on an object' do
@@ -323,10 +324,11 @@ describe Pry do
         end
 
         it 'store exceptions' do
-          mock_pry("foo!", "Pad.in = _in_[-1]; Pad.out = _out_[-1]")
+          InOut = Struct.new(:in, :out).new
+          mock_pry("foo!", "InOut.in = _in_[-1]; InOut.out = _out_[-1]")
 
-          expect(Pad.in).to eq "foo!\n"
-          expect(Pad.out).to be_a_kind_of NoMethodError
+          expect(InOut.in).to eq "foo!\n"
+          expect(InOut.out).to be_a_kind_of NoMethodError
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ require 'rspec'
 require 'pry/testable'
 require 'English'
 require 'stringio'
-require 'ostruct'
 
 Dir['./spec/support/**/*.rb'].map do |file|
   require file
@@ -19,8 +18,6 @@ class Module
   public :remove_method
   # rubocop:enable Style/AccessModifierDeclarations
 end
-
-Pad = OpenStruct.new
 
 # to help with tracking down bugs that cause an infinite loop in the test suite
 if ENV["SET_TRACE_FUNC"]


### PR DESCRIPTION
Specs were using a global structure called Pad for sharing state.

As not all specs needed, I've created smaller Structs for the specs that actually needed it locally them. For me, it make the tests read better. 