### PR TITLE
Avoid breaking pry when prism version is not detectable

### DIFF
--- a/lib/pry/repl.rb
+++ b/lib/pry/repl.rb
@@ -256,7 +256,7 @@ class Pry
         end
         # rubocop:enable Lint/SuppressedException
 
-        defined?(Prism) &&
+        defined?(Prism::VERSION) &&
           Gem::Version.new(Prism::VERSION) >= Gem::Version.new('0.25.0')
       end
     end


### PR DESCRIPTION
In case Prism was defined, but not Prism::VERSION. 

Still not sure why would prism not be available on that version. But the code will handle this scenario.