### PR TITLE
Remove pinned dependencies to older rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,6 @@ gem 'yard'
 gem 'rspec'
 gem 'irb'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0')
-  gem 'method_source', '= 1.0.0'
-end
-
 if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3.0')
   gem 'reline'
   gem 'prism', '>= 0.25.0'


### PR DESCRIPTION
Now, that some support is being removed, It's possible to remove some tweaks. 