### PR TITLE
Fixes compatibility with ruby 3.3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,9 @@ gem 'rake'
 gem 'yard'
 gem 'rspec'
 
-gem "psych", '<= 5.2.0'
+gem 'fiddle'
+gem 'psych', '<= 5.2.0'
+gem 'ostruct', '0.6.0'
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
   gem 'method_source', '= 1.0.0'


### PR DESCRIPTION
When running the specs using ruby 3.3.5, there is a test failure due to the lack of the fiddle gem. This PR resolves this. This PR also resolves a depreciation warning for ruby 3.5:

```ruby
/home/runner/work/***/***/vendor/bundle/ruby/3.3.0/gems/pry-0.14.2/lib/pry/command_state.rb:3: warning: /opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```
