### PR TITLE
Fix ls -G grep filtering across all variable types

### DIFF
--- a/lib/pry/commands/ls/constants.rb
+++ b/lib/pry/commands/ls/constants.rb
@@ -27,7 +27,8 @@ class Pry
         def output_self
           mod = interrogatee_mod
           constants = WrappedModule.new(mod).constants(@verbose_switch)
-          output_section('constants', grep.regexp[format(mod, constants)])
+          constants = grep.regexp[constants]
+          output_section('constants', format(mod, constants))
         end
 
         private

--- a/lib/pry/commands/ls/globals.rb
+++ b/lib/pry/commands/ls/globals.rb
@@ -27,8 +27,8 @@ class Pry
         end
 
         def output_self
-          variables = format(@target.eval('global_variables'))
-          output_section('global variables', grep.regexp[variables])
+          globals = grep.regexp[@target.eval('global_variables')]
+          output_section('global variables', format(globals))
         end
 
         private

--- a/lib/pry/commands/ls/instance_vars.rb
+++ b/lib/pry/commands/ls/instance_vars.rb
@@ -24,6 +24,8 @@ class Pry
                     [] # TODO: BasicObject support
                   end
           kvars = Pry::Method.safe_send(interrogatee_mod, :class_variables)
+          ivars = grep.regexp[ivars]
+          kvars = grep.regexp[kvars]
           ivars_out = output_section('instance variables', format(:instance_var, ivars))
           kvars_out = output_section('class variables', format(:class_var, kvars))
           ivars_out + kvars_out

--- a/lib/pry/commands/ls/local_vars.rb
+++ b/lib/pry/commands/ls/local_vars.rb
@@ -14,6 +14,7 @@ class Pry
           locals = @target.eval('local_variables').reject do |e|
             @sticky_locals.key?(e.to_sym)
           end
+          locals = grep.regexp[locals]
           name_value_pairs = locals.map do |name|
             [name, @target.eval(name.to_s)]
           end
@@ -37,7 +38,7 @@ class Pry
           pad = desired_width + color_escape_padding
           Kernel.format(
             "%-#{pad}<name>s = %<value>s",
-            name: color(:local_var, colorized_lhs),
+            name: colorized_lhs,
             value: rhs
           )
         end

--- a/lib/pry/commands/ls/ls_entity.rb
+++ b/lib/pry/commands/ls/ls_entity.rb
@@ -50,7 +50,7 @@ class Pry
         end
 
         def local_vars
-          LocalVars.new(@opts, pry_instance)
+          grep LocalVars.new(@opts, pry_instance)
         end
 
         def entities


### PR DESCRIPTION
ls -G now behaves consistently across all ls entity types.

Regex filtering is applied before ANSI colorization, ensuring accurate
and predictable matching.

The implementation also removes redundant colorization logic, resulting
in cleaner and more maintainable code.
