### PR TITLE
Fix warning that irb needs to be added to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 gem 'rake'
 gem 'yard'
 gem 'rspec'
+gem 'irb'
 
 gem "psych", '<= 5.3.0'
 


### PR DESCRIPTION
Just fixing following warning:

```
❯ bundle exec rake
: (snip)
Randomized with seed 62363
..............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*...../Users/yudai.takada/ydah/pry/spec/completion_spec.rb:242: warning: irb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add irb to your Gemfile or gemspec to silence this warning.
..........................**................................................................................................................................................................................................................................................
```