### PR TITLE
Fix `source_location` usage to support Ruby 4.0

### DIFF
--- a/lib/pry/method.rb
+++ b/lib/pry/method.rb
@@ -359,7 +359,7 @@ class Pry
     # @return [Fixnum, nil] The line of code in `source_file` which begins
     #   the method's definition, or `nil` if that information is unavailable.
     def source_line
-      source_location.nil? ? nil : source_location.last
+      source_location.nil? ? nil : source_location[1]
     end
 
     # @return [Range, nil] The range of lines in `source_file` which contain

--- a/lib/pry/method/weird_method_locator.rb
+++ b/lib/pry/method/weird_method_locator.rb
@@ -97,7 +97,7 @@ class Pry
 
       def target_line
         if target.respond_to?(:source_location)
-          target.source_location.last
+          target.source_location[1]
         else
           target.eval('__LINE__')
         end
@@ -170,7 +170,7 @@ class Pry
         if pry_file?
           source_location
         else
-          [File.expand_path(source_location.first), source_location.last]
+          [File.expand_path(source_location.first), source_location[1]]
         end
       end
 

--- a/lib/pry/wrapped_module/candidate.rb
+++ b/lib/pry/wrapped_module/candidate.rb
@@ -130,7 +130,13 @@ class Pry
       #
       # @return [Integer] number of lines.
       def number_of_lines_in_first_chunk
-        end_method_line = last_method_source_location.last
+        # Ruby 4.0+ provides more details, including end of method:
+        # https://bugs.ruby-lang.org/issues/6012
+        end_method_line = if last_method_source_location.size == 5
+          last_method_source_location[-2]
+        else
+          last_method_source_location.last
+        end
 
         end_method_line - line
       end

--- a/spec/class_command_spec.rb
+++ b/spec/class_command_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Pry::ClassCommand do
     subject { Class.new(described_class) }
 
     it "returns source location" do
-      expect(subject.source_location)
+      expect(subject.source_location.take(2))
         .to match([/class_command.rb/, be_kind_of(Integer)])
     end
   end

--- a/spec/commands/edit_spec.rb
+++ b/spec/commands/edit_spec.rb
@@ -793,7 +793,7 @@ describe "edit" do
 
     it 'should edit method context' do
       Pry.config.editor = lambda do |file, line|
-        expect([file, line]).to eq BinkyWink.instance_method(:m2).source_location
+        expect([file, line]).to eq BinkyWink.instance_method(:m2).source_location.take(2)
         nil
       end
 


### PR DESCRIPTION
`source_location` method in Ruby 4.0+ provides more details [[1]], such as end of method and offsets of stars and ends. This following test failure, which is fixed by this patch, nicely exhibits the difference:

~~~
$ rspec -rspec_helper spec/commands/edit_spec.rb:794 Run options: include {locations: {"./spec/commands/edit_spec.rb" => [794]}}

Randomized with seed 8752
F

Failures:

  1) edit --method flag should edit method context
     Failure/Error: expect([file, line]).to eq BinkyWink.instance_method(:m2).source_location

       expected: ["/builddir/build/BUILD/rubygem-pry-0.15.0-build/pry-0.15.0/usr/share/gems/gems/pry-0.15.0/spec/commands/edit_spec.rb", 783, 8, 786, 11]
            got: ["/builddir/build/BUILD/rubygem-pry-0.15.0-build/pry-0.15.0/usr/share/gems/gems/pry-0.15.0/spec/commands/edit_spec.rb", 783]

       (compared using ==)
     # ./spec/commands/edit_spec.rb:796:in 'block (4 levels) in <top (required)>'
     # ./lib/pry/editor.rb:63:in 'Pry::Editor#build_editor_invocation_string'
     # ./lib/pry/editor.rb:47:in 'Pry::Editor#invoke_editor'
     # ./lib/pry/commands/edit.rb:142:in 'Pry::Command::Edit#file_edit'
     # ./lib/pry/commands/edit.rb:62:in 'Pry::Command::Edit#process'
     # ./lib/pry/class_command.rb:82:in 'Pry::ClassCommand#call'
     # ./lib/pry/command.rb:495:in 'Pry::Command#call_with_hooks'
     # ./lib/pry/command.rb:431:in 'block in Pry::Command#call_safely'
     # ./lib/pry/command.rb:439:in 'Pry::Command#use_unpatched_symbol'
     # ./lib/pry/command.rb:430:in 'Pry::Command#call_safely'
     # ./lib/pry/command.rb:404:in 'Pry::Command#process_line'
     # ./lib/pry/command_set.rb:354:in 'Pry::CommandSet#process_line'
     # ./lib/pry/pry_instance.rb:326:in 'Pry#process_command'
     # ./lib/pry/testable/pry_tester.rb:62:in 'Pry::Testable::PryTester#process_command'
     # ./spec/commands/edit_spec.rb:801:in 'block (3 levels) in <top (required)>'

Finished in 0.01534 seconds (files took 0.11079 seconds to load) 1 example, 1 failure

Failed examples:

rspec ./spec/commands/edit_spec.rb:794 # edit --method flag should edit method context

Randomized with seed 8752
~~~

[1]: https://bugs.ruby-lang.org/issues/6012