### PR TITLE
Release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-### Unreleased
+### [v0.15.1](v0.15.1) (December 24, 2024)
 
 #### Bug Fixes
 
 * Restore Pry.config.ls compatibility
   ([#2335](https://github.com/pry/pry/pull/2335))
+* Avoid breaking reading inputs if Prism is not available
+  ([#2338](https://github.com/pry/pry/pull/2338))
 
 ### [v0.15.0][v0.15.0] (November 15, 2024)
 

--- a/lib/pry/version.rb
+++ b/lib/pry/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Pry
-  VERSION = '0.15.0'.freeze
+  VERSION = '0.15.1'.freeze
 end


### PR DESCRIPTION
### [v0.15.1](v0.15.1) (December 24, 2024)

#### Bug Fixes

* Restore Pry.config.ls compatibility
  ([#2335](https://github.com/pry/pry/pull/2335))
* Avoid breaking reading inputs if Prism is not available
  ([#2338](https://github.com/pry/pry/pull/2338))