### PR TITLE
Fix double shellwords parsing in command aliases

### DIFF
--- a/lib/pry/command_set.rb
+++ b/lib/pry/command_set.rb
@@ -192,6 +192,8 @@ class Pry
       original_options = cmd.options.dup
 
       options = original_options.merge!(
+        shellwords: false
+      ).merge!(
         desc: "Alias for `#{action}`",
         listing: match.is_a?(String) ? match : match.inspect
       ).merge!(options)


### PR DESCRIPTION
Fixes #2081. When creating an alias to a command using alias_command, the arguments were being double-parsed by Shellwords because the alias copied the shellwords true option from the original command. This caused quoted arguments like 'this is an arg' to be split into separate words when passed through an alias. The fix sets shellwords false for alias commands so they pass arguments through as-is to the target command without re-parsing them.