### PR TITLE
Add reline to 3.3+ to avoid fiddle warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
 inherit_from: .rubocop_todo.yml
 
+Style/IfUnlessModifier:
+  Exclude:
+    - "Gemfile"
+
 # Prevents Ruby 3.1 incompatibility error. You can enable this cop when Ruby 2.4 support is dropped.
 # See https://github.com/rubocop/rubocop/issues/10258
 Layout/BlockAlignment:

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,10 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
   gem 'method_source', '= 1.0.0'
 end
 
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3.0')
+  gem 'reline'
+end
+
 # Rubocop supports only >=2.2.0
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.2.0')
   gem 'rubocop', '= 0.66.0', require: false


### PR DESCRIPTION
On https://github.com/ruby/reline/pull/721 this warning was silenced and fixed.  I'm adding reline to our Gemfile, to make sure we're always using the most recent reline for testing.

This was causing errors on our specs on Ruby 3.3+ such as:

```
       expected: "[\"1\", \"-foo\", \"--bar\", \"--baz\", \"daz\"]"
            got: "/opt/hostedtoolcache/Ruby/3.3.5/x64/lib/ruby/3.3.0/reline.rb:9: warning: fiddle was loaded from the ... your Gemfile or gemspec to silence this warning.\n[\"1\", \"-foo\", \"--bar\", \"--baz\", \"daz\"]"
```