### PR TITLE
Revert copyright year to 2010 in LICENSE, README.md, and source files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ License
 
 (The MIT License)
 
-Copyright (c) 2013 John Mair (banisterfiend)
+Copyright (c) 2010 John Mair (banisterfiend)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ License
 
 (The MIT License)
 
-Copyright (c) 2016 John Mair (banisterfiend)
+Copyright (c) 2015 John Mair (banisterfiend)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ License
 
 (The MIT License)
 
-Copyright (c) 2015 John Mair (banisterfiend)
+Copyright (c) 2013 John Mair (banisterfiend)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ License
 
 (The MIT License)
 
-Copyright (c) 2025 John Mair (banisterfiend)
+Copyright (c) 2018 John Mair (banisterfiend)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ License
 
 (The MIT License)
 
-Copyright (c) 2018 John Mair (banisterfiend)
+Copyright (c) 2016 John Mair (banisterfiend)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Pry
 
 ![Pry logo](https://www.dropbox.com/s/zp8o63kquby2rln/pry_logo_350.png?raw=1)
 
-© John Mair ([banisterfiend](https://twitter.com/banisterfiend)) 2013<br> (Creator)
+© John Mair ([banisterfiend](https://twitter.com/banisterfiend)) 2010<br> (Creator)
 
-© Kyrylo Silin ([kyrylosilin](https://twitter.com/kyrylosilin)) 2013<br> (Maintainer)
+© Kyrylo Silin ([kyrylosilin](https://twitter.com/kyrylosilin)) 2010<br> (Maintainer)
 
 **Alumni:**
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Pry
 
 ![Pry logo](https://www.dropbox.com/s/zp8o63kquby2rln/pry_logo_350.png?raw=1)
 
-© John Mair ([banisterfiend](https://twitter.com/banisterfiend)) 2018<br> (Creator)
+© John Mair ([banisterfiend](https://twitter.com/banisterfiend)) 2016<br> (Creator)
 
 © Kyrylo Silin ([kyrylosilin](https://twitter.com/kyrylosilin)) 2018<br> (Maintainer)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Pry
 
 ![Pry logo](https://www.dropbox.com/s/zp8o63kquby2rln/pry_logo_350.png?raw=1)
 
-© John Mair ([banisterfiend](https://twitter.com/banisterfiend)) 2016<br> (Creator)
+© John Mair ([banisterfiend](https://twitter.com/banisterfiend)) 2015<br> (Creator)
 
 © Kyrylo Silin ([kyrylosilin](https://twitter.com/kyrylosilin)) 2018<br> (Maintainer)
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Pry
 
 ![Pry logo](https://www.dropbox.com/s/zp8o63kquby2rln/pry_logo_350.png?raw=1)
 
-© John Mair ([banisterfiend](https://twitter.com/banisterfiend)) 2015<br> (Creator)
+© John Mair ([banisterfiend](https://twitter.com/banisterfiend)) 2013<br> (Creator)
 
-© Kyrylo Silin ([kyrylosilin](https://twitter.com/kyrylosilin)) 2018<br> (Maintainer)
+© Kyrylo Silin ([kyrylosilin](https://twitter.com/kyrylosilin)) 2013<br> (Maintainer)
 
 **Alumni:**
 

--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# (C) John Mair (banisterfiend) 2016
+# (C) John Mair (banisterfiend) 2015
 # MIT License
 
 require 'pry/version'

--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# (C) John Mair (banisterfiend) 2015
+# (C) John Mair (banisterfiend) 2013
 # MIT License
 
 require 'pry/version'

--- a/lib/pry.rb
+++ b/lib/pry.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# (C) John Mair (banisterfiend) 2013
+# (C) John Mair (banisterfiend) 2010
 # MIT License
 
 require 'pry/version'

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -123,7 +123,7 @@ Pry::CLI.add_options do
     "Usage: pry [OPTIONS]\n" \
     "Start a Pry session.\n" \
     "See http://pry.github.io/ for more information.\n" \
-    "Copyright (c) 2015 John Mair (banisterfiend)" \
+    "Copyright (c) 2013 John Mair (banisterfiend)" \
   )
 
   on(

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -123,7 +123,7 @@ Pry::CLI.add_options do
     "Usage: pry [OPTIONS]\n" \
     "Start a Pry session.\n" \
     "See http://pry.github.io/ for more information.\n" \
-    "Copyright (c) 2016 John Mair (banisterfiend)" \
+    "Copyright (c) 2015 John Mair (banisterfiend)" \
   )
 
   on(

--- a/lib/pry/cli.rb
+++ b/lib/pry/cli.rb
@@ -123,7 +123,7 @@ Pry::CLI.add_options do
     "Usage: pry [OPTIONS]\n" \
     "Start a Pry session.\n" \
     "See http://pry.github.io/ for more information.\n" \
-    "Copyright (c) 2013 John Mair (banisterfiend)" \
+    "Copyright (c) 2010 John Mair (banisterfiend)" \
   )
 
   on(


### PR DESCRIPTION
Since the year following the Copyright is the year in which the work was first published, I feel that changing this would appear to not claim copyright for the period 2010-2024. So I think it is a good to change it back to the original.

see: https://github.com/pry/pry/commit/2dc06b23c8bf269be2281bf2ae8e40990e75a156