### PR TITLE
Add --no-multiline options to disable multiline with Reline

### DIFF
--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -145,6 +145,10 @@ Pry::CLI.add_options do
     Pry.config.color = false
   end
 
+  on "no-multiline", "Disables multiline (defaults to true with Reline)" do
+    Pry.config.multiline = false
+  end
+
   on :f, "Suppress loading of pryrc" do
     Pry.config.should_load_rc = false
     Pry.config.should_load_local_rc = false

--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -61,6 +61,9 @@ class Pry
     # @return [Boolean]
     attribute :pager
 
+    # @return [Boolean]
+    attribute :multiline
+
     # @return [Boolean] whether the global ~/.pryrc should be loaded
     attribute :should_load_rc
 
@@ -164,6 +167,7 @@ class Pry
         hooks: Pry::Hooks.default,
         pager: true,
         system: Pry::SystemCommandHandler.method(:default),
+        multiline: true,
         color: Pry::Helpers::BaseHelpers.use_ansi_codes?,
         default_window_size: 5,
         editor: Pry::Editor.default,

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Pry::Config do
   specify { expect(subject.pager).to be(true).or be(false) }
   specify { expect(subject.system).to be_a(Method) }
   specify { expect(subject.color).to be(true).or be(false) }
+  specify { expect(subject.multiline).to be(true).or be(false) }
   specify { expect(subject.default_window_size).to be_a(Numeric) }
   specify { expect(subject.editor).to be_a(String) }
   specify { expect(subject.should_load_rc).to be(true).or be(false) }


### PR DESCRIPTION
When Reline is available, the prompt will be multiline by default.

This PR adds a CLI option --no-multiline. And config on Pry.config.multiline to allow users to fall back to single-line.