### PR TITLE
Use modern hash conversion syntax

### DIFF
--- a/lib/pry/hooks.rb
+++ b/lib/pry/hooks.rb
@@ -137,7 +137,7 @@ class Pry
     # @note Modifying the returned hash does not alter the hooks, use
     # `add_hook`/`delete_hook` for that.
     def get_hooks(event_name)
-      Hash[@hooks[event_name.to_s]]
+      @hooks[event_name.to_s].to_h
     end
 
     # @param [Symbol] event_name The name of the event.

--- a/lib/pry/slop.rb
+++ b/lib/pry/slop.rb
@@ -285,7 +285,7 @@ class Pry
     #
     # include_commands - If true, merge options from all sub-commands.
     def to_hash(include_commands = false)
-      hash = Hash[options.map { |opt| [opt.key.to_sym, opt.value] }]
+      hash = options.map { |opt| [opt.key.to_sym, opt.value] }.to_h
       if include_commands
         @commands.each { |cmd, opts| hash.merge!(cmd.to_sym => opts.to_hash) }
       end

--- a/lib/pry/slop/commands.rb
+++ b/lib/pry/slop/commands.rb
@@ -151,7 +151,7 @@ class Pry
 
       # Returns a nested Hash with Slop options and values. See Slop#to_hash.
       def to_hash
-        Hash[commands.map { |k, v| [k.to_sym, v.to_hash] }]
+        commands.map { |k, v| [k.to_sym, v.to_hash] }.to_h
       end
 
       # Returns the help String.


### PR DESCRIPTION
Rubocop recommends hash literal `{}` or `.to_h` syntax as a better alternative to `Hash[]`:
https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashConversion

[RBS](https://github.com/ruby/rbs) also uses the `Hash[]` style syntax to define types and I believe this syntax will become more associated with type definitions in Ruby in the future instead of instance creation.

The `get_hooks(event_name)` method is tested by rspec.

The other 2 `to_hash` methods are not tested by rspec as far as I can tell. But they should be okay as they are array pairs inside an array which is suitable for `to_h`, as the array count is always an even number due to the pairing:

<img width="560" height="96" alt="Screenshot 2025-10-27 at 8 12 34 pm" src="https://github.com/user-attachments/assets/1a6a3658-631c-4dc8-a69f-6772edc1c9ab" />

**⚠️  Bias alert:** I came across this issue while developing a [gem](https://codeberg.org/low_ruby/low_type) that modifies `Array[]`/`Hash[]` and conflicts with Pry. I've worked around the issue my end (using Refinements), but I still believe that the modern syntax is more readable and more forward thinking.