### PR TITLE
Restore pry.config.ls compatibility to previous versions as a Hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Unreleased
+
+#### Bug Fixes
+
+* Restore Pry.config.ls compatibility
+  ([#2335](https://github.com/pry/pry/pull/2335))
+
 ### [v0.15.0][v0.15.0] (November 15, 2024)
 
 #### Features

--- a/lib/pry/commands/ls/config.rb
+++ b/lib/pry/commands/ls/config.rb
@@ -1,49 +1,52 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+
 class Pry
   class Command
     class Ls < Pry::ClassCommand
       class Config
-        attr_accessor :heading_color,
-                      :public_method_color,
-                      :private_method_color,
-                      :protected_method_color,
-                      :method_missing_color,
-                      :local_var_color,
-                      :pry_var_color,            # e.g. _, pry_instance, _file_
-                      :instance_var_color,       # e.g. @foo
-                      :class_var_color,          # e.g. @@foo
-                      :global_var_color,         # e.g. $CODERAY_DEBUG, $foo
-                      :builtin_global_color,     # e.g. $stdin, $-w, $PID
-                      :pseudo_global_color,      # e.g. $~, $1..$9, $LAST_MATCH_INFO
-                      :constant_color,           # e.g. VERSION, ARGF
-                      :class_constant_color,     # e.g. Object, Kernel
-                      :exception_constant_color, # e.g. Exception, RuntimeError
-                      :unloaded_constant_color,  # Constant that is still in .autoload?
-                      :separator,
-                      :ceiling
+        extend Forwardable
+
+        DEFAULT_OPTIONS = {
+          heading_color: :bright_blue,
+          public_method_color: :default,
+          private_method_color: :blue,
+          protected_method_color: :blue,
+          method_missing_color: :bright_red,
+          local_var_color: :yellow,
+          pry_var_color: :default,            # e.g. _, pry_instance, _file_
+          instance_var_color: :blue,          # e.g. @foo
+          class_var_color: :bright_blue,      # e.g. @@foo
+          global_var_color: :default,         # e.g. $CODERAY_DEBUG, $eventmachine_library
+          builtin_global_color: :cyan,        # e.g. $stdin, $-w, $PID
+          pseudo_global_color: :cyan,         # e.g. $~, $1..$9, $LAST_MATCH_INFO
+          constant_color: :default,           # e.g. VERSION, ARGF
+          class_constant_color: :blue,        # e.g. Object, Kernel
+          exception_constant_color: :magenta, # e.g. Exception, RuntimeError
+          unloaded_constant_color: :yellow,   # Constant still in .autoload? state
+          separator: "  ",
+          ceiling: [Object, Module, Class]
+        }.freeze
+
+        DEFAULT_OPTIONS.each_key do |key|
+          define_method key do
+            @config[key]
+          end
+
+          define_method "#{key}=" do |value|
+            @config[key] = value
+          end
+        end
+
+        def_delegators :@config, :[], :[]=, :each, :each_pair, :values, :keys, :to_a
+
+        def initialize(config)
+          @config = config
+        end
 
         def self.default
-          config = new
-          config.heading_color = :bright_blue
-          config.public_method_color = :default
-          config.private_method_color = :blue
-          config.protected_method_color = :blue
-          config.method_missing_color = :bright_red
-          config.local_var_color = :yellow
-          config.pry_var_color = :default
-          config.instance_var_color = :blue
-          config.class_var_color = :bright_blue
-          config.global_var_color = :default
-          config.builtin_global_color = :cyan
-          config.pseudo_global_color = :cyan
-          config.constant_color = :default
-          config.class_constant_color = :blue
-          config.exception_constant_color = :magenta
-          config.unloaded_constant_color = :yellow
-          config.separator = "  "
-          config.ceiling = [Object, Module, Class]
-          config
+          new(DEFAULT_OPTIONS.dup)
         end
       end
     end

--- a/spec/commands/ls_spec.rb
+++ b/spec/commands/ls_spec.rb
@@ -247,6 +247,30 @@ describe "ls" do
     end
   end
 
+  describe "colors" do
+    around do |example|
+      old_config = Pry.config.ls
+      Pry.config.ls = Pry::Command::Ls::Config.default
+      example.run
+      Pry.config.ls = old_config
+    end
+
+    it "should configure colors via config.ls" do
+      pry_eval("Pry.config.ls.heading_color = :bright_green")
+      expect(Pry.config.ls.heading_color).to eql(:bright_green)
+    end
+
+    it "should be accessible via Hash access " do
+      pry_eval("Pry.config.ls[:heading_color] = :bright_red")
+      expect(Pry.config.ls.heading_color).to eql(:bright_red)
+    end
+
+    it "should be able to iterate over all configured colors" do
+      expect(Pry.config.ls.keys.member?(:protected_method_color)).to be_truthy
+      expect(Pry.config.ls.each_pair.to_a).to_not be_empty
+    end
+  end
+
   describe "grep" do
     it "should reduce the number of outputted things" do
       expect(pry_eval("ls -c Object")).to match(/ArgumentError/)


### PR DESCRIPTION
Before #2309, Pry.config.ls was an OpenStruct which allowed colors to be accessed/mutated as a Hash or Methods.

I'm restoring compatibility and adding specs to prevent future regressions.

Fixes #2334 