### PR TITLE
Do not rely on Readline being available for Ruby 3.5+

### DIFF
--- a/lib/pry/config.rb
+++ b/lib/pry/config.rb
@@ -290,10 +290,15 @@ class Pry
       require 'readline'
       ::Readline
     rescue LoadError
+      require 'reline'
+      ::Reline
+    rescue LoadError
       output.puts(
         "Sorry, you can't use Pry without Readline or a compatible library. \n" \
         "Possible solutions: \n" \
         " * Rebuild Ruby with Readline support using `--with-readline` \n" \
+        " * Use the reline gem \n" \
+        " * Use the readline-ext gem \n " \
         " * Use the rb-readline gem, which is a pure-Ruby port of Readline \n" \
         " * Use the pry-coolline gem, a pure-ruby alternative to Readline"
       )

--- a/spec/completion_spec.rb
+++ b/spec/completion_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-require "readline" unless defined?(Readline)
 require "pry/input_completer"
 
 def completer_test(bind, pry = nil, assert_flag = true)
   test = proc do |symbol|
-    input = pry || Readline
+    input = pry || Pry.config.input
     input_completer = Pry::InputCompleter.new(input, pry)
     completions = input_completer.call(symbol[0..-2], target: Pry.binding_for(bind))
     expect(completions.include?(symbol)).to eq(assert_flag)
@@ -36,7 +35,7 @@ describe Pry::InputCompleter do
   it "should not crash if there's a Module that has a symbolic name." do
     skip unless Pry::Helpers::Platform.jruby?
     expect do
-      Pry::InputCompleter.new(Readline).call(
+      Pry::InputCompleter.new(Pry.config.input).call(
         "a.to_s.", target: Pry.binding_for(Object.new)
       )
     end.not_to raise_error
@@ -44,7 +43,7 @@ describe Pry::InputCompleter do
 
   it 'should take parenthesis and other characters into account for symbols' do
     expect do
-      Pry::InputCompleter.new(Readline).call(
+      Pry::InputCompleter.new(Pry.config.input).call(
         ":class)", target: Pry.binding_for(Object.new)
       )
     end.not_to raise_error
@@ -124,7 +123,7 @@ describe Pry::InputCompleter do
     completer_test(binding).call('o.foo')
 
     # trailing slash
-    expect(Pry::InputCompleter.new(Readline).call('Mod2/', target: Pry.binding_for(Mod))
+    expect(Pry::InputCompleter.new(Pry.config.input).call('Mod2/', target: Pry.binding_for(Mod))
       .include?('Mod2/')).to eq(true)
   end
 
@@ -197,7 +196,7 @@ describe Pry::InputCompleter do
     completer_test(binding).call('o.foo')
 
     # trailing slash
-    expect(Pry::InputCompleter.new(Readline).call('Mod2/', target: Pry.binding_for(Mod))
+    expect(Pry::InputCompleter.new(Pry.config.input).call('Mod2/', target: Pry.binding_for(Mod))
       .include?('Mod2/')).to eq(true)
   end
 
@@ -223,7 +222,7 @@ describe Pry::InputCompleter do
 
   it 'should not return nil in its output' do
     pry = Pry.new
-    expect(Pry::InputCompleter.new(Readline, pry).call("pry.", target: binding))
+    expect(Pry::InputCompleter.new(Pry.config.input, pry).call("pry.", target: binding))
       .not_to include nil
   end
 

--- a/spec/pry_spec.rb
+++ b/spec/pry_spec.rb
@@ -487,7 +487,7 @@ describe Pry do
         end
 
         it "should raise if more than two arguments are passed to Object#pry" do
-          expect { pry(20, :quiet, input: Readline) }.to raise_error ArgumentError
+          expect { pry(20, :quiet, input: Pry.config.input) }.to raise_error ArgumentError
         end
       end
 


### PR DESCRIPTION
This PR intends to fix Readline compatibility with 3.5+. However, other issues that may have changed in Ruby 3.5 still need to be addressed.

Fixes #2348