### PR TITLE
Add compatibility with ruby 3.4+ errors

### DIFF
--- a/spec/pry_repl_spec.rb
+++ b/spec/pry_repl_spec.rb
@@ -108,7 +108,7 @@ describe Pry::REPL do
 
     describe "with more than 1 space" do
       it "prioritizes commands over variables" do
-        expect(mock_pry('    ls = 2+2')).to match(/SyntaxError.+unexpected '='/)
+        expect(mock_pry('    ls = 2+2')).to match(/SyntaxError.+unexpected '='/m)
       end
     end
   end


### PR DESCRIPTION
Errors in Ruby 3.4+ are changing a bit, and we have some specs on top of a few messages.

I'm also taking the opportunity to use Prism to better validate parsing/errors. For previous versions, the code still uses eval.
