### PR TITLE
Prep for v0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [v0.15.2](v0.15.2) (December 24, 2024)
+
+#### Bug Fixes
+
+* Avoid breaking reading input if Prism version is undetectable
+  ([#2340](https://github.com/pry/pry/pull/2340))
+
 ### [v0.15.1](v0.15.1) (December 24, 2024)
 
 #### Bug Fixes

--- a/lib/pry/version.rb
+++ b/lib/pry/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Pry
-  VERSION = '0.15.1'.freeze
+  VERSION = '0.15.2'.freeze
 end


### PR DESCRIPTION
This release fixes one additional scenario that could happen if prism was not available. 

#### Bug Fixes

* Avoid breaking reading input if Prism version is undetectable
  ([#2340](https://github.com/pry/pry/pull/2340))


